### PR TITLE
Implement completion and pagination utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
@@ -1,0 +1,62 @@
+package com.amannmalik.mcp.server.completion;
+
+import java.util.Map;
+
+/** Request sent by the client to ask for completion options. */
+public record CompleteRequest(
+        Ref ref,
+        Argument argument,
+        Context context
+) {
+    public CompleteRequest {
+        if (ref == null || argument == null) {
+            throw new IllegalArgumentException("ref and argument are required");
+        }
+    }
+
+    /** Which argument to complete. */
+    public record Argument(String name, String value) {
+        public Argument {
+            if (name == null || value == null) {
+                throw new IllegalArgumentException("name and value are required");
+            }
+        }
+    }
+
+    /** Additional completion context. */
+    public record Context(Map<String, String> arguments) {
+        public Context {
+            arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
+        }
+
+        @Override
+        public Map<String, String> arguments() {
+            return Map.copyOf(arguments);
+        }
+    }
+
+    /** Completion reference type. */
+    public sealed interface Ref permits Ref.PromptRef, Ref.ResourceRef {
+        String type();
+
+        /** References a prompt by name. */
+        record PromptRef(String name) implements Ref {
+            public PromptRef {
+                if (name == null) throw new IllegalArgumentException("name required");
+            }
+
+            @Override
+            public String type() { return "ref/prompt"; }
+        }
+
+        /** References a resource URI or template. */
+        record ResourceRef(String uri) implements Ref {
+            public ResourceRef {
+                if (uri == null) throw new IllegalArgumentException("uri required");
+            }
+
+            @Override
+            public String type() { return "ref/resource"; }
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
@@ -1,0 +1,22 @@
+package com.amannmalik.mcp.server.completion;
+
+import java.util.List;
+
+/** Response to a completion request. */
+public record CompleteResult(Completion completion) {
+    public CompleteResult {
+        if (completion == null) throw new IllegalArgumentException("completion required");
+    }
+
+    /** Completion result payload. */
+    public record Completion(List<String> values, Integer total, Boolean hasMore) {
+        public Completion {
+            values = values == null ? List.of() : List.copyOf(values);
+        }
+
+        @Override
+        public List<String> values() {
+            return List.copyOf(values);
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
@@ -1,0 +1,85 @@
+package com.amannmalik.mcp.server.completion;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** JSON utilities for completion messages. */
+public final class CompletionCodec {
+    private CompletionCodec() {}
+
+    public static JsonObject toJsonObject(CompleteRequest req) {
+        JsonObjectBuilder obj = Json.createObjectBuilder()
+                .add("ref", toJsonObject(req.ref()))
+                .add("argument", Json.createObjectBuilder()
+                        .add("name", req.argument().name())
+                        .add("value", req.argument().value())
+                        .build());
+        if (req.context() != null && !req.context().arguments().isEmpty()) {
+            JsonObjectBuilder ctx = Json.createObjectBuilder();
+            req.context().arguments().forEach(ctx::add);
+            obj.add("context", Json.createObjectBuilder().add("arguments", ctx.build()).build());
+        }
+        return obj.build();
+    }
+
+    public static CompleteRequest toCompleteRequest(JsonObject obj) {
+        CompleteRequest.Ref ref = toRef(obj.getJsonObject("ref"));
+        JsonObject arg = obj.getJsonObject("argument");
+        CompleteRequest.Argument argument = new CompleteRequest.Argument(arg.getString("name"), arg.getString("value"));
+        CompleteRequest.Context ctx = null;
+        if (obj.containsKey("context")) {
+            JsonObject argsObj = obj.getJsonObject("context").getJsonObject("arguments");
+            Map<String, String> args = new HashMap<>();
+            if (argsObj != null) {
+                argsObj.forEach((k, v) -> args.put(k, v.toString().replace("\"", "")));
+            }
+            ctx = new CompleteRequest.Context(args);
+        }
+        return new CompleteRequest(ref, argument, ctx);
+    }
+
+    public static JsonObject toJsonObject(CompleteResult result) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        result.completion().values().forEach(arr::add);
+        JsonObjectBuilder comp = Json.createObjectBuilder().add("values", arr.build());
+        if (result.completion().total() != null) comp.add("total", result.completion().total());
+        if (result.completion().hasMore() != null) comp.add("hasMore", result.completion().hasMore());
+        return Json.createObjectBuilder().add("completion", comp.build()).build();
+    }
+
+    public static CompleteResult toCompleteResult(JsonObject obj) {
+        JsonObject comp = obj.getJsonObject("completion");
+        var values = comp.getJsonArray("values").getValuesAs(jakarta.json.JsonString.class).stream()
+                .map(jakarta.json.JsonString::getString)
+                .toList();
+        Integer total = comp.containsKey("total") ? comp.getInt("total") : null;
+        Boolean hasMore = comp.containsKey("hasMore") ? comp.getBoolean("hasMore") : null;
+        return new CompleteResult(new CompleteResult.Completion(values, total, hasMore));
+    }
+
+    static JsonObject toJsonObject(CompleteRequest.Ref ref) {
+        return switch (ref) {
+            case CompleteRequest.Ref.PromptRef p -> Json.createObjectBuilder()
+                    .add("type", p.type())
+                    .add("name", p.name())
+                    .build();
+            case CompleteRequest.Ref.ResourceRef r -> Json.createObjectBuilder()
+                    .add("type", r.type())
+                    .add("uri", r.uri())
+                    .build();
+        };
+    }
+
+    static CompleteRequest.Ref toRef(JsonObject obj) {
+        return switch (obj.getString("type")) {
+            case "ref/prompt" -> new CompleteRequest.Ref.PromptRef(obj.getString("name"));
+            case "ref/resource" -> new CompleteRequest.Ref.ResourceRef(obj.getString("uri"));
+            default -> throw new IllegalArgumentException("unknown ref type");
+        };
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionProvider.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.server.completion;
+
+import java.io.IOException;
+
+/** Interface for providing completion suggestions. */
+public interface CompletionProvider extends AutoCloseable {
+    CompleteResult complete(CompleteRequest request) throws IOException;
+
+    @Override
+    default void close() throws IOException {}
+}

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionServer.java
@@ -1,0 +1,43 @@
+package com.amannmalik.mcp.server.completion;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.JsonObject;
+
+import java.util.EnumSet;
+
+/** McpServer extension providing completion support. */
+public class CompletionServer extends McpServer {
+    private final CompletionProvider provider;
+
+    public CompletionServer(CompletionProvider provider, Transport transport) {
+        super(EnumSet.of(ServerCapability.COMPLETIONS), transport);
+        this.provider = provider;
+        registerRequestHandler("completion/complete", this::complete);
+    }
+
+    private JsonRpcMessage complete(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        if (params == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing params", null));
+        }
+        try {
+            CompleteRequest request = CompletionCodec.toCompleteRequest(params);
+            CompleteResult result = provider.complete(request);
+            return new JsonRpcResponse(req.id(), CompletionCodec.toJsonObject(result));
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        } catch (Exception e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/util/PaginatedRequest.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginatedRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.util;
+
+/** Request carrying an optional pagination cursor. */
+public record PaginatedRequest(String cursor) {}

--- a/src/main/java/com/amannmalik/mcp/util/PaginatedResult.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginatedResult.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.util;
+
+/** Result that may indicate more items are available. */
+public record PaginatedResult(String nextCursor) {}

--- a/src/main/java/com/amannmalik/mcp/util/Pagination.java
+++ b/src/main/java/com/amannmalik/mcp/util/Pagination.java
@@ -1,0 +1,44 @@
+package com.amannmalik.mcp.util;
+
+import java.util.Base64;
+import java.util.List;
+
+/** Basic cursor-based pagination helper. */
+public final class Pagination {
+    private Pagination() {}
+
+    public static <T> Page<T> page(List<T> items, String cursor, int size) {
+        int start = decode(cursor);
+        if (start < 0 || start > items.size()) throw new IllegalArgumentException("Invalid cursor");
+        int end = Math.min(items.size(), start + size);
+        List<T> slice = items.subList(start, end);
+        String next = end < items.size() ? encode(end) : null;
+        return new Page<>(List.copyOf(slice), next);
+    }
+
+    private static String encode(int index) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(Integer.toString(index).getBytes());
+    }
+
+    private static int decode(String cursor) {
+        if (cursor == null) return 0;
+        try {
+            String s = new String(Base64.getUrlDecoder().decode(cursor));
+            return Integer.parseInt(s);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid cursor");
+        }
+    }
+
+    /** A page of results. */
+    public record Page<T>(List<T> items, String nextCursor) {
+        public Page {
+            items = items == null ? List.of() : List.copyOf(items);
+        }
+
+        @Override
+        public List<T> items() {
+            return List.copyOf(items);
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/completion/CompletionCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/completion/CompletionCodecTest.java
@@ -1,0 +1,31 @@
+package com.amannmalik.mcp.server.completion;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompletionCodecTest {
+    @Test
+    void requestRoundTrip() {
+        CompleteRequest req = new CompleteRequest(
+                new CompleteRequest.Ref.PromptRef("code"),
+                new CompleteRequest.Argument("lang", "j"),
+                new CompleteRequest.Context(Map.of("framework", "spring"))
+        );
+        JsonObject json = CompletionCodec.toJsonObject(req);
+        CompleteRequest parsed = CompletionCodec.toCompleteRequest(json);
+        assertEquals(req, parsed);
+    }
+
+    @Test
+    void resultRoundTrip() {
+        CompleteResult res = new CompleteResult(new CompleteResult.Completion(List.of("java", "javascript"), 5, true));
+        JsonObject json = CompletionCodec.toJsonObject(res);
+        CompleteResult parsed = CompletionCodec.toCompleteResult(json);
+        assertEquals(res, parsed);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/completion/CompletionServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/completion/CompletionServerTest.java
@@ -1,0 +1,49 @@
+package com.amannmalik.mcp.server.completion;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcCodec;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompletionServerTest {
+    @Test
+    void complete() throws Exception {
+        CompletionProvider provider = req -> new CompleteResult(new CompleteResult.Completion(List.of("java"), 1, false));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        StdioTransport transport = new StdioTransport(new ByteArrayInputStream(new byte[0]), out);
+        TestServer server = new TestServer(provider, transport);
+
+        CompleteRequest request = new CompleteRequest(
+                new CompleteRequest.Ref.PromptRef("code"),
+                new CompleteRequest.Argument("lang", "j"),
+                new CompleteRequest.Context(Map.of())
+        );
+        JsonRpcRequest rpcReq = new JsonRpcRequest(new RequestId.NumericId(1), "completion/complete", CompletionCodec.toJsonObject(request));
+        server.handle(rpcReq);
+
+        JsonObject respJson = Json.createReader(new ByteArrayInputStream(out.toByteArray())).readObject();
+        JsonRpcResponse resp = (JsonRpcResponse) JsonRpcCodec.fromJsonObject(respJson);
+        assertEquals("java", resp.result().getJsonObject("completion").getJsonArray("values").getString(0));
+    }
+
+    private static class TestServer extends CompletionServer {
+        TestServer(CompletionProvider provider, StdioTransport transport) {
+            super(provider, transport);
+        }
+
+        void handle(JsonRpcRequest req) throws Exception {
+            onRequest(req);
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/util/PaginationTest.java
+++ b/src/test/java/com/amannmalik/mcp/util/PaginationTest.java
@@ -1,0 +1,31 @@
+package com.amannmalik.mcp.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaginationTest {
+    @Test
+    void paginateThroughList() {
+        List<Integer> data = IntStream.range(0, 7).boxed().toList();
+        Pagination.Page<Integer> p1 = Pagination.page(data, null, 3);
+        assertEquals(List.of(0,1,2), p1.items());
+        assertNotNull(p1.nextCursor());
+
+        Pagination.Page<Integer> p2 = Pagination.page(data, p1.nextCursor(), 3);
+        assertEquals(List.of(3,4,5), p2.items());
+        assertNotNull(p2.nextCursor());
+
+        Pagination.Page<Integer> p3 = Pagination.page(data, p2.nextCursor(), 3);
+        assertEquals(List.of(6), p3.items());
+        assertNull(p3.nextCursor());
+    }
+
+    @Test
+    void invalidCursor() {
+        assertThrows(IllegalArgumentException.class, () -> Pagination.page(List.of(1,2,3), "bad", 2));
+    }
+}


### PR DESCRIPTION
## Summary
- add basic pagination helper and request/response records
- implement completion request/response types with JSON codec
- expose completion server with provider interface
- add unit tests for codecs, pagination and server

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6886bf529b148324a0c87cc94520d10f