### PR TITLE
Implement stdio process transport

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
@@ -4,16 +4,46 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public final class StdioTransport implements Transport {
     private final BufferedReader in;
     private final BufferedWriter out;
+    private final Process process;
+    private final Thread logReader;
 
     public StdioTransport(InputStream in, OutputStream out) {
         this.in = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         this.out = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+        this.process = null;
+        this.logReader = null;
+    }
+
+    public StdioTransport(ProcessBuilder builder, Consumer<String> logSink) throws IOException {
+        Objects.requireNonNull(logSink, "logSink");
+        builder.redirectErrorStream(false);
+        this.process = builder.start();
+        this.in = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+        this.out = new BufferedWriter(new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
+        this.logReader = new Thread(() -> readLogs(process.getErrorStream(), logSink));
+        this.logReader.setDaemon(true);
+        this.logReader.start();
+    }
+
+    public StdioTransport(ProcessBuilder builder) throws IOException {
+        this(builder, System.err::println);
     }
 
     @Override
@@ -34,7 +64,31 @@ public final class StdioTransport implements Transport {
 
     @Override
     public void close() throws IOException {
-        in.close();
-        out.close();
+        IOException ex = null;
+        try { out.close(); } catch (IOException e) { ex = e; }
+        try { in.close(); } catch (IOException e) { if (ex == null) ex = e; }
+        if (process != null) {
+            process.destroy();
+            try {
+                if (!process.waitFor(2, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    process.waitFor(2, TimeUnit.SECONDS);
+                }
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (logReader != null) {
+            try { logReader.join(100); } catch (InterruptedException ignore) { Thread.currentThread().interrupt(); }
+        }
+        if (ex != null) throw ex;
+    }
+
+    private static void readLogs(InputStream err, Consumer<String> sink) {
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(err, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = r.readLine()) != null) sink.accept(line);
+        } catch (IOException ignore) {
+        }
     }
 }

--- a/src/test/java/com/amannmalik/mcp/transport/StdioTransportTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/StdioTransportTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -24,5 +26,18 @@ class StdioTransportTest {
         StdioTransport server = new StdioTransport(in, new ByteArrayOutputStream());
         JsonObject read = server.receive();
         assertEquals(msg, read);
+    }
+
+    @Test
+    void spawnProcess() throws Exception {
+        ProcessBuilder pb = new ProcessBuilder("sh", "-c", "echo err >&2; cat");
+        List<String> logs = new ArrayList<>();
+        try (StdioTransport t = new StdioTransport(pb, logs::add)) {
+            JsonObject msg = Json.createObjectBuilder().add("ping", true).build();
+            t.send(msg);
+            JsonObject resp = t.receive();
+            assertEquals(msg, resp);
+        }
+        assertEquals(List.of("err"), logs);
     }
 }


### PR DESCRIPTION
## Summary
- extend `StdioTransport` with optional process spawning
- capture and forward stderr lines
- terminate child processes on close
- test process based behaviour

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886c17fb90c8324ad88874b20c4a52f