### PR TITLE
Implement tools server

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/tools/SchemaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/SchemaValidator.java
@@ -1,0 +1,46 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+
+/** Very small subset of JSON Schema validation used for tool inputs. */
+public final class SchemaValidator {
+    private SchemaValidator() {}
+
+    public static void validate(JsonObject schema, JsonObject value) {
+        if (schema == null) return;
+        if ("object".equals(schema.getString("type", null))) {
+            JsonArray required = schema.getJsonArray("required");
+            if (required != null) {
+                for (var r : required.getValuesAs(JsonString.class)) {
+                    if (!value.containsKey(r.getString())) {
+                        throw new IllegalArgumentException("Missing required field: " + r.getString());
+                    }
+                }
+            }
+            JsonObject props = schema.getJsonObject("properties");
+            if (props != null) {
+                for (var e : props.entrySet()) {
+                    if (!value.containsKey(e.getKey())) continue;
+                    String t = e.getValue().asJsonObject().getString("type", null);
+                    if (t != null) {
+                        switch (t) {
+                            case "string" -> {
+                                if (!value.get(e.getKey()).getValueType().equals(jakarta.json.JsonValue.ValueType.STRING))
+                                    throw new IllegalArgumentException("Expected string for " + e.getKey());
+                            }
+                            case "number" -> {
+                                var vt = value.get(e.getKey()).getValueType();
+                                if (vt != jakarta.json.JsonValue.ValueType.NUMBER)
+                                    throw new IllegalArgumentException("Expected number for " + e.getKey());
+                            }
+                            case "object" -> validate(e.getValue().asJsonObject(), value.getJsonObject(e.getKey()));
+                            default -> {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.JsonObject;
+
+/** Definition of a server-exposed tool. */
+public record Tool(String name,
+                    String title,
+                    String description,
+                    JsonObject inputSchema,
+                    JsonObject outputSchema) {
+    public Tool {
+        if (name == null || inputSchema == null) {
+            throw new IllegalArgumentException("name and inputSchema are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -1,0 +1,37 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/** JSON utilities for tool messages. */
+public final class ToolCodec {
+    private ToolCodec() {}
+
+    public static JsonObject toJsonObject(Tool tool) {
+        JsonObjectBuilder builder = Json.createObjectBuilder()
+                .add("name", tool.name());
+        if (tool.title() != null) builder.add("title", tool.title());
+        if (tool.description() != null) builder.add("description", tool.description());
+        builder.add("inputSchema", tool.inputSchema());
+        if (tool.outputSchema() != null) builder.add("outputSchema", tool.outputSchema());
+        return builder.build();
+    }
+
+    public static JsonObject toJsonObject(ToolPage page) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        page.tools().forEach(t -> arr.add(toJsonObject(t)));
+        JsonObjectBuilder builder = Json.createObjectBuilder().add("tools", arr);
+        if (page.nextCursor() != null) builder.add("nextCursor", page.nextCursor());
+        return builder.build();
+    }
+
+    public static JsonObject toJsonObject(ToolResult result) {
+        JsonObjectBuilder builder = Json.createObjectBuilder()
+                .add("content", result.content())
+                .add("isError", result.isError());
+        if (result.structuredContent() != null) builder.add("structuredContent", result.structuredContent());
+        return builder.build();
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolPage.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolPage.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.server.tools;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Result of a tool listing request. */
+public record ToolPage(List<Tool> tools, String nextCursor) {
+    public ToolPage {
+        tools = tools == null || tools.isEmpty() ? List.of() : List.copyOf(tools);
+    }
+
+    public List<Tool> tools() {
+        return Collections.unmodifiableList(tools);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.JsonObject;
+
+/** Service exposing tools to clients. */
+public interface ToolProvider {
+    ToolPage list(String cursor);
+
+    ToolResult call(String name, JsonObject arguments);
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+/** Result of a tool invocation. */
+public record ToolResult(JsonArray content, JsonObject structuredContent, boolean isError) {
+    public ToolResult {
+        content = content == null ? JsonValue.EMPTY_JSON_ARRAY : content;
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/tools/ToolServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/tools/ToolServerTest.java
@@ -1,0 +1,106 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ToolServerTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private ToolServer server;
+    private Thread serverThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        server = new ToolServer(new EchoProvider(), serverTransport);
+        serverThread = new Thread(() -> {
+            try {
+                server.serve();
+            } catch (IOException ignored) {
+            }
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void listAndCall() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("client", "Client", "1"),
+                EnumSet.of(ClientCapability.EXPERIMENTAL),
+                clientTransport);
+        client.connect();
+        JsonRpcMessage listMsg = client.request("tools/list", Json.createObjectBuilder().build());
+        assertTrue(listMsg instanceof JsonRpcResponse);
+        JsonObject listResult = ((JsonRpcResponse) listMsg).result();
+        JsonArray tools = listResult.getJsonArray("tools");
+        assertEquals(1, tools.size());
+
+        JsonObject args = Json.createObjectBuilder().add("message", "hi").build();
+        JsonRpcMessage callMsg = client.request("tools/call", Json.createObjectBuilder()
+                .add("name", "echo")
+                .add("arguments", args)
+                .build());
+        assertTrue(callMsg instanceof JsonRpcResponse);
+        JsonObject callResult = ((JsonRpcResponse) callMsg).result();
+        assertEquals("hi", callResult.getJsonArray("content").getJsonObject(0).getString("text"));
+        client.disconnect();
+    }
+
+    private static class EchoProvider implements ToolProvider {
+        private final Tool tool;
+
+        EchoProvider() {
+            JsonObject schema = Json.createObjectBuilder()
+                    .add("type", "object")
+                    .add("properties", Json.createObjectBuilder()
+                            .add("message", Json.createObjectBuilder().add("type", "string")))
+                    .add("required", Json.createArrayBuilder().add("message"))
+                    .build();
+            tool = new Tool("echo", "Echo", "Echo text", schema, null);
+        }
+
+        @Override
+        public ToolPage list(String cursor) {
+            return new ToolPage(java.util.List.of(tool), null);
+        }
+
+        @Override
+        public ToolResult call(String name, JsonObject arguments) {
+            if (!tool.name().equals(name)) throw new IllegalArgumentException("Unknown tool");
+            SchemaValidator.validate(tool.inputSchema(), arguments);
+            JsonArray content = Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder().add("type", "text").add("text", arguments.getString("message")).build())
+                    .build();
+            return new ToolResult(content, null, false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Tool model, provider interface and result types
- implement simple JSON Schema validator
- create ToolServer for tool listing and calling
- test ToolServer with SimpleMcpClient

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886bab4d02c83249498a86c2673953a