### PR TITLE
Implement client roots feature

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/InMemoryRootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/InMemoryRootsProvider.java
@@ -1,0 +1,39 @@
+package com.amannmalik.mcp.client.roots;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/** Simple in-memory RootsProvider. */
+public final class InMemoryRootsProvider implements RootsProvider {
+    private final List<Root> roots = new CopyOnWriteArrayList<>();
+    private final List<RootsListener> listeners = new CopyOnWriteArrayList<>();
+
+    public InMemoryRootsProvider(List<Root> initial) {
+        if (initial != null) roots.addAll(initial);
+    }
+
+    @Override
+    public List<Root> list() {
+        return List.copyOf(roots);
+    }
+
+    @Override
+    public RootsSubscription subscribe(RootsListener listener) {
+        listeners.add(listener);
+        return () -> listeners.remove(listener);
+    }
+
+    public void add(Root root) {
+        roots.add(root);
+        notifyListeners();
+    }
+
+    public void remove(String uri) {
+        roots.removeIf(r -> r.uri().equals(uri));
+        notifyListeners();
+    }
+
+    private void notifyListeners() {
+        listeners.forEach(RootsListener::listChanged);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/roots/Root.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/Root.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.client.roots;
+
+/** Filesystem boundary made available to a server. */
+public record Root(String uri, String name) {
+    public Root {
+        if (uri == null) throw new IllegalArgumentException("uri is required");
+        if (!uri.startsWith("file:")) {
+            throw new IllegalArgumentException("uri must start with file:");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -1,0 +1,38 @@
+package com.amannmalik.mcp.client.roots;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** JSON helpers for root messages. */
+public final class RootsCodec {
+    private RootsCodec() {}
+
+    public static JsonObject toJsonObject(Root root) {
+        JsonObjectBuilder b = Json.createObjectBuilder().add("uri", root.uri());
+        if (root.name() != null) b.add("name", root.name());
+        return b.build();
+    }
+
+    public static Root toRoot(JsonObject obj) {
+        return new Root(obj.getString("uri"), obj.getString("name", null));
+    }
+
+    public static JsonObject toJsonObject(List<Root> roots) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (Root r : roots) arr.add(toJsonObject(r));
+        return Json.createObjectBuilder().add("roots", arr).build();
+    }
+
+    public static List<Root> toRoots(JsonObject obj) {
+        var arr = obj.getJsonArray("roots");
+        if (arr == null || arr.isEmpty()) return List.of();
+        List<Root> list = new ArrayList<>(arr.size());
+        arr.forEach(v -> list.add(toRoot(v.asJsonObject())));
+        return List.copyOf(list);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsListener.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.client.roots;
+
+@FunctionalInterface
+public interface RootsListener {
+    void listChanged();
+}

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsProvider.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.client.roots;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Supplies filesystem roots to a server. */
+public interface RootsProvider extends AutoCloseable {
+    /** Current roots. */
+    List<Root> list() throws IOException;
+
+    /** Subscribe to root list changes. */
+    RootsSubscription subscribe(RootsListener listener) throws IOException;
+
+    @Override
+    default void close() throws IOException {}
+}

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsSubscription.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.client.roots;
+
+public interface RootsSubscription extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/src/test/java/com/amannmalik/mcp/client/roots/InMemoryRootsProviderTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/roots/InMemoryRootsProviderTest.java
@@ -1,0 +1,33 @@
+package com.amannmalik.mcp.client.roots;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryRootsProviderTest {
+    @Test
+    void listAddRemoveAndNotify() throws Exception {
+        Root r1 = new Root("file:///a", "A");
+        InMemoryRootsProvider provider = new InMemoryRootsProvider(List.of(r1));
+        assertEquals(List.of(r1), provider.list());
+
+        AtomicInteger called = new AtomicInteger();
+        RootsSubscription sub = provider.subscribe(called::incrementAndGet);
+
+        Root r2 = new Root("file:///b", "B");
+        provider.add(r2);
+        assertEquals(2, provider.list().size());
+        assertEquals(1, called.get());
+
+        provider.remove("file:///a");
+        assertEquals(List.of(r2), provider.list());
+        assertEquals(2, called.get());
+
+        sub.close();
+        provider.add(new Root("file:///c", "C"));
+        assertEquals(2, called.get());
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/client/roots/RootsCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/roots/RootsCodecTest.java
@@ -1,0 +1,26 @@
+package com.amannmalik.mcp.client.roots;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RootsCodecTest {
+    @Test
+    void rootRoundTrip() {
+        Root root = new Root("file:///a", "A");
+        JsonObject json = RootsCodec.toJsonObject(root);
+        Root parsed = RootsCodec.toRoot(json);
+        assertEquals(root, parsed);
+    }
+
+    @Test
+    void listRoundTrip() {
+        List<Root> list = List.of(new Root("file:///a", "A"), new Root("file:///b", "B"));
+        JsonObject json = RootsCodec.toJsonObject(list);
+        List<Root> parsed = RootsCodec.toRoots(json);
+        assertEquals(list, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- add data types and provider API for Roots capability
- supply in-memory RootsProvider
- add codec for encoding/decoding root messages
- test codec and provider logic

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886bd0a153c832486bd8bf93fd55135