### PR TITLE
Implement Wave 1 primitives

### DIFF
--- a/src/main/java/com/mcp/protocol/enums/LoggingLevel.java
+++ b/src/main/java/com/mcp/protocol/enums/LoggingLevel.java
@@ -1,0 +1,12 @@
+package com.mcp.protocol.enums;
+
+public enum LoggingLevel {
+    EMERGENCY,
+    ALERT,
+    CRITICAL,
+    ERROR,
+    WARNING,
+    NOTICE,
+    INFO,
+    DEBUG
+}

--- a/src/main/java/com/mcp/protocol/enums/Role.java
+++ b/src/main/java/com/mcp/protocol/enums/Role.java
@@ -1,0 +1,6 @@
+package com.mcp.protocol.enums;
+
+public enum Role {
+    ASSISTANT,
+    USER
+}

--- a/src/main/java/com/mcp/protocol/foundation/BaseMetadata.java
+++ b/src/main/java/com/mcp/protocol/foundation/BaseMetadata.java
@@ -1,0 +1,11 @@
+package com.mcp.protocol.foundation;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record BaseMetadata(String name, Optional<String> title) {
+    public BaseMetadata {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(title);
+    }
+}

--- a/src/main/java/com/mcp/protocol/foundation/Implementation.java
+++ b/src/main/java/com/mcp/protocol/foundation/Implementation.java
@@ -1,0 +1,12 @@
+package com.mcp.protocol.foundation;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record Implementation(String name, String version, Optional<String> title) {
+    public Implementation {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(version);
+        Objects.requireNonNull(title);
+    }
+}

--- a/src/main/java/com/mcp/protocol/foundation/ModelHint.java
+++ b/src/main/java/com/mcp/protocol/foundation/ModelHint.java
@@ -1,0 +1,10 @@
+package com.mcp.protocol.foundation;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public record ModelHint(Optional<String> name) {
+    public ModelHint {
+        Objects.requireNonNull(name);
+    }
+}

--- a/src/main/java/com/mcp/protocol/primitives/Cursor.java
+++ b/src/main/java/com/mcp/protocol/primitives/Cursor.java
@@ -1,0 +1,9 @@
+package com.mcp.protocol.primitives;
+
+import java.util.Objects;
+
+public record Cursor(String value) {
+    public Cursor {
+        Objects.requireNonNull(value);
+    }
+}

--- a/src/main/java/com/mcp/protocol/primitives/ProgressToken.java
+++ b/src/main/java/com/mcp/protocol/primitives/ProgressToken.java
@@ -1,0 +1,12 @@
+package com.mcp.protocol.primitives;
+
+import java.util.Objects;
+
+public sealed interface ProgressToken permits ProgressToken.StringToken, ProgressToken.IntegerToken {
+    record StringToken(String value) implements ProgressToken {
+        public StringToken {
+            Objects.requireNonNull(value);
+        }
+    }
+    record IntegerToken(long value) implements ProgressToken {}
+}

--- a/src/main/java/com/mcp/protocol/primitives/RequestId.java
+++ b/src/main/java/com/mcp/protocol/primitives/RequestId.java
@@ -1,0 +1,12 @@
+package com.mcp.protocol.primitives;
+
+import java.util.Objects;
+
+public sealed interface RequestId permits RequestId.StringId, RequestId.IntegerId {
+    record StringId(String value) implements RequestId {
+        public StringId {
+            Objects.requireNonNull(value);
+        }
+    }
+    record IntegerId(long value) implements RequestId {}
+}


### PR DESCRIPTION
## Summary
- add enums for `Role` and `LoggingLevel`
- introduce primitive types `RequestId`, `Cursor`, `ProgressToken`
- add foundational records `Implementation`, `BaseMetadata`, `ModelHint`

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886712b773c8324944e308273db1961