### PR TITLE
Implement transport layer foundation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
@@ -1,0 +1,40 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+public final class StdioTransport implements Transport {
+    private final BufferedReader in;
+    private final BufferedWriter out;
+
+    public StdioTransport(InputStream in, OutputStream out) {
+        this.in = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+        this.out = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public synchronized void send(JsonObject message) throws IOException {
+        out.write(message.toString());
+        out.write('\n');
+        out.flush();
+    }
+
+    @Override
+    public synchronized JsonObject receive() throws IOException {
+        String line = in.readLine();
+        if (line == null) throw new EOFException();
+        try (JsonReader reader = Json.createReader(new StringReader(line))) {
+            return reader.readObject();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+        out.close();
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -1,0 +1,93 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+public final class StreamableHttpTransport implements Transport {
+    private final HttpClient client;
+    private final URI endpoint;
+    private final BlockingQueue<JsonObject> queue = new ArrayBlockingQueue<>(16);
+    private volatile InputStream sseStream;
+
+    public StreamableHttpTransport(URI endpoint) {
+        this.client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public void send(JsonObject message) throws IOException {
+        HttpRequest request = HttpRequest.newBuilder(endpoint)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .POST(HttpRequest.BodyPublishers.ofString(message.toString()))
+                .build();
+        try {
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            String contentType = response.headers().firstValue("Content-Type").orElse("");
+            if (contentType.startsWith("text/event-stream")) {
+                if (sseStream != null) sseStream.close();
+                sseStream = response.body();
+                new Thread(() -> readSse(sseStream)).start();
+            } else if (contentType.startsWith("application/json")) {
+                try (JsonReader reader = Json.createReader(response.body())) {
+                    queue.offer(reader.readObject());
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+    }
+
+    private void readSse(InputStream stream) {
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            StringBuilder data = new StringBuilder();
+            while ((line = r.readLine()) != null) {
+                if (line.isEmpty()) {
+                    if (data.length() > 0) {
+                        try (JsonReader reader = Json.createReader(new StringReader(data.toString()))) {
+                            queue.offer(reader.readObject());
+                        }
+                        data.setLength(0);
+                    }
+                    continue;
+                }
+                if (line.startsWith("data:")) {
+                    data.append(line.substring(5).trim());
+                }
+            }
+        } catch (IOException ignore) {
+        }
+    }
+
+    @Override
+    public JsonObject receive() throws IOException {
+        try {
+            return queue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (sseStream != null) sseStream.close();
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/Transport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/Transport.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.JsonObject;
+import java.io.IOException;
+
+public interface Transport extends AutoCloseable {
+    void send(JsonObject message) throws IOException;
+    JsonObject receive() throws IOException;
+    @Override
+    void close() throws IOException;
+}

--- a/src/test/java/com/amannmalik/mcp/transport/StdioTransportTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/StdioTransportTest.java
@@ -1,0 +1,28 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StdioTransportTest {
+    @Test
+    void roundTrip() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        StdioTransport client = new StdioTransport(new ByteArrayInputStream(new byte[0]), out);
+
+        JsonObject msg = Json.createObjectBuilder().add("hello", "world").build();
+        client.send(msg);
+        String written = out.toString(StandardCharsets.UTF_8);
+
+        ByteArrayInputStream in = new ByteArrayInputStream(written.getBytes(StandardCharsets.UTF_8));
+        StdioTransport server = new StdioTransport(in, new ByteArrayOutputStream());
+        JsonObject read = server.receive();
+        assertEquals(msg, read);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/transport/StreamableHttpTransportTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/StreamableHttpTransportTest.java
@@ -1,0 +1,74 @@
+package com.amannmalik.mcp.transport;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StreamableHttpTransportTest {
+    private HttpServer server;
+    private URI endpoint;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/mcp", new Handler());
+        server.start();
+        endpoint = URI.create("http://localhost:" + server.getAddress().getPort() + "/mcp");
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void simplePost() throws Exception {
+        try (StreamableHttpTransport transport = new StreamableHttpTransport(endpoint)) {
+            JsonObject req = Json.createObjectBuilder().add("ping", true).build();
+            transport.send(req);
+            JsonObject resp = transport.receive();
+            assertEquals(Json.createObjectBuilder().add("pong", true).build(), resp);
+        }
+    }
+
+    private static class Handler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if ("POST".equals(exchange.getRequestMethod())) {
+                InputStream body = exchange.getRequestBody();
+                try (JsonReader reader = Json.createReader(body)) {
+                    JsonObject obj = reader.readObject();
+                    if (obj.containsKey("ping")) {
+                        JsonObject resp = Json.createObjectBuilder().add("pong", true).build();
+                        byte[] bytes = resp.toString().getBytes(StandardCharsets.UTF_8);
+                        exchange.getResponseHeaders().add("Content-Type", "application/json");
+                        exchange.sendResponseHeaders(200, bytes.length);
+                        try (OutputStream os = exchange.getResponseBody()) {
+                            os.write(bytes);
+                        }
+                        return;
+                    }
+                }
+                exchange.sendResponseHeaders(202, -1);
+            } else {
+                exchange.sendResponseHeaders(405, -1);
+            }
+            exchange.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Transport` interface
- implement newline-oriented `StdioTransport`
- add HTTP-based `StreamableHttpTransport`
- test transports with simple round-trips

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886a7a5c6788324a4afb043f028f627