### PR TITLE
Implement JSON serialization framework

### DIFF
--- a/src/main/java/com/amannmalik/mcp/json/Base64Util.java
+++ b/src/main/java/com/amannmalik/mcp/json/Base64Util.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.json;
+
+import java.util.Base64;
+
+public final class Base64Util {
+    private Base64Util() {}
+
+    public static String encode(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    public static byte[] decode(String value) {
+        return Base64.getDecoder().decode(value);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/json/JsonCodec.java
+++ b/src/main/java/com/amannmalik/mcp/json/JsonCodec.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.json;
+
+import jakarta.json.JsonValue;
+
+public interface JsonCodec<T> {
+    JsonValue toJson(T value);
+    T fromJson(JsonValue json);
+}

--- a/src/main/java/com/amannmalik/mcp/json/JsonRegistry.java
+++ b/src/main/java/com/amannmalik/mcp/json/JsonRegistry.java
@@ -1,0 +1,44 @@
+package com.amannmalik.mcp.json;
+
+import jakarta.json.JsonObject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class JsonRegistry {
+    private static final Map<Class<?>, JsonCodec<?>> BY_TYPE = new ConcurrentHashMap<>();
+    private static final Map<String, JsonCodec<?>> BY_NAME = new ConcurrentHashMap<>();
+
+    private JsonRegistry() {}
+
+    public static <T> void register(Class<T> type, JsonCodec<T> codec) {
+        BY_TYPE.put(type, codec);
+    }
+
+    public static <T> void register(String name, JsonCodec<? extends T> codec) {
+        BY_NAME.put(name, codec);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<JsonCodec<T>> codec(Class<T> type) {
+        return Optional.ofNullable((JsonCodec<T>) BY_TYPE.get(type));
+    }
+
+    public static Optional<JsonCodec<?>> codec(String name) {
+        return Optional.ofNullable(BY_NAME.get(name));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<T> fromUnion(JsonObject obj) {
+        return Optional.ofNullable(obj.getString("type", null))
+                .flatMap(JsonRegistry::codec)
+                .map(c -> (T) c.fromJson(obj));
+    }
+
+    public static JsonObject toUnion(Object value) {
+        @SuppressWarnings("unchecked")
+        JsonCodec<Object> codec = (JsonCodec<Object>) BY_TYPE.get(value.getClass());
+        if (codec == null) throw new IllegalArgumentException("No codec for " + value.getClass());
+        return (JsonObject) codec.toJson(value);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/json/McpJsonReader.java
+++ b/src/main/java/com/amannmalik/mcp/json/McpJsonReader.java
@@ -1,0 +1,33 @@
+package com.amannmalik.mcp.json;
+
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonObject;
+
+import java.util.Optional;
+
+public record McpJsonReader(JsonValue value) {
+    public Optional<JsonObject> asObject() {
+        return value instanceof JsonObject o ? Optional.of(o) : Optional.empty();
+    }
+
+    public Optional<String> asString() {
+        return value instanceof JsonString s ? Optional.of(s.getString()) : Optional.empty();
+    }
+
+    public Optional<String> field(String name) {
+        return asObject().map(o -> o.get(name)).flatMap(v -> new McpJsonReader(v).asString());
+    }
+
+    public Optional<byte[]> base64Field(String name) {
+        return field(name).map(Base64Util::decode);
+    }
+
+    public <T> Optional<T> field(String name, Class<T> type) {
+        return asObject().map(o -> o.get(name)).flatMap(v -> JsonRegistry.codec(type).map(c -> c.fromJson(v)));
+    }
+
+    public <T> Optional<T> unionField(String name) {
+        return asObject().map(o -> o.getJsonObject(name)).flatMap(JsonRegistry::fromUnion);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/json/McpJsonWriter.java
+++ b/src/main/java/com/amannmalik/mcp/json/McpJsonWriter.java
@@ -1,0 +1,40 @@
+package com.amannmalik.mcp.json;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class McpJsonWriter {
+    private static final JsonBuilderFactory FACTORY = Json.createBuilderFactory(Map.of());
+
+    private McpJsonWriter() {}
+
+    public static JsonObjectBuilder object() {
+        return FACTORY.createObjectBuilder();
+    }
+
+    public static JsonArrayBuilder array() {
+        return FACTORY.createArrayBuilder();
+    }
+
+    public static <T> void add(JsonObjectBuilder b, String k, Optional<T> v, JsonCodec<T> c) {
+        v.ifPresent(value -> b.add(k, c.toJson(value)));
+    }
+
+    public static void add(JsonObjectBuilder b, String k, Optional<? extends JsonValue> v) {
+        v.ifPresent(value -> b.add(k, value));
+    }
+
+    public static void addBase64(JsonObjectBuilder b, String k, Optional<byte[]> v) {
+        v.ifPresent(bytes -> b.add(k, Base64Util.encode(bytes)));
+    }
+
+    public static void addUnion(JsonObjectBuilder b, String k, Optional<?> v) {
+        v.ifPresent(value -> b.add(k, JsonRegistry.toUnion(value)));
+    }
+}


### PR DESCRIPTION
## Summary
- add `JsonCodec` for object serialization
- register codecs and union types via `JsonRegistry`
- provide helper reader/writer utilities and Base64 encoder
- enable optional field and union support in writer/reader

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68861ee35e2c8324bd794e5a2305c34c