### PR TITLE
Add Sampling API classes

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.client.sampling;
+
+import java.util.List;
+
+/** Parameters for requesting a new message from a model. */
+public record CreateMessageRequest(
+        List<SamplingMessage> messages,
+        ModelPreferences modelPreferences,
+        String systemPrompt,
+        Integer maxTokens
+) {
+    public CreateMessageRequest {
+        messages = messages == null || messages.isEmpty() ? List.of() : List.copyOf(messages);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageResponse.java
@@ -1,0 +1,17 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.prompts.Role;
+
+/** Model-generated message. */
+public record CreateMessageResponse(
+        Role role,
+        MessageContent content,
+        String model,
+        String stopReason
+) {
+    public CreateMessageResponse {
+        if (role == null || content == null) {
+            throw new IllegalArgumentException("role and content are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
@@ -1,0 +1,34 @@
+package com.amannmalik.mcp.client.sampling;
+
+/** Content of a sampling message. */
+public sealed interface MessageContent permits MessageContent.Text, MessageContent.Image, MessageContent.Audio {
+    String type();
+
+    /** Text content. */
+    record Text(String text) implements MessageContent {
+        public Text {
+            if (text == null) throw new IllegalArgumentException("text is required");
+        }
+        @Override public String type() { return "text"; }
+    }
+
+    /** Image content. */
+    record Image(byte[] data, String mimeType) implements MessageContent {
+        public Image {
+            if (data == null || mimeType == null) {
+                throw new IllegalArgumentException("data and mimeType are required");
+            }
+        }
+        @Override public String type() { return "image"; }
+    }
+
+    /** Audio content. */
+    record Audio(byte[] data, String mimeType) implements MessageContent {
+        public Audio {
+            if (data == null || mimeType == null) {
+                throw new IllegalArgumentException("data and mimeType are required");
+            }
+        }
+        @Override public String type() { return "audio"; }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/ModelHint.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/ModelHint.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.client.sampling;
+
+/** Advisory model identifier hint. */
+public record ModelHint(String name) {
+    public ModelHint {
+        if (name == null) throw new IllegalArgumentException("name is required");
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/ModelPreferences.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/ModelPreferences.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.client.sampling;
+
+import java.util.List;
+
+/** Model selection parameters. */
+public record ModelPreferences(
+        List<ModelHint> hints,
+        Double costPriority,
+        Double speedPriority,
+        Double intelligencePriority
+) {
+    public ModelPreferences {
+        hints = hints == null || hints.isEmpty() ? List.of() : List.copyOf(hints);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
@@ -1,0 +1,113 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.prompts.Role;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import java.util.Base64;
+import java.util.List;
+
+/** JSON utilities for sampling messages. */
+public final class SamplingCodec {
+    private SamplingCodec() {}
+
+    public static JsonObject toJsonObject(CreateMessageRequest req) {
+        JsonArrayBuilder msgs = Json.createArrayBuilder();
+        for (SamplingMessage m : req.messages()) msgs.add(toJsonObject(m));
+        JsonObjectBuilder obj = Json.createObjectBuilder().add("messages", msgs.build());
+        if (req.modelPreferences() != null) obj.add("modelPreferences", toJsonObject(req.modelPreferences()));
+        if (req.systemPrompt() != null) obj.add("systemPrompt", req.systemPrompt());
+        if (req.maxTokens() != null) obj.add("maxTokens", req.maxTokens());
+        return obj.build();
+    }
+
+    public static CreateMessageRequest toCreateMessageRequest(JsonObject obj) {
+        List<SamplingMessage> messages = obj.getJsonArray("messages").stream()
+                .map(v -> toSamplingMessage(v.asJsonObject()))
+                .toList();
+        ModelPreferences prefs = obj.containsKey("modelPreferences")
+                ? toModelPreferences(obj.getJsonObject("modelPreferences"))
+                : null;
+        String system = obj.getString("systemPrompt", null);
+        Integer max = obj.containsKey("maxTokens") ? obj.getInt("maxTokens") : null;
+        return new CreateMessageRequest(messages, prefs, system, max);
+    }
+
+    public static JsonObject toJsonObject(CreateMessageResponse resp) {
+        JsonObjectBuilder obj = Json.createObjectBuilder()
+                .add("role", resp.role().name().toLowerCase())
+                .add("content", toJsonObject(resp.content()));
+        if (resp.model() != null) obj.add("model", resp.model());
+        if (resp.stopReason() != null) obj.add("stopReason", resp.stopReason());
+        return obj.build();
+    }
+
+    public static CreateMessageResponse toCreateMessageResponse(JsonObject obj) {
+        Role role = Role.valueOf(obj.getString("role").toUpperCase());
+        MessageContent content = toContent(obj.getJsonObject("content"));
+        String model = obj.getString("model", null);
+        String stop = obj.getString("stopReason", null);
+        return new CreateMessageResponse(role, content, model, stop);
+    }
+
+    static JsonObject toJsonObject(SamplingMessage msg) {
+        return Json.createObjectBuilder()
+                .add("role", msg.role().name().toLowerCase())
+                .add("content", toJsonObject(msg.content()))
+                .build();
+    }
+
+    static SamplingMessage toSamplingMessage(JsonObject obj) {
+        Role role = Role.valueOf(obj.getString("role").toUpperCase());
+        MessageContent content = toContent(obj.getJsonObject("content"));
+        return new SamplingMessage(role, content);
+    }
+
+    static JsonObject toJsonObject(MessageContent content) {
+        JsonObjectBuilder b = Json.createObjectBuilder().add("type", content.type());
+        switch (content) {
+            case MessageContent.Text t -> b.add("text", t.text());
+            case MessageContent.Image i -> b.add("data", Base64.getEncoder().encodeToString(i.data()))
+                    .add("mimeType", i.mimeType());
+            case MessageContent.Audio a -> b.add("data", Base64.getEncoder().encodeToString(a.data()))
+                    .add("mimeType", a.mimeType());
+        }
+        return b.build();
+    }
+
+    static MessageContent toContent(JsonObject obj) {
+        return switch (obj.getString("type")) {
+            case "text" -> new MessageContent.Text(obj.getString("text"));
+            case "image" -> new MessageContent.Image(Base64.getDecoder().decode(obj.getString("data")), obj.getString("mimeType"));
+            case "audio" -> new MessageContent.Audio(Base64.getDecoder().decode(obj.getString("data")), obj.getString("mimeType"));
+            default -> throw new IllegalArgumentException("Unknown content type");
+        };
+    }
+
+    static JsonObject toJsonObject(ModelPreferences prefs) {
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (!prefs.hints().isEmpty()) {
+            JsonArrayBuilder arr = Json.createArrayBuilder();
+            for (ModelHint h : prefs.hints()) arr.add(Json.createObjectBuilder().add("name", h.name()).build());
+            b.add("hints", arr.build());
+        }
+        if (prefs.costPriority() != null) b.add("costPriority", prefs.costPriority());
+        if (prefs.speedPriority() != null) b.add("speedPriority", prefs.speedPriority());
+        if (prefs.intelligencePriority() != null) b.add("intelligencePriority", prefs.intelligencePriority());
+        return b.build();
+    }
+
+    static ModelPreferences toModelPreferences(JsonObject obj) {
+        List<ModelHint> hints = obj.containsKey("hints")
+                ? obj.getJsonArray("hints").stream()
+                    .map(v -> new ModelHint(v.asJsonObject().getString("name")))
+                    .toList()
+                : List.of();
+        Double cost = obj.containsKey("costPriority") ? obj.getJsonNumber("costPriority").doubleValue() : null;
+        Double speed = obj.containsKey("speedPriority") ? obj.getJsonNumber("speedPriority").doubleValue() : null;
+        Double intel = obj.containsKey("intelligencePriority") ? obj.getJsonNumber("intelligencePriority").doubleValue() : null;
+        return new ModelPreferences(hints, cost, speed, intel);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingMessage.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingMessage.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.prompts.Role;
+
+/** A single conversational message. */
+public record SamplingMessage(Role role, MessageContent content) {
+    public SamplingMessage {
+        if (role == null || content == null) {
+            throw new IllegalArgumentException("role and content are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingProvider.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.client.sampling;
+
+import java.io.IOException;
+
+/** Interface for integrating language model providers. */
+public interface SamplingProvider extends AutoCloseable {
+    CreateMessageResponse createMessage(CreateMessageRequest request) throws IOException;
+
+    @Override
+    default void close() throws IOException {}
+}

--- a/src/test/java/com/amannmalik/mcp/client/sampling/SamplingCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/sampling/SamplingCodecTest.java
@@ -1,0 +1,36 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.prompts.Role;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SamplingCodecTest {
+    @Test
+    void requestRoundTrip() {
+        CreateMessageRequest req = new CreateMessageRequest(
+                List.of(new SamplingMessage(Role.USER, new MessageContent.Text("hi"))),
+                new ModelPreferences(List.of(new ModelHint("a")), 0.1, 0.2, 0.3),
+                "sys", 10
+        );
+        JsonObject json = SamplingCodec.toJsonObject(req);
+        CreateMessageRequest parsed = SamplingCodec.toCreateMessageRequest(json);
+        assertEquals(req, parsed);
+    }
+
+    @Test
+    void responseRoundTrip() {
+        CreateMessageResponse resp = new CreateMessageResponse(
+                Role.ASSISTANT,
+                new MessageContent.Text("ok"),
+                "model-1",
+                "endTurn"
+        );
+        JsonObject json = SamplingCodec.toJsonObject(resp);
+        CreateMessageResponse parsed = SamplingCodec.toCreateMessageResponse(json);
+        assertEquals(resp, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- add `client.sampling` package with new data types
- support JSON serialization via `SamplingCodec`
- cover round-trip encoding/decoding with tests

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6886bd04be908324836f1df240384952