### PR TITLE
Implement HTTP transport SSE support

### DIFF
--- a/src/test/java/com/amannmalik/mcp/transport/StreamableHttpServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/StreamableHttpServerTest.java
@@ -47,4 +47,15 @@ class StreamableHttpServerTest {
             assertEquals(Json.createObjectBuilder().add("pong", true).build(), resp);
         }
     }
+
+    @Test
+    void sseGet() throws Exception {
+        try (StreamableHttpTransport client = new StreamableHttpTransport(endpoint)) {
+            client.listen();
+            JsonObject msg = Json.createObjectBuilder().add("hello", "world").build();
+            server.send(msg);
+            JsonObject recv = client.receive();
+            assertEquals(msg, recv);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement SSE GET endpoint and session checks in `StreamableHttpServer`
- add client-side `listen` method and session headers in `StreamableHttpTransport`
- test GET-based SSE on both client and server

## Testing
- `gradle test` *(fails: timeout in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6886cae761b08324977783d742c68e31