### PR TITLE
Implement logging and ping utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
@@ -1,0 +1,28 @@
+package com.amannmalik.mcp.ping;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+/** JSON-RPC helpers for ping messages. */
+public final class PingCodec {
+    private PingCodec() {}
+
+    public static JsonRpcRequest toRequest(RequestId id) {
+        return new JsonRpcRequest(id, "ping", null);
+    }
+
+    public static PingRequest toPingRequest(JsonRpcRequest req) {
+        return new PingRequest();
+    }
+
+    public static JsonRpcResponse toResponse(RequestId id) {
+        return new JsonRpcResponse(id, Json.createObjectBuilder().build());
+    }
+
+    public static PingResponse toPingResponse(JsonRpcResponse resp) {
+        return new PingResponse();
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/ping/PingRequest.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.ping;
+
+/** Empty ping request. */
+public record PingRequest() {}

--- a/src/main/java/com/amannmalik/mcp/ping/PingResponse.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingResponse.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.ping;
+
+/** Empty ping response. */
+public record PingResponse() {}

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -36,6 +36,7 @@ public abstract class McpServer implements AutoCloseable {
 
         registerRequestHandler("initialize", this::initialize);
         registerNotificationHandler("notifications/initialized", this::initialized);
+        registerRequestHandler("ping", this::ping);
     }
 
     protected final ProtocolLifecycle lifecycle() {
@@ -87,6 +88,10 @@ public abstract class McpServer implements AutoCloseable {
 
     private void initialized(JsonRpcNotification note) {
         lifecycle.initialized();
+    }
+
+    private JsonRpcMessage ping(JsonRpcRequest req) {
+        return new JsonRpcResponse(req.id(), jakarta.json.Json.createObjectBuilder().build());
     }
 
     protected final void send(JsonRpcMessage msg) throws IOException {

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
@@ -1,0 +1,35 @@
+package com.amannmalik.mcp.server.logging;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/** JSON helpers for logging messages. */
+public final class LoggingCodec {
+    private LoggingCodec() {}
+
+    public static JsonObject toJsonObject(LoggingNotification n) {
+        JsonObjectBuilder b = Json.createObjectBuilder()
+                .add("level", n.level().name().toLowerCase())
+                .add("data", n.data());
+        if (n.logger() != null) b.add("logger", n.logger());
+        return b.build();
+    }
+
+    public static LoggingNotification toLoggingNotification(JsonObject obj) {
+        LoggingLevel level = LoggingLevel.valueOf(obj.getString("level").toUpperCase());
+        String logger = obj.getString("logger", null);
+        return new LoggingNotification(level, logger, obj.get("data"));
+    }
+
+    public static JsonObject toJsonObject(SetLevelRequest req) {
+        return Json.createObjectBuilder()
+                .add("level", req.level().name().toLowerCase())
+                .build();
+    }
+
+    public static SetLevelRequest toSetLevelRequest(JsonObject obj) {
+        LoggingLevel level = LoggingLevel.valueOf(obj.getString("level").toUpperCase());
+        return new SetLevelRequest(level);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingLevel.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingLevel.java
@@ -1,0 +1,13 @@
+package com.amannmalik.mcp.server.logging;
+
+/** Severity of a log message following RFC 5424 levels. */
+public enum LoggingLevel {
+    DEBUG,
+    INFO,
+    NOTICE,
+    WARNING,
+    ERROR,
+    CRITICAL,
+    ALERT,
+    EMERGENCY;
+}

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingNotification.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingNotification.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.server.logging;
+
+import jakarta.json.JsonValue;
+
+/** A log message notification sent from server to client. */
+public record LoggingNotification(LoggingLevel level, String logger, JsonValue data) {
+    public LoggingNotification {
+        if (level == null || data == null) {
+            throw new IllegalArgumentException("level and data are required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingServer.java
@@ -1,0 +1,49 @@
+package com.amannmalik.mcp.server.logging;
+
+import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+/** McpServer extension providing structured logging. */
+public class LoggingServer extends McpServer {
+    private volatile LoggingLevel minLevel = LoggingLevel.INFO;
+    private final Logger slf4j = LoggerFactory.getLogger(LoggingServer.class);
+
+    public LoggingServer(Transport transport) {
+        super(EnumSet.of(ServerCapability.LOGGING), transport);
+        registerRequestHandler("logging/setLevel", this::setLevel);
+    }
+
+    private JsonRpcMessage setLevel(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        if (params == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing params", null));
+        }
+        SetLevelRequest sl = LoggingCodec.toSetLevelRequest(params);
+        minLevel = sl.level();
+        return new JsonRpcResponse(req.id(), Json.createObjectBuilder().build());
+    }
+
+    public void log(LoggingLevel level, String loggerName, JsonValue data) throws IOException {
+        if (level.ordinal() < minLevel.ordinal()) return;
+        Logger log = loggerName == null ? slf4j : LoggerFactory.getLogger(loggerName);
+        switch (level) {
+            case DEBUG -> log.debug(data.toString());
+            case INFO, NOTICE -> log.info(data.toString());
+            case WARNING -> log.warn(data.toString());
+            default -> log.error(data.toString());
+        }
+        LoggingNotification note = new LoggingNotification(level, loggerName, data);
+        send(new JsonRpcNotification("notifications/message", LoggingCodec.toJsonObject(note)));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/logging/SetLevelRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/SetLevelRequest.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.server.logging;
+
+/** Request from client to set minimum log level. */
+public record SetLevelRequest(LoggingLevel level) {
+    public SetLevelRequest {
+        if (level == null) {
+            throw new IllegalArgumentException("level is required");
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/client/SimpleMcpClientTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/SimpleMcpClientTest.java
@@ -64,7 +64,7 @@ class SimpleMcpClientTest {
         JsonRpcMessage msg = client.request("ping", Json.createObjectBuilder().build());
         assertTrue(msg instanceof JsonRpcResponse);
         JsonObject result = ((JsonRpcResponse) msg).result();
-        assertEquals(Json.createObjectBuilder().add("pong", true).build(), result);
+        assertEquals(Json.createObjectBuilder().build(), result);
         client.disconnect();
         assertFalse(client.connected());
     }
@@ -72,7 +72,6 @@ class SimpleMcpClientTest {
     private static class TestServer extends McpServer {
         TestServer(Transport t) {
             super(EnumSet.noneOf(ServerCapability.class), t);
-            registerRequestHandler("ping", req -> new JsonRpcResponse(req.id(), Json.createObjectBuilder().add("pong", true).build()));
         }
     }
 }

--- a/src/test/java/com/amannmalik/mcp/ping/PingCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/ping/PingCodecTest.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp.ping;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PingCodecTest {
+    @Test
+    void requestAndResponse() {
+        RequestId id = new RequestId.NumericId(1);
+        JsonRpcRequest req = PingCodec.toRequest(id);
+        assertEquals("ping", req.method());
+        JsonRpcResponse resp = PingCodec.toResponse(id);
+        assertEquals(id, resp.id());
+        assertEquals(0, resp.result().size());
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/logging/LoggingCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/logging/LoggingCodecTest.java
@@ -1,0 +1,25 @@
+package com.amannmalik.mcp.server.logging;
+
+import jakarta.json.JsonValue;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggingCodecTest {
+    @Test
+    void notificationRoundTrip() {
+        LoggingNotification n = new LoggingNotification(LoggingLevel.ERROR, "test", JsonValue.TRUE);
+        JsonObject json = LoggingCodec.toJsonObject(n);
+        LoggingNotification parsed = LoggingCodec.toLoggingNotification(json);
+        assertEquals(n, parsed);
+    }
+
+    @Test
+    void setLevelRoundTrip() {
+        SetLevelRequest req = new SetLevelRequest(LoggingLevel.WARNING);
+        JsonObject json = LoggingCodec.toJsonObject(req);
+        SetLevelRequest parsed = LoggingCodec.toSetLevelRequest(json);
+        assertEquals(req, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LoggingLevel`, `LoggingNotification`, and `LoggingServer`
- implement ping request/response helpers and default ping handler
- support logging level configuration and JSON-RPC notifications
- extend `McpServer` with built-in ping request handling
- update tests and add new unit tests

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6886bf4f17688324a2c5f1b5b4735f74