### PR TITLE
Implement core schema value objects

### DIFF
--- a/src/main/java/com/amannmalik/mcp/schema/core/Annotations.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/Annotations.java
@@ -1,0 +1,18 @@
+package com.amannmalik.mcp.schema.core;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/** Optional hints about how data should be used or displayed. */
+public record Annotations(
+        Optional<List<Role>> audience,
+        Optional<Instant> lastModified,
+        Optional<Double> priority) {
+    public Annotations {
+        audience = audience.map(list -> List.copyOf(list.stream().filter(r -> r != null).toList()));
+        priority.ifPresent(p -> {
+            if (p < 0 || p > 1) throw new IllegalArgumentException("priority out of range");
+        });
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/BaseMetadata.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/BaseMetadata.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.schema.core;
+
+import java.util.Optional;
+
+/** Base metadata with a required name and optional title. */
+public sealed interface BaseMetadata permits BaseMetadataRecord, Implementation {
+    String name();
+    Optional<String> title();
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/BaseMetadataRecord.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/BaseMetadataRecord.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.schema.core;
+
+import java.util.Optional;
+
+/** Simple implementation of {@link BaseMetadata}. */
+public record BaseMetadataRecord(String name, Optional<String> title) implements BaseMetadata {
+    public BaseMetadataRecord {
+        FieldValidations.requireName(name);
+        title = title.filter(t -> !t.isBlank());
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/Cursor.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/Cursor.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.schema.core;
+
+/** Opaque pagination token. */
+public record Cursor(String value) {
+    public Cursor {
+        FieldValidations.requireNotBlank("cursor", value);
+    }
+
+    @Override
+    public String toString() { return value; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/FieldValidations.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/FieldValidations.java
@@ -1,0 +1,18 @@
+package com.amannmalik.mcp.schema.core;
+
+import java.util.Objects;
+
+/** Common validation helpers for core value objects. */
+final class FieldValidations {
+    private FieldValidations() {}
+
+    static String requireName(String value) {
+        return requireNotBlank("name", value);
+    }
+
+    static String requireNotBlank(String field, String value) {
+        Objects.requireNonNull(value, field + " cannot be null");
+        if (value.isBlank()) throw new IllegalArgumentException(field + " cannot be blank");
+        return value;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/Implementation.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/Implementation.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.schema.core;
+
+import java.util.Optional;
+
+/** Name and version of an MCP implementation. */
+public record Implementation(String name, Optional<String> title, String version) implements BaseMetadata {
+    public Implementation {
+        FieldValidations.requireName(name);
+        FieldValidations.requireNotBlank("version", version);
+        title = title.filter(t -> !t.isBlank());
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/LoggingLevel.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/LoggingLevel.java
@@ -1,0 +1,20 @@
+package com.amannmalik.mcp.schema.core;
+
+/** Severity of a log message. */
+public enum LoggingLevel {
+    EMERGENCY("emergency"),
+    ALERT("alert"),
+    CRITICAL("critical"),
+    ERROR("error"),
+    WARNING("warning"),
+    NOTICE("notice"),
+    INFO("info"),
+    DEBUG("debug");
+
+    private final String value;
+
+    LoggingLevel(String value) { this.value = value; }
+
+    @Override
+    public String toString() { return value; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/Meta.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/Meta.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.schema.core;
+
+import jakarta.json.JsonValue;
+
+import java.util.Map;
+
+/** Arbitrary metadata fields. */
+public record Meta(Map<String, JsonValue> values) {
+    public Meta {
+        values = Map.copyOf(values);
+    }
+
+    public static final Meta EMPTY = new Meta(Map.of());
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/Role.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/Role.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.schema.core;
+
+/** Sender or recipient role in a conversation. */
+public enum Role {
+    USER("user"),
+    ASSISTANT("assistant");
+
+    private final String value;
+
+    Role(String value) { this.value = value; }
+
+    @Override
+    public String toString() { return value; }
+}


### PR DESCRIPTION
## Summary
- add schema core enums `Role` and `LoggingLevel`
- add value objects `Cursor`, `Implementation`, `BaseMetadata` & `BaseMetadataRecord`
- add `Annotations` and `Meta` structures
- provide common `FieldValidations` helpers

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68861edfa49c8324b680249e6b0759a3