### PR TITLE
Implement JSON‑RPC message system

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/IdTracker.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/IdTracker.java
@@ -1,0 +1,18 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Tracks request IDs used within a session to ensure uniqueness. */
+public final class IdTracker {
+    private final Set<RequestId> seen = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Registers the ID, throwing if it was already seen.
+     */
+    public void register(RequestId id) {
+        if (!seen.add(id)) {
+            throw new IllegalArgumentException("Duplicate id: " + id);
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpc.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpc.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.jsonrpc;
+
+/** Constants for the JSON-RPC protocol. */
+public final class JsonRpc {
+    private JsonRpc() {}
+
+    public static final String VERSION = "2.0";
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -1,0 +1,88 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.Json;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonString;
+
+/** Utility for serializing and deserializing JSON-RPC messages. */
+public final class JsonRpcCodec {
+    private JsonRpcCodec() {}
+
+    public static JsonObject toJsonObject(JsonRpcMessage msg) {
+        var builder = Json.createObjectBuilder();
+        builder.add("jsonrpc", JsonRpc.VERSION);
+
+        switch (msg) {
+            case JsonRpcRequest r -> {
+                addId(builder, r.id());
+                builder.add("method", r.method());
+                if (r.params() != null) builder.add("params", r.params());
+            }
+            case JsonRpcNotification n -> {
+                builder.add("method", n.method());
+                if (n.params() != null) builder.add("params", n.params());
+            }
+            case JsonRpcResponse r -> {
+                addId(builder, r.id());
+                builder.add("result", r.result() != null ? r.result() : JsonValue.NULL);
+            }
+            case JsonRpcError e -> {
+                addId(builder, e.id());
+                var err = e.error();
+                var errBuilder = Json.createObjectBuilder()
+                        .add("code", err.code())
+                        .add("message", err.message());
+                if (err.data() != null) errBuilder.add("data", err.data());
+                builder.add("error", errBuilder.build());
+            }
+        }
+        return builder.build();
+    }
+
+    private static void addId(JsonObjectBuilder builder, RequestId id) {
+        switch (id) {
+            case RequestId.StringId s -> builder.add("id", s.value());
+            case RequestId.NumericId n -> builder.add("id", n.value());
+        }
+    }
+
+    public static JsonRpcMessage fromJsonObject(JsonObject obj) {
+        var idValue = obj.get("id");
+        var method = obj.getString("method", null);
+        var hasError = obj.containsKey("error");
+        var hasResult = obj.containsKey("result");
+
+        if (method != null && idValue != null) {
+            // Request
+            return new JsonRpcRequest(toId(idValue), method, obj.getJsonObject("params"));
+        }
+        if (method != null) {
+            // Notification
+            return new JsonRpcNotification(method, obj.getJsonObject("params"));
+        }
+        if (hasResult) {
+            return new JsonRpcResponse(toId(idValue), obj.getJsonObject("result"));
+        }
+        if (hasError) {
+            var errObj = obj.getJsonObject("error");
+            var detail = new JsonRpcError.ErrorDetail(
+                    errObj.getInt("code"),
+                    errObj.getString("message"),
+                    errObj.get("data")
+            );
+            return new JsonRpcError(toId(idValue), detail);
+        }
+        throw new IllegalArgumentException("Unknown message type");
+    }
+
+    private static RequestId toId(JsonValue value) {
+        return switch (value.getValueType()) {
+            case NUMBER -> new RequestId.NumericId(((JsonNumber) value).longValue());
+            case STRING -> new RequestId.StringId(((JsonString) value).getString());
+            default -> throw new IllegalArgumentException("Invalid id type");
+        };
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.JsonValue;
+
+/** An error response for a JSON-RPC request. */
+public record JsonRpcError(RequestId id, ErrorDetail error) implements JsonRpcMessage {
+    public record ErrorDetail(int code, String message, JsonValue data) {}
+
+    public JsonRpcError {
+        if (id == null || error == null) {
+            throw new IllegalArgumentException("id and error are required");
+        }
+    }
+
+    @Override
+    public String jsonrpc() {
+        return JsonRpc.VERSION;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcErrorCode.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcErrorCode.java
@@ -1,0 +1,27 @@
+package com.amannmalik.mcp.jsonrpc;
+
+/** Standard JSON-RPC error codes. */
+public enum JsonRpcErrorCode {
+    PARSE_ERROR(-32700),
+    INVALID_REQUEST(-32600),
+    METHOD_NOT_FOUND(-32601),
+    INVALID_PARAMS(-32602),
+    INTERNAL_ERROR(-32603);
+
+    private final int code;
+
+    JsonRpcErrorCode(int code) {
+        this.code = code;
+    }
+
+    public int code() {
+        return code;
+    }
+
+    public static JsonRpcErrorCode fromCode(int code) {
+        for (var c : values()) {
+            if (c.code == code) return c;
+        }
+        throw new IllegalArgumentException("Unknown error code: " + code);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcMessage.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcMessage.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.jsonrpc;
+
+/** Base marker for all JSON-RPC messages. */
+public sealed interface JsonRpcMessage permits JsonRpcRequest, JsonRpcNotification, JsonRpcResponse, JsonRpcError {
+    String jsonrpc();
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcNotification.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcNotification.java
@@ -1,0 +1,17 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.JsonObject;
+
+/** A one-way JSON-RPC notification. */
+public record JsonRpcNotification(String method, JsonObject params) implements JsonRpcMessage {
+    public JsonRpcNotification {
+        if (method == null) {
+            throw new IllegalArgumentException("method is required");
+        }
+    }
+
+    @Override
+    public String jsonrpc() {
+        return JsonRpc.VERSION;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcRequest.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcRequest.java
@@ -1,0 +1,17 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.JsonObject;
+
+/** A JSON-RPC request expecting a response. */
+public record JsonRpcRequest(RequestId id, String method, JsonObject params) implements JsonRpcMessage {
+    public JsonRpcRequest {
+        if (id == null || method == null) {
+            throw new IllegalArgumentException("id and method are required");
+        }
+    }
+
+    @Override
+    public String jsonrpc() {
+        return JsonRpc.VERSION;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcResponse.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcResponse.java
@@ -1,0 +1,17 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.JsonObject;
+
+/** A successful JSON-RPC response. */
+public record JsonRpcResponse(RequestId id, JsonObject result) implements JsonRpcMessage {
+    public JsonRpcResponse {
+        if (id == null) {
+            throw new IllegalArgumentException("id is required");
+        }
+    }
+
+    @Override
+    public String jsonrpc() {
+        return JsonRpc.VERSION;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -1,0 +1,7 @@
+package com.amannmalik.mcp.jsonrpc;
+
+/** Identifier for a JSON-RPC request. */
+public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId {
+    record StringId(String value) implements RequestId {}
+    record NumericId(long value) implements RequestId {}
+}

--- a/src/test/java/com/amannmalik/mcp/jsonrpc/IdTrackerTest.java
+++ b/src/test/java/com/amannmalik/mcp/jsonrpc/IdTrackerTest.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdTrackerTest {
+    @Test
+    void rejectsDuplicateIds() {
+        var tracker = new IdTracker();
+        tracker.register(new RequestId.NumericId(1));
+        assertThrows(IllegalArgumentException.class, () -> tracker.register(new RequestId.NumericId(1)));
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodecTest.java
@@ -1,0 +1,26 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonRpcCodecTest {
+    @Test
+    void roundTripRequest() {
+        var request = new JsonRpcRequest(new RequestId.NumericId(1), "ping", null);
+        JsonObject json = JsonRpcCodec.toJsonObject(request);
+        var parsed = JsonRpcCodec.fromJsonObject(json);
+        assertEquals(request, parsed);
+    }
+
+    @Test
+    void roundTripError() {
+        var detail = new JsonRpcError.ErrorDetail(JsonRpcErrorCode.INVALID_PARAMS.code(), "oops", JsonValue.NULL);
+        var error = new JsonRpcError(new RequestId.StringId("1"), detail);
+        JsonObject json = JsonRpcCodec.toJsonObject(error);
+        var parsed = JsonRpcCodec.fromJsonObject(json);
+        assertEquals(error, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `JsonRpc` constants and `RequestId` type
- implement sealed message types with Parsson serialization in `JsonRpcCodec`
- provide standard error codes and an ID tracker
- add unit tests for codec round trips and ID uniqueness

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6886a7a1589c8324b089c011b82b414b