### PR TITLE
Implement initial MCP client framework

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/SimpleMcpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/SimpleMcpClient.java
@@ -1,0 +1,96 @@
+package com.amannmalik.mcp.client;
+
+import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.lifecycle.*;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.JsonObject;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Minimal implementation of an MCP client. */
+public final class SimpleMcpClient implements McpClient {
+    private final ClientInfo info;
+    private final Set<ClientCapability> capabilities;
+    private final Transport transport;
+    private final AtomicLong id = new AtomicLong(1);
+    private volatile boolean connected;
+    private Set<ServerCapability> serverCapabilities = Set.of();
+    private String instructions;
+
+    public SimpleMcpClient(ClientInfo info, Set<ClientCapability> capabilities, Transport transport) {
+        this.info = info;
+        this.capabilities = capabilities.isEmpty() ? Set.of() : EnumSet.copyOf(capabilities);
+        this.transport = transport;
+    }
+
+    @Override
+    public ClientInfo info() {
+        return info;
+    }
+
+    @Override
+    public synchronized void connect() throws IOException {
+        if (connected) return;
+        InitializeRequest init = new InitializeRequest(
+                ProtocolLifecycle.SUPPORTED_VERSION,
+                new Capabilities(capabilities, Set.of()),
+                info
+        );
+        RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
+        JsonRpcRequest request = new JsonRpcRequest(reqId, "initialize", LifecycleCodec.toJsonObject(init));
+        transport.send(JsonRpcCodec.toJsonObject(request));
+        JsonRpcMessage msg = JsonRpcCodec.fromJsonObject(transport.receive());
+        if (msg instanceof JsonRpcResponse resp) {
+            InitializeResponse ir = LifecycleCodec.toInitializeResponse(resp.result());
+            serverCapabilities = ir.capabilities().server();
+            instructions = ir.instructions();
+        } else if (msg instanceof JsonRpcError err) {
+            throw new IOException("Initialization failed: " + err.error().message());
+        } else {
+            throw new IOException("Unexpected message type: " + msg.getClass().getSimpleName());
+        }
+        JsonRpcNotification note = new JsonRpcNotification("notifications/initialized", null);
+        transport.send(JsonRpcCodec.toJsonObject(note));
+        connected = true;
+    }
+
+    @Override
+    public synchronized void disconnect() throws IOException {
+        if (!connected) return;
+        connected = false;
+        transport.close();
+    }
+
+    @Override
+    public boolean connected() {
+        return connected;
+    }
+
+    @Override
+    public String context() {
+        return instructions == null ? "" : instructions;
+    }
+
+    public JsonRpcMessage request(String method, JsonObject params) throws IOException {
+        if (!connected) throw new IllegalStateException("not connected");
+        RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
+        JsonRpcRequest req = new JsonRpcRequest(reqId, method, params);
+        transport.send(JsonRpcCodec.toJsonObject(req));
+        while (true) {
+            JsonRpcMessage msg = JsonRpcCodec.fromJsonObject(transport.receive());
+            if (msg instanceof JsonRpcResponse resp && resp.id().equals(reqId)) {
+                return resp;
+            }
+            if (msg instanceof JsonRpcError err && err.id().equals(reqId)) {
+                return err;
+            }
+        }
+    }
+
+    public Set<ServerCapability> serverCapabilities() {
+        return serverCapabilities;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
@@ -11,6 +11,25 @@ import java.util.Set;
 public final class LifecycleCodec {
     private LifecycleCodec() {}
 
+    public static JsonObject toJsonObject(InitializeRequest req) {
+        var client = Json.createObjectBuilder();
+        req.capabilities().client().forEach(c -> client.add(c.name().toLowerCase(), JsonValue.EMPTY_JSON_OBJECT));
+        var server = Json.createObjectBuilder();
+        req.capabilities().server().forEach(c -> server.add(c.name().toLowerCase(), JsonValue.EMPTY_JSON_OBJECT));
+        return Json.createObjectBuilder()
+                .add("protocolVersion", req.protocolVersion())
+                .add("capabilities", Json.createObjectBuilder()
+                        .add("client", client)
+                        .add("server", server)
+                        .build())
+                .add("clientInfo", Json.createObjectBuilder()
+                        .add("name", req.clientInfo().name())
+                        .add("title", req.clientInfo().title())
+                        .add("version", req.clientInfo().version())
+                        .build())
+                .build();
+    }
+
     public static InitializeRequest toInitializeRequest(JsonObject obj) {
         String version = obj.getString("protocolVersion");
         JsonObject capsObj = obj.getJsonObject("capabilities");
@@ -55,5 +74,26 @@ public final class LifecycleCodec {
             builder.add("instructions", resp.instructions());
         }
         return builder.build();
+    }
+
+    public static InitializeResponse toInitializeResponse(JsonObject obj) {
+        String version = obj.getString("protocolVersion");
+        JsonObject capsObj = obj.getJsonObject("capabilities");
+        Set<ClientCapability> client = EnumSet.noneOf(ClientCapability.class);
+        Set<ServerCapability> server = EnumSet.noneOf(ServerCapability.class);
+        if (capsObj != null) {
+            var c = capsObj.getJsonObject("client");
+            if (c != null) c.forEach((k, v) -> client.add(ClientCapability.valueOf(k.toUpperCase())));
+            var s = capsObj.getJsonObject("server");
+            if (s != null) s.forEach((k, v) -> server.add(ServerCapability.valueOf(k.toUpperCase())));
+        }
+        Capabilities caps = new Capabilities(
+                client.isEmpty() ? Set.of() : EnumSet.copyOf(client),
+                server.isEmpty() ? Set.of() : EnumSet.copyOf(server)
+        );
+        JsonObject si = obj.getJsonObject("serverInfo");
+        ServerInfo info = new ServerInfo(si.getString("name"), si.getString("title"), si.getString("version"));
+        String instructions = obj.containsKey("instructions") ? obj.getString("instructions") : null;
+        return new InitializeResponse(version, caps, info, instructions);
     }
 }

--- a/src/test/java/com/amannmalik/mcp/client/SimpleMcpClientTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/SimpleMcpClientTest.java
@@ -1,0 +1,78 @@
+package com.amannmalik.mcp.client;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.StdioTransport;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SimpleMcpClientTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private TestServer server;
+    private Thread serverThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        server = new TestServer(serverTransport);
+        serverThread = new Thread(() -> {
+            try {
+                server.serve();
+            } catch (IOException ignored) {
+            }
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void initializationAndRequest() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("client", "Client", "1"),
+                EnumSet.of(ClientCapability.ROOTS),
+                clientTransport);
+        client.connect();
+        assertTrue(client.connected());
+        assertTrue(client.serverCapabilities().isEmpty());
+        JsonRpcMessage msg = client.request("ping", Json.createObjectBuilder().build());
+        assertTrue(msg instanceof JsonRpcResponse);
+        JsonObject result = ((JsonRpcResponse) msg).result();
+        assertEquals(Json.createObjectBuilder().add("pong", true).build(), result);
+        client.disconnect();
+        assertFalse(client.connected());
+    }
+
+    private static class TestServer extends McpServer {
+        TestServer(Transport t) {
+            super(EnumSet.noneOf(ServerCapability.class), t);
+            registerRequestHandler("ping", req -> new JsonRpcResponse(req.id(), Json.createObjectBuilder().add("pong", true).build()));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add methods to convert lifecycle messages to and from JSON
- implement `SimpleMcpClient` with connection management and request handling
- test client/server initialization and basic request/response

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886b8c46b4c8324998bd9e59bd60b07