### PR TITLE
Implement protocol lifecycle

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/Capabilities.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/Capabilities.java
@@ -1,0 +1,20 @@
+package com.amannmalik.mcp.lifecycle;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public record Capabilities(Set<ClientCapability> client, Set<ServerCapability> server) {
+    public Capabilities {
+        client = client == null ? Set.of() : EnumSet.copyOf(client);
+        server = server == null ? Set.of() : EnumSet.copyOf(server);
+    }
+
+    public Set<ClientCapability> client() {
+        return Collections.unmodifiableSet(client);
+    }
+
+    public Set<ServerCapability> server() {
+        return Collections.unmodifiableSet(server);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ClientCapability.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ClientCapability.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.lifecycle;
+
+public enum ClientCapability {
+    ROOTS,
+    SAMPLING,
+    ELICITATION,
+    EXPERIMENTAL
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ClientInfo.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ClientInfo.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.lifecycle;
+
+public record ClientInfo(String name, String title, String version) {
+    public ClientInfo {
+        if (name == null || title == null || version == null) {
+            throw new IllegalArgumentException("ClientInfo fields must not be null");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/InitializeRequest.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/InitializeRequest.java
@@ -1,0 +1,13 @@
+package com.amannmalik.mcp.lifecycle;
+
+public record InitializeRequest(
+        String protocolVersion,
+        Capabilities capabilities,
+        ClientInfo clientInfo
+) {
+    public InitializeRequest {
+        if (protocolVersion == null) {
+            throw new IllegalArgumentException("protocolVersion must not be null");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/InitializeResponse.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/InitializeResponse.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.lifecycle;
+
+public record InitializeResponse(
+        String protocolVersion,
+        Capabilities capabilities,
+        ServerInfo serverInfo,
+        String instructions
+) {}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleState.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleState.java
@@ -1,0 +1,7 @@
+package com.amannmalik.mcp.lifecycle;
+
+public enum LifecycleState {
+    INIT,
+    OPERATION,
+    SHUTDOWN
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -1,0 +1,60 @@
+package com.amannmalik.mcp.lifecycle;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class ProtocolLifecycle {
+    public static final String SUPPORTED_VERSION = "2025-06-18";
+
+    private final Set<ServerCapability> serverCapabilities;
+    private LifecycleState state = LifecycleState.INIT;
+    private Set<ClientCapability> clientCapabilities = Set.of();
+
+    public ProtocolLifecycle(Set<ServerCapability> serverCapabilities) {
+        this.serverCapabilities = EnumSet.copyOf(serverCapabilities);
+    }
+
+    public InitializeResponse initialize(InitializeRequest request) {
+        ensureState(LifecycleState.INIT);
+
+        if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
+            throw new UnsupportedProtocolVersionException(request.protocolVersion(), SUPPORTED_VERSION);
+        }
+
+        clientCapabilities = EnumSet.copyOf(request.capabilities().client());
+
+        return new InitializeResponse(
+                SUPPORTED_VERSION,
+                new Capabilities(clientCapabilities, serverCapabilities),
+                new ServerInfo("mcp-java", "MCP Java Reference", "0.1.0"),
+                null
+        );
+    }
+
+    public void initialized() {
+        ensureState(LifecycleState.INIT);
+        state = LifecycleState.OPERATION;
+    }
+
+    public void shutdown() {
+        state = LifecycleState.SHUTDOWN;
+    }
+
+    public LifecycleState state() {
+        return state;
+    }
+
+    public Set<ClientCapability> negotiatedClientCapabilities() {
+        return clientCapabilities;
+    }
+
+    public Set<ServerCapability> serverCapabilities() {
+        return serverCapabilities;
+    }
+
+    private void ensureState(LifecycleState expected) {
+        if (state != expected) {
+            throw new IllegalStateException("Invalid lifecycle state: " + state);
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ServerCapability.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ServerCapability.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.lifecycle;
+
+public enum ServerCapability {
+    PROMPTS,
+    RESOURCES,
+    TOOLS,
+    LOGGING,
+    COMPLETIONS,
+    EXPERIMENTAL
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ServerInfo.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ServerInfo.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.lifecycle;
+
+public record ServerInfo(String name, String title, String version) {
+    public ServerInfo {
+        if (name == null || title == null || version == null) {
+            throw new IllegalArgumentException("ServerInfo fields must not be null");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/UnsupportedProtocolVersionException.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/UnsupportedProtocolVersionException.java
@@ -1,0 +1,20 @@
+package com.amannmalik.mcp.lifecycle;
+
+public class UnsupportedProtocolVersionException extends RuntimeException {
+    private final String requested;
+    private final String supported;
+
+    public UnsupportedProtocolVersionException(String requested, String supported) {
+        super("Unsupported protocol version: " + requested + " (supported: " + supported + ")");
+        this.requested = requested;
+        this.supported = supported;
+    }
+
+    public String requested() {
+        return requested;
+    }
+
+    public String supported() {
+        return supported;
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycleTest.java
+++ b/src/test/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycleTest.java
@@ -1,0 +1,42 @@
+package com.amannmalik.mcp.lifecycle;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProtocolLifecycleTest {
+    @Test
+    void successfulInitializationTransitionsToOperationAfterInitialized() {
+        ProtocolLifecycle lifecycle = new ProtocolLifecycle(EnumSet.of(ServerCapability.PROMPTS));
+        InitializeRequest request = new InitializeRequest(
+                ProtocolLifecycle.SUPPORTED_VERSION,
+                new Capabilities(EnumSet.of(ClientCapability.ROOTS), EnumSet.noneOf(ServerCapability.class)),
+                new ClientInfo("client", "Client", "1")
+        );
+        InitializeResponse response = lifecycle.initialize(request);
+        assertEquals(ProtocolLifecycle.SUPPORTED_VERSION, response.protocolVersion());
+        assertEquals(LifecycleState.INIT, lifecycle.state());
+        lifecycle.initialized();
+        assertEquals(LifecycleState.OPERATION, lifecycle.state());
+    }
+
+    @Test
+    void unsupportedVersionThrowsException() {
+        ProtocolLifecycle lifecycle = new ProtocolLifecycle(EnumSet.noneOf(ServerCapability.class));
+        InitializeRequest request = new InitializeRequest(
+                "2024-11-05",
+                new Capabilities(EnumSet.noneOf(ClientCapability.class), EnumSet.noneOf(ServerCapability.class)),
+                new ClientInfo("client", "Client", "1")
+        );
+        assertThrows(UnsupportedProtocolVersionException.class, () -> lifecycle.initialize(request));
+    }
+
+    @Test
+    void shutdownAlwaysAllowed() {
+        ProtocolLifecycle lifecycle = new ProtocolLifecycle(EnumSet.noneOf(ServerCapability.class));
+        lifecycle.shutdown();
+        assertEquals(LifecycleState.SHUTDOWN, lifecycle.state());
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic protocol lifecycle state machine
- add capability enums and records
- add initialization request/response types
- tests for lifecycle management

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886a7aa92588324b23e890396c21c3e