### PR TITLE
Implement Resource System

### DIFF
--- a/src/main/java/com/amannmalik/mcp/schema/core/BaseMetadata.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/BaseMetadata.java
@@ -3,7 +3,7 @@ package com.amannmalik.mcp.schema.core;
 import java.util.Optional;
 
 /** Base metadata with a required name and optional title. */
-public sealed interface BaseMetadata permits BaseMetadataRecord, Implementation {
+public interface BaseMetadata {
     String name();
     Optional<String> title();
 }

--- a/src/main/java/com/amannmalik/mcp/schema/core/FieldValidations.java
+++ b/src/main/java/com/amannmalik/mcp/schema/core/FieldValidations.java
@@ -3,16 +3,27 @@ package com.amannmalik.mcp.schema.core;
 import java.util.Objects;
 
 /** Common validation helpers for core value objects. */
-final class FieldValidations {
+public final class FieldValidations {
     private FieldValidations() {}
 
-    static String requireName(String value) {
+    public static String requireName(String value) {
         return requireNotBlank("name", value);
     }
 
-    static String requireNotBlank(String field, String value) {
+    public static String requireNotBlank(String field, String value) {
         Objects.requireNonNull(value, field + " cannot be null");
         if (value.isBlank()) throw new IllegalArgumentException(field + " cannot be blank");
+        return value;
+    }
+
+    public static String requireUri(String value) {
+        requireNotBlank("uri", value);
+        try { java.net.URI.create(value); } catch (IllegalArgumentException e) { throw new IllegalArgumentException("uri invalid", e); }
+        return value;
+    }
+
+    public static long requireNonNegative(String field, long value) {
+        if (value < 0) throw new IllegalArgumentException(field + " cannot be negative");
         return value;
     }
 }

--- a/src/main/java/com/amannmalik/mcp/schema/resources/BlobResourceContents.java
+++ b/src/main/java/com/amannmalik/mcp/schema/resources/BlobResourceContents.java
@@ -1,0 +1,23 @@
+package com.amannmalik.mcp.schema.resources;
+
+import com.amannmalik.mcp.schema.core.FieldValidations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+import java.util.Arrays;
+
+/** Binary resource contents. */
+public record BlobResourceContents(
+        String uri,
+        byte[] blob,
+        Optional<String> mimeType,
+        Optional<Meta> _meta
+) implements ResourceContents {
+    public BlobResourceContents {
+        uri = FieldValidations.requireUri(uri);
+        blob = blob.clone();
+        mimeType = mimeType.filter(m -> !m.isBlank());
+    }
+
+    public byte[] blob() { return blob.clone(); }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/resources/Resource.java
+++ b/src/main/java/com/amannmalik/mcp/schema/resources/Resource.java
@@ -1,0 +1,26 @@
+package com.amannmalik.mcp.schema.resources;
+
+import com.amannmalik.mcp.schema.core.*;
+
+import java.util.Optional;
+
+/** Known resource available from the server. */
+public record Resource(
+        String name,
+        Optional<String> title,
+        String uri,
+        Optional<String> description,
+        Optional<String> mimeType,
+        Optional<Annotations> annotations,
+        Optional<Long> size,
+        Optional<Meta> _meta
+) implements BaseMetadata {
+    public Resource {
+        FieldValidations.requireName(name);
+        uri = FieldValidations.requireUri(uri);
+        title = title.filter(t -> !t.isBlank());
+        description = description.filter(d -> !d.isBlank());
+        mimeType = mimeType.filter(m -> !m.isBlank());
+        size = size.map(s -> FieldValidations.requireNonNegative("size", s));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/resources/ResourceContents.java
+++ b/src/main/java/com/amannmalik/mcp/schema/resources/ResourceContents.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.schema.resources;
+
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+/** Contents of a resource or sub-resource. */
+public sealed interface ResourceContents permits TextResourceContents, BlobResourceContents {
+    String uri();
+    Optional<String> mimeType();
+    Optional<Meta> _meta();
+}

--- a/src/main/java/com/amannmalik/mcp/schema/resources/ResourceReference.java
+++ b/src/main/java/com/amannmalik/mcp/schema/resources/ResourceReference.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.schema.resources;
+
+import com.amannmalik.mcp.schema.core.FieldValidations;
+
+/** Reference to a resource or resource template. */
+public record ResourceReference(String uri) {
+    public static final String TYPE = "ref/resource";
+    public ResourceReference {
+        FieldValidations.requireUri(uri);
+    }
+    public String type() { return TYPE; }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/resources/ResourceTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/schema/resources/ResourceTemplate.java
@@ -1,0 +1,24 @@
+package com.amannmalik.mcp.schema.resources;
+
+import com.amannmalik.mcp.schema.core.*;
+
+import java.util.Optional;
+
+/** Template description for resources available from the server. */
+public record ResourceTemplate(
+        String name,
+        Optional<String> title,
+        String uriTemplate,
+        Optional<String> description,
+        Optional<String> mimeType,
+        Optional<Annotations> annotations,
+        Optional<Meta> _meta
+) implements BaseMetadata {
+    public ResourceTemplate {
+        FieldValidations.requireName(name);
+        uriTemplate = FieldValidations.requireNotBlank("uriTemplate", uriTemplate);
+        title = title.filter(t -> !t.isBlank());
+        description = description.filter(d -> !d.isBlank());
+        mimeType = mimeType.filter(m -> !m.isBlank());
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/schema/resources/TextResourceContents.java
+++ b/src/main/java/com/amannmalik/mcp/schema/resources/TextResourceContents.java
@@ -1,0 +1,20 @@
+package com.amannmalik.mcp.schema.resources;
+
+import com.amannmalik.mcp.schema.core.FieldValidations;
+import com.amannmalik.mcp.schema.core.Meta;
+
+import java.util.Optional;
+
+/** Text-based resource contents. */
+public record TextResourceContents(
+        String uri,
+        String text,
+        Optional<String> mimeType,
+        Optional<Meta> _meta
+) implements ResourceContents {
+    public TextResourceContents {
+        uri = FieldValidations.requireUri(uri);
+        text = FieldValidations.requireNotBlank("text", text);
+        mimeType = mimeType.filter(m -> !m.isBlank());
+    }
+}


### PR DESCRIPTION
## Summary
- implement Resource and ResourceTemplate records
- add sealed `ResourceContents` and implementations for text and blobs
- add `ResourceReference` for referencing definitions
- expose FieldValidations for broader use
- unseal BaseMetadata to allow new implementations

## Testing
- `gradle test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6886212134008324b5488da09e0be43a