### PR TITLE
Implement basic elicitation model

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationAction.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationAction.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.client.elicitation;
+
+/**
+ * User response actions for elicitation requests.
+ */
+public enum ElicitationAction {
+    ACCEPT,
+    DECLINE,
+    CANCEL
+}

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationCodec.java
@@ -1,0 +1,40 @@
+package com.amannmalik.mcp.client.elicitation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/**
+ * JSON utilities for elicitation messages.
+ */
+public final class ElicitationCodec {
+    private ElicitationCodec() {}
+
+    public static JsonObject toJsonObject(ElicitationRequest req) {
+        return Json.createObjectBuilder()
+                .add("message", req.message())
+                .add("requestedSchema", req.requestedSchema())
+                .build();
+    }
+
+    public static ElicitationRequest toRequest(JsonObject obj) {
+        return new ElicitationRequest(
+                obj.getString("message"),
+                obj.getJsonObject("requestedSchema")
+        );
+    }
+
+    public static JsonObject toJsonObject(ElicitationResponse resp) {
+        JsonObjectBuilder b = Json.createObjectBuilder()
+                .add("action", resp.action().name().toLowerCase());
+        if (resp.content() != null) b.add("content", resp.content());
+        return b.build();
+    }
+
+    public static ElicitationResponse toResponse(JsonObject obj) {
+        String a = obj.getString("action");
+        ElicitationAction action = ElicitationAction.valueOf(a.toUpperCase());
+        JsonObject content = obj.getJsonObject("content");
+        return new ElicitationResponse(action, content);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationProvider.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.client.elicitation;
+
+/**
+ * Interface implemented by clients to obtain user input when requested by a server.
+ */
+public interface ElicitationProvider {
+    /**
+     * Prompt the user according to the request. A timeout of {@code 0} means wait indefinitely.
+     */
+    ElicitationResponse elicit(ElicitationRequest request, long timeoutMillis) throws InterruptedException;
+
+    default ElicitationResponse elicit(ElicitationRequest request) throws InterruptedException {
+        return elicit(request, 0);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationRequest.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.client.elicitation;
+
+import jakarta.json.JsonObject;
+
+/**
+ * A server request asking the client to collect information from the user.
+ */
+public record ElicitationRequest(String message, JsonObject requestedSchema) {
+    public ElicitationRequest {
+        if (message == null || requestedSchema == null) {
+            throw new IllegalArgumentException("message and requestedSchema are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.client.elicitation;
+
+import jakarta.json.JsonObject;
+
+/**
+ * The client's response to an elicitation request.
+ */
+public record ElicitationResponse(ElicitationAction action, JsonObject content) {
+    public ElicitationResponse {
+        if (action == null) throw new IllegalArgumentException("action is required");
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/client/elicitation/ElicitationCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/elicitation/ElicitationCodecTest.java
@@ -1,0 +1,33 @@
+package com.amannmalik.mcp.client.elicitation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ElicitationCodecTest {
+    @Test
+    void requestRoundTrip() {
+        JsonObject schema = Json.createObjectBuilder()
+                .add("type", "object")
+                .add("properties", Json.createObjectBuilder()
+                        .add("name", Json.createObjectBuilder().add("type", "string")))
+                .add("required", Json.createArrayBuilder().add("name"))
+                .build();
+        ElicitationRequest req = new ElicitationRequest("Provide name", schema);
+        JsonObject json = ElicitationCodec.toJsonObject(req);
+        ElicitationRequest parsed = ElicitationCodec.toRequest(json);
+        assertEquals(req, parsed);
+    }
+
+    @Test
+    void responseRoundTrip() {
+        JsonObject content = Json.createObjectBuilder().add("name", "a").build();
+        ElicitationResponse resp = new ElicitationResponse(ElicitationAction.ACCEPT, content);
+        JsonObject json = ElicitationCodec.toJsonObject(resp);
+        ElicitationResponse parsed = ElicitationCodec.toResponse(json);
+        assertEquals(resp.action(), parsed.action());
+        assertEquals(resp.content(), parsed.content());
+    }
+}


### PR DESCRIPTION
## Summary
- implement ElicitationAction and POJOs for request/response
- add an ElicitationProvider interface
- add codec helpers with tests

## Testing
- `gradle test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6886bd11657c8324970c467a0d787b45