### PR TITLE
Add Jetty-based HTTP transport

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServer.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServer.java
@@ -1,0 +1,124 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Jetty-based HTTP server implementing the MCP Streamable HTTP transport. */
+public final class StreamableHttpServer implements Transport {
+    private final Server server;
+    private final URI endpoint;
+    private final AtomicReference<Session> sessionRef = new AtomicReference<>();
+
+    public StreamableHttpServer(int port, String path) throws Exception {
+        server = new Server(new InetSocketAddress("localhost", port));
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(new TransportServlet()), path);
+        server.setHandler(context);
+        server.start();
+        ServerConnector connector = (ServerConnector) server.getConnectors()[0];
+        endpoint = URI.create("http://localhost:" + connector.getLocalPort() + path);
+    }
+
+    public URI endpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public void send(JsonObject message) {
+        Session session = sessionRef.get();
+        if (session == null) throw new IllegalStateException("no session");
+        session.outbound.offer(message);
+    }
+
+    @Override
+    public JsonObject receive() throws IOException {
+        Session session = sessionRef.get();
+        if (session == null) throw new IOException("no session");
+        try {
+            return session.inbound.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            server.stop();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static final class Session {
+        final String id;
+        final BlockingQueue<JsonObject> inbound = new ArrayBlockingQueue<>(16);
+        final BlockingQueue<JsonObject> outbound = new ArrayBlockingQueue<>(16);
+
+        Session(String id) {
+            this.id = id;
+        }
+    }
+
+    private final class TransportServlet extends HttpServlet {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            try (InputStream in = req.getInputStream(); JsonReader r = Json.createReader(in)) {
+                JsonObject obj = r.readObject();
+                Session session = getSession(req, resp, true);
+                if (session == null) return;
+                session.inbound.offer(obj);
+                JsonObject out = take(session.outbound);
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.setContentType("application/json");
+                resp.getWriter().write(out.toString());
+            }
+        }
+
+        private Session getSession(HttpServletRequest req, HttpServletResponse resp, boolean create) {
+            Session session = sessionRef.get();
+            String id = req.getHeader("Mcp-Session-Id");
+            if (session == null && create) {
+                String newId = UUID.randomUUID().toString();
+                session = new Session(newId);
+                sessionRef.set(session);
+                resp.setHeader("Mcp-Session-Id", newId);
+            } else if (session != null && (id == null || !session.id.equals(id))) {
+                session = null;
+            }
+            if (session == null) {
+                resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            }
+            return session;
+        }
+
+        private JsonObject take(BlockingQueue<JsonObject> q) {
+            try {
+                return q.take();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/transport/StreamableHttpServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/StreamableHttpServerTest.java
@@ -1,0 +1,50 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StreamableHttpServerTest {
+    private StreamableHttpServer server;
+    private URI endpoint;
+    private Thread worker;
+
+    @BeforeEach
+    void start() throws Exception {
+        server = new StreamableHttpServer(0, "/mcp");
+        endpoint = server.endpoint();
+        worker = new Thread(() -> {
+            try {
+                JsonObject req = server.receive();
+                if (req.containsKey("ping")) {
+                    JsonObject resp = Json.createObjectBuilder().add("pong", true).build();
+                    server.send(resp);
+                }
+            } catch (IOException ignored) {}
+        });
+        worker.start();
+    }
+
+    @AfterEach
+    void stop() throws Exception {
+        server.close();
+        worker.join();
+    }
+
+    @Test
+    void simplePost() throws Exception {
+        try (StreamableHttpTransport client = new StreamableHttpTransport(endpoint)) {
+            JsonObject req = Json.createObjectBuilder().add("ping", true).build();
+            client.send(req);
+            JsonObject resp = client.receive();
+            assertEquals(Json.createObjectBuilder().add("pong", true).build(), resp);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `StreamableHttpServer` using Jetty
- add unit test for server/transport round trip

## Testing
- `gradle test` *(fails: unreported due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6886c183f8f08324a18a900663c64152