### PR TITLE
Implement host orchestrator

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -1,0 +1,23 @@
+package com.amannmalik.mcp.client;
+
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import java.io.IOException;
+
+/** Basic client contract managed by a HostProcess. */
+public interface McpClient extends AutoCloseable {
+    ClientInfo info();
+
+    void connect() throws IOException;
+
+    void disconnect() throws IOException;
+
+    boolean connected();
+
+    /** Context currently held by the client for aggregation. */
+    String context();
+
+    @Override
+    default void close() throws IOException {
+        disconnect();
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/host/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/host/HostProcess.java
@@ -1,0 +1,56 @@
+package com.amannmalik.mcp.host;
+
+import com.amannmalik.mcp.client.McpClient;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Manages a collection of MCP clients within a single host application.
+ */
+public final class HostProcess implements AutoCloseable {
+    private final Map<String, McpClient> clients = new ConcurrentHashMap<>();
+    private final SecurityPolicy policy;
+
+    public HostProcess(SecurityPolicy policy) {
+        this.policy = policy;
+    }
+
+    public void register(String id, McpClient client) throws IOException {
+        if (!policy.allow(client)) {
+            throw new SecurityException("Client not authorized: " + client.info().name());
+        }
+        if (clients.putIfAbsent(id, client) != null) {
+            throw new IllegalArgumentException("Client already registered: " + id);
+        }
+        client.connect();
+    }
+
+    public void unregister(String id) throws IOException {
+        McpClient client = clients.remove(id);
+        if (client != null) {
+            client.disconnect();
+        }
+    }
+
+    public Set<String> clientIds() {
+        return Collections.unmodifiableSet(clients.keySet());
+    }
+
+    public String aggregateContext() {
+        return clients.values().stream()
+                .map(McpClient::context)
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (String id : Set.copyOf(clients.keySet())) {
+            unregister(id);
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/host/SecurityPolicy.java
+++ b/src/main/java/com/amannmalik/mcp/host/SecurityPolicy.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.host;
+
+import com.amannmalik.mcp.client.McpClient;
+
+/** Determines whether a client is allowed to connect. */
+public interface SecurityPolicy {
+    boolean allow(McpClient client);
+}

--- a/src/test/java/com/amannmalik/mcp/host/HostProcessTest.java
+++ b/src/test/java/com/amannmalik/mcp/host/HostProcessTest.java
@@ -1,0 +1,62 @@
+package com.amannmalik.mcp.host;
+
+import com.amannmalik.mcp.client.McpClient;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HostProcessTest {
+    private static class FakeClient implements McpClient {
+        private final AtomicBoolean connected = new AtomicBoolean();
+
+        @Override
+        public ClientInfo info() {
+            return new ClientInfo("fake", "Fake", "1");
+        }
+
+        @Override
+        public void connect() {
+            connected.set(true);
+        }
+
+        @Override
+        public void disconnect() {
+            connected.set(false);
+        }
+
+        @Override
+        public boolean connected() {
+            return connected.get();
+        }
+
+        @Override
+        public String context() {
+            return "ctx";
+        }
+    }
+
+    @Test
+    void registersAndAggregates() throws IOException {
+        SecurityPolicy allowAll = c -> true;
+        HostProcess host = new HostProcess(allowAll);
+        FakeClient client = new FakeClient();
+        host.register("one", client);
+        assertTrue(client.connected());
+        assertEquals(Set.of("one"), host.clientIds());
+        assertEquals("ctx", host.aggregateContext());
+        host.unregister("one");
+        assertFalse(client.connected());
+    }
+
+    @Test
+    void rejectsUnauthorizedClient() {
+        SecurityPolicy denyAll = c -> false;
+        HostProcess host = new HostProcess(denyAll);
+        assertThrows(SecurityException.class, () -> host.register("x", new FakeClient()));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `McpClient` interface for clients
- implement `SecurityPolicy` and `HostProcess`
- test host process orchestration

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886b574656483249a4d45d8ce8545a9