### PR TITLE
Implement content block schema (Phase 2.1)

### DIFF
--- a/src/main/java/com/amannmalik/mcp/schema/content/AudioContent.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/AudioContent.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp.schema.content;
+
+import com.amannmalik.mcp.schema.core.Annotations;
+import com.amannmalik.mcp.schema.core.FieldValidations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+public record AudioContent(
+        byte[] data,
+        String mimeType,
+        Optional<Annotations> annotations,
+        Optional<Meta> meta
+) implements ContentBlock {
+    public AudioContent {
+        data = data.clone();
+        FieldValidations.requireMimeType(mimeType);
+    }
+
+    public String type() { return "audio"; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/content/ContentBlock.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/ContentBlock.java
@@ -1,0 +1,3 @@
+package com.amannmalik.mcp.schema.content;
+
+sealed public interface ContentBlock permits TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource {}

--- a/src/main/java/com/amannmalik/mcp/schema/content/EmbeddedResource.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/EmbeddedResource.java
@@ -1,0 +1,17 @@
+package com.amannmalik.mcp.schema.content;
+
+import com.amannmalik.mcp.schema.core.Annotations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+public record EmbeddedResource(
+        ResourceContents resource,
+        Optional<Annotations> annotations,
+        Optional<Meta> meta
+) implements ContentBlock {
+    public EmbeddedResource {
+    }
+
+    public String type() { return "resource"; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/content/ImageContent.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/ImageContent.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp.schema.content;
+
+import com.amannmalik.mcp.schema.core.Annotations;
+import com.amannmalik.mcp.schema.core.FieldValidations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+public record ImageContent(
+        byte[] data,
+        String mimeType,
+        Optional<Annotations> annotations,
+        Optional<Meta> meta
+) implements ContentBlock {
+    public ImageContent {
+        data = data.clone();
+        FieldValidations.requireMimeType(mimeType);
+    }
+
+    public String type() { return "image"; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/content/ResourceContents.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/ResourceContents.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.schema.content;
+
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+public interface ResourceContents {
+    String uri();
+    Optional<String> mimeType();
+    Optional<Meta> meta();
+}

--- a/src/main/java/com/amannmalik/mcp/schema/content/ResourceLink.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/ResourceLink.java
@@ -1,0 +1,29 @@
+package com.amannmalik.mcp.schema.content;
+
+import com.amannmalik.mcp.schema.core.Annotations;
+import com.amannmalik.mcp.schema.core.FieldValidations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+public record ResourceLink(
+        String uri,
+        String name,
+        Optional<String> title,
+        Optional<String> description,
+        Optional<String> mimeType,
+        Optional<Annotations> annotations,
+        Optional<Long> size,
+        Optional<Meta> meta
+) implements ContentBlock {
+    public ResourceLink {
+        FieldValidations.requireNotBlank("uri", uri);
+        FieldValidations.requireName(name);
+        title = title.filter(t -> !t.isBlank());
+        description = description.filter(d -> !d.isBlank());
+        mimeType = mimeType.filter(m -> !m.isBlank());
+        size.ifPresent(s -> { if (s < 0) throw new IllegalArgumentException("size cannot be negative"); });
+    }
+
+    public String type() { return "resource_link"; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/content/TextContent.java
+++ b/src/main/java/com/amannmalik/mcp/schema/content/TextContent.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.schema.content;
+
+import com.amannmalik.mcp.schema.core.Annotations;
+import com.amannmalik.mcp.schema.core.FieldValidations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+public record TextContent(
+        String text,
+        Optional<Annotations> annotations,
+        Optional<Meta> meta
+) implements ContentBlock {
+    public TextContent {
+        FieldValidations.requireNotBlank("text", text);
+    }
+
+    public String type() { return "text"; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/core/FieldValidations.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/FieldValidations.java
@@ -3,16 +3,22 @@ package com.amannmalik.mcp.schema.core;
 import java.util.Objects;
 
 /** Common validation helpers for core value objects. */
-final class FieldValidations {
+public final class FieldValidations {
     private FieldValidations() {}
 
-    static String requireName(String value) {
+    public static String requireName(String value) {
         return requireNotBlank("name", value);
     }
 
-    static String requireNotBlank(String field, String value) {
+    public static String requireNotBlank(String field, String value) {
         Objects.requireNonNull(value, field + " cannot be null");
         if (value.isBlank()) throw new IllegalArgumentException(field + " cannot be blank");
+        return value;
+    }
+
+    public static String requireMimeType(String value) {
+        requireNotBlank("mimeType", value);
+        if (!value.contains("/")) throw new IllegalArgumentException("invalid mimeType");
         return value;
     }
 }


### PR DESCRIPTION
## Summary
- add sealed ContentBlock interface and supporting records
- validate mime types in FieldValidations

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68862118d0dc8324b9932937c579e323