### PR TITLE
Add HTTP authorization framework

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/AuthorizationException.java
+++ b/src/main/java/com/amannmalik/mcp/auth/AuthorizationException.java
@@ -1,0 +1,7 @@
+package com.amannmalik.mcp.auth;
+
+public class AuthorizationException extends Exception {
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/auth/AuthorizationManager.java
+++ b/src/main/java/com/amannmalik/mcp/auth/AuthorizationManager.java
@@ -1,0 +1,22 @@
+package com.amannmalik.mcp.auth;
+
+import java.util.List;
+
+public final class AuthorizationManager {
+    private final List<AuthorizationStrategy> strategies;
+
+    public AuthorizationManager(List<AuthorizationStrategy> strategies) {
+        if (strategies == null || strategies.isEmpty()) {
+            throw new IllegalArgumentException("strategies required");
+        }
+        this.strategies = List.copyOf(strategies);
+    }
+
+    public Principal authorize(String authorizationHeader) throws AuthorizationException {
+        for (AuthorizationStrategy strategy : strategies) {
+            var result = strategy.authorize(authorizationHeader);
+            if (result.isPresent()) return result.get();
+        }
+        throw new AuthorizationException("No valid authorization strategy");
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/auth/AuthorizationStrategy.java
+++ b/src/main/java/com/amannmalik/mcp/auth/AuthorizationStrategy.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.auth;
+
+import java.util.Optional;
+
+@FunctionalInterface
+public interface AuthorizationStrategy {
+    Optional<Principal> authorize(String authorizationHeader) throws AuthorizationException;
+}

--- a/src/main/java/com/amannmalik/mcp/auth/BearerTokenAuthorizationStrategy.java
+++ b/src/main/java/com/amannmalik/mcp/auth/BearerTokenAuthorizationStrategy.java
@@ -1,0 +1,23 @@
+package com.amannmalik.mcp.auth;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public final class BearerTokenAuthorizationStrategy implements AuthorizationStrategy {
+    private final TokenValidator validator;
+
+    public BearerTokenAuthorizationStrategy(TokenValidator validator) {
+        this.validator = validator;
+    }
+
+    @Override
+    public Optional<Principal> authorize(String authorizationHeader) throws AuthorizationException {
+        if (authorizationHeader == null) return Optional.empty();
+        String[] parts = authorizationHeader.split("\\s+", 2);
+        if (!"bearer".equalsIgnoreCase(parts[0])) return Optional.empty();
+        if (parts.length != 2 || parts[1].trim().isEmpty()) {
+            throw new AuthorizationException("Invalid bearer token");
+        }
+        return Optional.of(validator.validate(parts[1].trim()));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/auth/Principal.java
+++ b/src/main/java/com/amannmalik/mcp/auth/Principal.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.auth;
+
+import java.util.Set;
+
+public record Principal(String id, Set<String> scopes) {
+    public Principal {
+        if (id == null) throw new IllegalArgumentException("id is required");
+        scopes = scopes == null || scopes.isEmpty() ? Set.of() : Set.copyOf(scopes);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/auth/TokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/TokenValidator.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.auth;
+
+@FunctionalInterface
+public interface TokenValidator {
+    Principal validate(String token) throws AuthorizationException;
+}

--- a/src/test/java/com/amannmalik/mcp/auth/AuthorizationManagerTest.java
+++ b/src/test/java/com/amannmalik/mcp/auth/AuthorizationManagerTest.java
@@ -1,0 +1,27 @@
+package com.amannmalik.mcp.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthorizationManagerTest {
+    @Test
+    void choosesStrategy() throws Exception {
+        AuthorizationStrategy skip = header -> Optional.empty();
+        AuthorizationStrategy bearer = new BearerTokenAuthorizationStrategy(token -> new Principal(token, Set.of()));
+        AuthorizationManager manager = new AuthorizationManager(List.of(skip, bearer));
+        Principal p = manager.authorize("Bearer t");
+        assertEquals("t", p.id());
+    }
+
+    @Test
+    void failsWhenNoneMatch() {
+        AuthorizationStrategy skip = header -> Optional.empty();
+        AuthorizationManager manager = new AuthorizationManager(List.of(skip));
+        assertThrows(AuthorizationException.class, () -> manager.authorize("Bearer x"));
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/auth/BearerTokenAuthorizationStrategyTest.java
+++ b/src/test/java/com/amannmalik/mcp/auth/BearerTokenAuthorizationStrategyTest.java
@@ -1,0 +1,31 @@
+package com.amannmalik.mcp.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BearerTokenAuthorizationStrategyTest {
+    @Test
+    void parsesBearerToken() throws Exception {
+        var strategy = new BearerTokenAuthorizationStrategy(token -> new Principal(token, Set.of()));
+        var result = strategy.authorize("Bearer abc").orElseThrow();
+        assertEquals("abc", result.id());
+    }
+
+    @Test
+    void rejectsMalformedHeader() {
+        var strategy = new BearerTokenAuthorizationStrategy(token -> new Principal(token, Set.of()));
+        assertThrows(AuthorizationException.class, () -> strategy.authorize("Bearer"));
+        assertThrows(AuthorizationException.class, () -> strategy.authorize("Bearer "));
+    }
+
+    @Test
+    void ignoresUnsupportedHeader() throws Exception {
+        var strategy = new BearerTokenAuthorizationStrategy(token -> { throw new AuthorizationException("should not" ); });
+        assertTrue(strategy.authorize("Basic aaa").isEmpty());
+        assertTrue(strategy.authorize(null).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add `auth` package with bearer token validation and authorization manager
- ensure invalid headers fail fast and allow multiple strategies
- test bearer token parsing and strategy selection

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886c1882f70832494326482f50ad139