### PR TITLE
Implement prompts operations

### DIFF
--- a/src/main/java/com/amannmalik/mcp/schema/BaseProtocol.java
+++ b/src/main/java/com/amannmalik/mcp/schema/BaseProtocol.java
@@ -18,7 +18,9 @@ public final class BaseProtocol {
     /** Base request type. */
     public sealed interface Request extends JsonRpcTypes.JsonRpcRequest, WithMeta
             permits StubRequest, BaseOperations.PingRequest,
-                    Initialization.InitializeRequest {
+                    Initialization.InitializeRequest,
+                    Prompts.ListPromptsRequest,
+                    Prompts.GetPromptRequest {
     }
 
     /** Base result type. */

--- a/src/main/java/com/amannmalik/mcp/schema/Prompts.java
+++ b/src/main/java/com/amannmalik/mcp/schema/Prompts.java
@@ -1,0 +1,61 @@
+package com.amannmalik.mcp.schema;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Prompt system operations and data structures.
+ */
+public final class Prompts {
+    private Prompts() {}
+
+    /** Request to list available prompts. */
+    public record ListPromptsRequest(JsonRpcTypes.RequestId id,
+                                     Optional<Cursor> cursor,
+                                     Optional<Map<String, Object>> _meta)
+            implements BaseProtocol.Request {
+        public ListPromptsRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(cursor);
+            Objects.requireNonNull(_meta);
+        }
+        @Override public String method() { return "prompts/list"; }
+    }
+
+    /** Prompt argument definition. */
+    public record PromptArgument(String name,
+                                 Optional<String> description) {
+        public PromptArgument {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(description);
+        }
+    }
+
+    /** Prompt metadata. */
+    public record Prompt(String name,
+                         Optional<String> description,
+                         List<PromptArgument> arguments) {
+        public Prompt {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(description);
+            arguments = List.copyOf(arguments);
+        }
+    }
+
+    /** Request to retrieve a prompt with arguments applied. */
+    public record GetPromptRequest(JsonRpcTypes.RequestId id,
+                                   String name,
+                                   Map<String, String> arguments,
+                                   Optional<Map<String, Object>> _meta)
+            implements BaseProtocol.Request {
+        public GetPromptRequest {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(name);
+            arguments = Map.copyOf(arguments);
+            Objects.requireNonNull(_meta);
+        }
+        @Override public String method() { return "prompts/get"; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Prompts system with request types
- extend BaseProtocol to allow prompt requests

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68859857f5148324a78af0fb86044cd5