### PR TITLE
Add server framework

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/Capabilities.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/Capabilities.java
@@ -6,8 +6,8 @@ import java.util.Set;
 
 public record Capabilities(Set<ClientCapability> client, Set<ServerCapability> server) {
     public Capabilities {
-        client = client == null ? Set.of() : EnumSet.copyOf(client);
-        server = server == null ? Set.of() : EnumSet.copyOf(server);
+        client = client == null ? Set.of() : client.isEmpty() ? Set.of() : EnumSet.copyOf(client);
+        server = server == null ? Set.of() : server.isEmpty() ? Set.of() : EnumSet.copyOf(server);
     }
 
     public Set<ClientCapability> client() {

--- a/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
@@ -1,0 +1,59 @@
+package com.amannmalik.mcp.lifecycle;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/** JSON utilities for lifecycle messages. */
+public final class LifecycleCodec {
+    private LifecycleCodec() {}
+
+    public static InitializeRequest toInitializeRequest(JsonObject obj) {
+        String version = obj.getString("protocolVersion");
+        JsonObject capsObj = obj.getJsonObject("capabilities");
+        Set<ClientCapability> client = EnumSet.noneOf(ClientCapability.class);
+        Set<ServerCapability> server = EnumSet.noneOf(ServerCapability.class);
+        if (capsObj != null) {
+            var clientObj = capsObj.getJsonObject("client");
+            if (clientObj != null) {
+                clientObj.forEach((k, v) -> client.add(ClientCapability.valueOf(k.toUpperCase())));
+            }
+            var serverObj = capsObj.getJsonObject("server");
+            if (serverObj != null) {
+                serverObj.forEach((k, v) -> server.add(ServerCapability.valueOf(k.toUpperCase())));
+            }
+        }
+        Capabilities caps = new Capabilities(
+                client.isEmpty() ? Set.of() : EnumSet.copyOf(client),
+                server.isEmpty() ? Set.of() : EnumSet.copyOf(server)
+        );
+        JsonObject ci = obj.getJsonObject("clientInfo");
+        ClientInfo info = new ClientInfo(ci.getString("name"), ci.getString("title"), ci.getString("version"));
+        return new InitializeRequest(version, caps, info);
+    }
+
+    public static JsonObject toJsonObject(InitializeResponse resp) {
+        var client = Json.createObjectBuilder();
+        resp.capabilities().client().forEach(c -> client.add(c.name().toLowerCase(), JsonValue.EMPTY_JSON_OBJECT));
+        var server = Json.createObjectBuilder();
+        resp.capabilities().server().forEach(c -> server.add(c.name().toLowerCase(), JsonValue.EMPTY_JSON_OBJECT));
+        var builder = Json.createObjectBuilder()
+                .add("protocolVersion", resp.protocolVersion())
+                .add("capabilities", Json.createObjectBuilder()
+                        .add("client", client)
+                        .add("server", server)
+                        .build())
+                .add("serverInfo", Json.createObjectBuilder()
+                        .add("name", resp.serverInfo().name())
+                        .add("title", resp.serverInfo().title())
+                        .add("version", resp.serverInfo().version())
+                        .build());
+        if (resp.instructions() != null) {
+            builder.add("instructions", resp.instructions());
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -21,7 +21,8 @@ public class ProtocolLifecycle {
             throw new UnsupportedProtocolVersionException(request.protocolVersion(), SUPPORTED_VERSION);
         }
 
-        clientCapabilities = EnumSet.copyOf(request.capabilities().client());
+        Set<ClientCapability> requested = request.capabilities().client();
+        clientCapabilities = requested.isEmpty() ? EnumSet.noneOf(ClientCapability.class) : EnumSet.copyOf(requested);
 
         return new InitializeResponse(
                 SUPPORTED_VERSION,

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -1,0 +1,122 @@
+package com.amannmalik.mcp.server;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcCodec;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcNotification;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.InitializeRequest;
+import com.amannmalik.mcp.lifecycle.InitializeResponse;
+import com.amannmalik.mcp.lifecycle.LifecycleCodec;
+import com.amannmalik.mcp.lifecycle.LifecycleState;
+import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.JsonObject;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Basic framework for implementing MCP servers. */
+public abstract class McpServer implements AutoCloseable {
+    private final Transport transport;
+    private final ProtocolLifecycle lifecycle;
+    private final Map<String, RequestHandler> requestHandlers = new ConcurrentHashMap<>();
+    private final Map<String, NotificationHandler> notificationHandlers = new ConcurrentHashMap<>();
+
+    protected McpServer(Set<ServerCapability> capabilities, Transport transport) {
+        this.transport = transport;
+        this.lifecycle = new ProtocolLifecycle(EnumSet.copyOf(capabilities));
+
+        registerRequestHandler("initialize", this::initialize);
+        registerNotificationHandler("notifications/initialized", this::initialized);
+    }
+
+    protected final ProtocolLifecycle lifecycle() {
+        return lifecycle;
+    }
+
+    protected final void registerRequestHandler(String method, RequestHandler handler) {
+        requestHandlers.put(method, handler);
+    }
+
+    protected final void registerNotificationHandler(String method, NotificationHandler handler) {
+        notificationHandlers.put(method, handler);
+    }
+
+    public final void serve() throws IOException {
+        while (lifecycle.state() != LifecycleState.SHUTDOWN) {
+            JsonObject obj = transport.receive();
+            JsonRpcMessage msg = JsonRpcCodec.fromJsonObject(obj);
+            switch (msg) {
+                case JsonRpcRequest req -> onRequest(req);
+                case JsonRpcNotification note -> onNotification(note);
+                default -> {}
+            }
+        }
+    }
+
+    protected void onRequest(JsonRpcRequest req) throws IOException {
+        var handler = requestHandlers.get(req.method());
+        if (handler == null) {
+            send(new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.METHOD_NOT_FOUND.code(),
+                    "Unknown method: " + req.method(), null)));
+            return;
+        }
+        JsonRpcMessage resp = handler.handle(req);
+        if (resp != null) send(resp);
+    }
+
+    protected void onNotification(JsonRpcNotification note) throws IOException {
+        var handler = notificationHandlers.get(note.method());
+        if (handler != null) handler.handle(note);
+    }
+
+    private JsonRpcMessage initialize(JsonRpcRequest req) {
+        InitializeRequest init = LifecycleCodec.toInitializeRequest(req.params());
+        InitializeResponse resp = lifecycle.initialize(init);
+        return new JsonRpcResponse(req.id(), LifecycleCodec.toJsonObject(resp));
+    }
+
+    private void initialized(JsonRpcNotification note) {
+        lifecycle.initialized();
+    }
+
+    protected final void send(JsonRpcMessage msg) throws IOException {
+        transport.send(JsonRpcCodec.toJsonObject(msg));
+    }
+
+    protected final void requireClientCapability(ClientCapability cap) {
+        if (!lifecycle.negotiatedClientCapabilities().contains(cap)) {
+            throw new IllegalStateException("Missing client capability: " + cap);
+        }
+    }
+
+    protected final void requireServerCapability(ServerCapability cap) {
+        if (!lifecycle.serverCapabilities().contains(cap)) {
+            throw new IllegalStateException("Server capability not declared: " + cap);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        transport.close();
+    }
+
+    @FunctionalInterface
+    protected interface RequestHandler {
+        JsonRpcMessage handle(JsonRpcRequest request);
+    }
+
+    @FunctionalInterface
+    protected interface NotificationHandler {
+        void handle(JsonRpcNotification notification) throws IOException;
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/McpServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/McpServerTest.java
@@ -1,0 +1,52 @@
+package com.amannmalik.mcp.server;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcCodec;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class McpServerTest {
+    @Test
+    void initializationRoundTrip() throws Exception {
+        ByteArrayOutputStream serverOut = new ByteArrayOutputStream();
+        StdioTransport transport = new StdioTransport(new ByteArrayInputStream(new byte[0]), serverOut);
+        TestServer server = new TestServer(transport);
+
+        JsonObject initParams = Json.createObjectBuilder()
+                .add("protocolVersion", "2025-06-18")
+                .add("capabilities", Json.createObjectBuilder()
+                        .add("client", Json.createObjectBuilder())
+                        .add("server", Json.createObjectBuilder())
+                        .build())
+                .add("clientInfo", Json.createObjectBuilder()
+                        .add("name", "test")
+                        .add("title", "Test")
+                        .add("version", "0")
+                        .build())
+                .build();
+        JsonRpcRequest request = new JsonRpcRequest(new RequestId.NumericId(1), "initialize", initParams);
+
+        server.onRequest(request);
+
+        JsonObject responseJson = Json.createReader(new ByteArrayInputStream(serverOut.toByteArray())).readObject();
+        JsonRpcResponse response = (JsonRpcResponse) JsonRpcCodec.fromJsonObject(responseJson);
+        assertEquals(new RequestId.NumericId(1), response.id());
+    }
+
+    private static class TestServer extends McpServer {
+        TestServer(StdioTransport transport) {
+            super(EnumSet.of(ServerCapability.PROMPTS), transport);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `McpServer` base class with request/notification routing
- add `LifecycleCodec` utilities
- relax empty capability handling
- add test coverage for server initialization

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6886b56aa6ec8324841e2e891a789e7a