### PR TITLE
Implement prompts subsystem

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -1,0 +1,31 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Simple PromptProvider backed by in-memory templates. */
+public final class InMemoryPromptProvider implements PromptProvider {
+    private final Map<String, PromptTemplate> templates = new ConcurrentHashMap<>();
+
+    public void add(PromptTemplate template) {
+        templates.put(template.prompt().name(), template);
+    }
+
+    @Override
+    public List<Prompt> listPrompts() {
+        List<Prompt> list = new ArrayList<>();
+        for (PromptTemplate t : templates.values()) {
+            list.add(t.prompt());
+        }
+        return list;
+    }
+
+    @Override
+    public PromptInstance getPrompt(String name, Map<String, String> arguments) {
+        PromptTemplate tmpl = templates.get(name);
+        if (tmpl == null) throw new IllegalArgumentException("unknown prompt: " + name);
+        return tmpl.instantiate(arguments);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.List;
+
+/** Metadata for a prompt that can be listed by the server. */
+public record Prompt(
+        String name,
+        String title,
+        String description,
+        List<PromptArgument> arguments
+) {
+    public Prompt {
+        if (name == null) throw new IllegalArgumentException("name is required");
+        arguments = arguments == null || arguments.isEmpty() ? List.of() : List.copyOf(arguments);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
@@ -1,0 +1,13 @@
+package com.amannmalik.mcp.prompts;
+
+/** Definition of a parameter that can be passed to a prompt template. */
+public record PromptArgument(
+        String name,
+        String title,
+        String description,
+        boolean required
+) {
+    public PromptArgument {
+        if (name == null) throw new IllegalArgumentException("name is required");
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -1,0 +1,58 @@
+package com.amannmalik.mcp.prompts;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/** JSON utilities for prompt messages. */
+public final class PromptCodec {
+    private PromptCodec() {}
+
+    public static JsonObject toJsonObject(Prompt prompt) {
+        var builder = Json.createObjectBuilder()
+                .add("name", prompt.name());
+        if (prompt.title() != null) builder.add("title", prompt.title());
+        if (prompt.description() != null) builder.add("description", prompt.description());
+        if (!prompt.arguments().isEmpty()) {
+            JsonArrayBuilder args = Json.createArrayBuilder();
+            for (PromptArgument a : prompt.arguments()) {
+                JsonObjectBuilder ab = Json.createObjectBuilder().add("name", a.name());
+                if (a.title() != null) ab.add("title", a.title());
+                if (a.description() != null) ab.add("description", a.description());
+                if (a.required()) ab.add("required", true);
+                args.add(ab.build());
+            }
+            builder.add("arguments", args.build());
+        }
+        return builder.build();
+    }
+
+    public static JsonObject toJsonObject(PromptInstance inst) {
+        JsonArrayBuilder msgs = Json.createArrayBuilder();
+        for (PromptMessage m : inst.messages()) {
+            msgs.add(Json.createObjectBuilder()
+                    .add("role", m.role().name().toLowerCase())
+                    .add("content", Json.createObjectBuilder()
+                            .add("type", "text")
+                            .add("text", m.text())
+                            .build())
+                    .build());
+        }
+        JsonObjectBuilder obj = Json.createObjectBuilder().add("messages", msgs.build());
+        if (inst.description() != null) obj.add("description", inst.description());
+        return obj.build();
+    }
+
+    public static Map<String, String> toArguments(JsonObject obj) {
+        if (obj == null) return Map.of();
+        return obj.entrySet().stream().collect(java.util.stream.Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue().getValueType() == jakarta.json.JsonValue.ValueType.STRING
+                        ? ((jakarta.json.JsonString) e.getValue()).getString()
+                        : e.getValue().toString()));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptInstance.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptInstance.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.List;
+
+/** Result of resolving a prompt template. */
+public record PromptInstance(String description, List<PromptMessage> messages) {
+    public PromptInstance {
+        messages = messages == null || messages.isEmpty() ? List.of() : List.copyOf(messages);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptMessage.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptMessage.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.prompts;
+
+/** A single message in a prompt. Only text content is currently supported. */
+public record PromptMessage(Role role, String text) {
+    public PromptMessage {
+        if (role == null || text == null) {
+            throw new IllegalArgumentException("role and text are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptMessageTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptMessageTemplate.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.prompts;
+
+/** Template for a single message in a prompt. */
+public record PromptMessageTemplate(Role role, String template) {
+    public PromptMessageTemplate {
+        if (role == null || template == null) {
+            throw new IllegalArgumentException("role and template are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.List;
+import java.util.Map;
+
+/** Mechanism for a server to expose prompts to clients. */
+public interface PromptProvider {
+    List<Prompt> listPrompts();
+
+    PromptInstance getPrompt(String name, Map<String, String> arguments);
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptServer.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptServer.java
@@ -1,0 +1,64 @@
+package com.amannmalik.mcp.prompts;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcNotification;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+/** McpServer extension that exposes prompts/list and prompts/get. */
+public class PromptServer extends McpServer {
+    private final PromptProvider provider;
+
+    public PromptServer(PromptProvider provider, Transport transport) {
+        super(EnumSet.of(ServerCapability.PROMPTS), transport);
+        this.provider = provider;
+        registerRequestHandler("prompts/list", this::listPrompts);
+        registerRequestHandler("prompts/get", this::getPrompt);
+    }
+
+    private JsonRpcMessage listPrompts(JsonRpcRequest req) {
+        List<Prompt> prompts = provider.listPrompts();
+        var arr = Json.createArrayBuilder();
+        for (Prompt p : prompts) arr.add(PromptCodec.toJsonObject(p));
+        JsonObject result = Json.createObjectBuilder()
+                .add("prompts", arr.build())
+                .build();
+        return new JsonRpcResponse(req.id(), result);
+    }
+
+    private JsonRpcMessage getPrompt(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        String name = params.getString("name", null);
+        if (name == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(),
+                    "name is required", null));
+        }
+        Map<String, String> args = PromptCodec.toArguments(params.getJsonObject("arguments"));
+        try {
+            PromptInstance inst = provider.getPrompt(name, args);
+            JsonObject result = PromptCodec.toJsonObject(inst);
+            return new JsonRpcResponse(req.id(), result);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
+    }
+
+    /** Notify clients that the list of prompts has changed. */
+    public void listChanged() throws IOException {
+        send(new JsonRpcNotification("notifications/prompts/list_changed", null));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -1,0 +1,33 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A template used to generate prompt instances. Placeholders in messages
+ * use curly braces, e.g. {code}.
+ */
+public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages) {
+    public PromptTemplate {
+        messages = messages == null || messages.isEmpty() ? List.of() : List.copyOf(messages);
+    }
+
+    PromptInstance instantiate(Map<String, String> args) {
+        List<PromptMessage> list = new ArrayList<>();
+        for (PromptMessageTemplate t : messages) {
+            list.add(new PromptMessage(t.role(), substitute(t.template(), args)));
+        }
+        return new PromptInstance(prompt.description(), list);
+    }
+
+    private static String substitute(String template, Map<String, String> args) {
+        String result = template;
+        if (args != null) {
+            for (Map.Entry<String, String> e : args.entrySet()) {
+                result = result.replace("{" + e.getKey() + "}", e.getValue());
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/Role.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/Role.java
@@ -1,0 +1,7 @@
+package com.amannmalik.mcp.prompts;
+
+/** Sender or recipient of a prompt message. */
+public enum Role {
+    USER,
+    ASSISTANT
+}

--- a/src/test/java/com/amannmalik/mcp/prompts/PromptServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/prompts/PromptServerTest.java
@@ -1,0 +1,66 @@
+package com.amannmalik.mcp.prompts;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcCodec;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PromptServerTest {
+    @Test
+    void listAndGet() throws Exception {
+        InMemoryPromptProvider provider = new InMemoryPromptProvider();
+        Prompt meta = new Prompt(
+                "hello",
+                "Hello",
+                "Simple greeting",
+                List.of(new PromptArgument("name", "Name", null, true))
+        );
+        PromptTemplate tmpl = new PromptTemplate(
+                meta,
+                List.of(new PromptMessageTemplate(Role.USER, "Hello {name}!"))
+        );
+        provider.add(tmpl);
+
+        ByteArrayOutputStream serverOut = new ByteArrayOutputStream();
+        StdioTransport transport = new StdioTransport(new ByteArrayInputStream(new byte[0]), serverOut);
+        TestServer server = new TestServer(provider, transport);
+
+        JsonRpcRequest listReq = new JsonRpcRequest(new RequestId.NumericId(1), "prompts/list", Json.createObjectBuilder().build());
+        server.handle(listReq);
+        JsonObject listRespJson = Json.createReader(new ByteArrayInputStream(serverOut.toByteArray())).readObject();
+        serverOut.reset();
+        JsonRpcResponse listResp = (JsonRpcResponse) JsonRpcCodec.fromJsonObject(listRespJson);
+        assertTrue(listResp.result().getJsonArray("prompts").size() == 1);
+
+        JsonObject getParams = Json.createObjectBuilder()
+                .add("name", "hello")
+                .add("arguments", Json.createObjectBuilder().add("name", "World").build())
+                .build();
+        JsonRpcRequest getReq = new JsonRpcRequest(new RequestId.NumericId(2), "prompts/get", getParams);
+        server.handle(getReq);
+        JsonObject getRespJson = Json.createReader(new ByteArrayInputStream(serverOut.toByteArray())).readObject();
+        JsonRpcResponse getResp = (JsonRpcResponse) JsonRpcCodec.fromJsonObject(getRespJson);
+        assertEquals("Hello World!", getResp.result().getJsonArray("messages").getJsonObject(0).getJsonObject("content").getString("text"));
+    }
+
+    private static class TestServer extends PromptServer {
+        TestServer(PromptProvider provider, StdioTransport transport) {
+            super(provider, transport);
+        }
+
+        void handle(JsonRpcRequest req) throws Exception {
+            onRequest(req);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add model classes for prompts
- implement InMemoryPromptProvider and PromptServer
- wire JSON encoding helpers for prompt data
- test prompt listing and retrieval with template substitution

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6886babb558483249f027fbd5f31a20e