### PR TITLE
Implement CLI commands with config support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ val jmhVersion by extra("1.37")
 val slf4jVersion by extra("2.0.16")
 val jettyVersion by extra("12.0.9")
 val jakartaServletVersion by extra("6.1.0")
+val snakeyamlVersion by extra("2.7")
 
 repositories {
     mavenLocal()
@@ -31,6 +32,7 @@ dependencies {
     implementation("org.eclipse.jetty.ee10:jetty-ee10-servlet:$jettyVersion")
     implementation("org.eclipse.jetty:jetty-util:$jettyVersion")
     implementation("jakarta.servlet:jakarta.servlet-api:$jakartaServletVersion")
+    implementation("org.snakeyaml:snakeyaml-engine:$snakeyamlVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     jmh("org.openjdk.jmh:jmh-core:$jmhVersion")
     jmh("org.openjdk.jmh:jmh-generator-annprocess:$jmhVersion")

--- a/src/main/java/com/amannmalik/mcp/Main.java
+++ b/src/main/java/com/amannmalik/mcp/Main.java
@@ -1,13 +1,16 @@
 package com.amannmalik.mcp;
 
+import com.amannmalik.mcp.cli.ClientCommand;
+import com.amannmalik.mcp.cli.ServerCommand;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
-public class Main implements Callable<Integer> {
-
+@CommandLine.Command(name = "mcp", subcommands = {ServerCommand.class, ClientCommand.class}, mixinStandardHelpOptions = true)
+public final class Main implements Callable<Integer> {
     @Override
     public Integer call() {
+        CommandLine.usage(this, System.out);
         return 0;
     }
 

--- a/src/main/java/com/amannmalik/mcp/cli/CliConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/CliConfig.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.cli;
+
+public sealed interface CliConfig permits ServerConfig, ClientConfig {
+}

--- a/src/main/java/com/amannmalik/mcp/cli/ClientCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ClientCommand.java
@@ -1,0 +1,53 @@
+package com.amannmalik.mcp.cli;
+
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.transport.StdioTransport;
+import picocli.CommandLine;
+
+import jakarta.json.Json;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "client", description = "Run MCP client", mixinStandardHelpOptions = true)
+public final class ClientCommand implements Callable<Integer> {
+    @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
+    private Path config;
+
+    @CommandLine.Option(names = "--command", description = "Server command for stdio")
+    private String command;
+
+    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
+    private boolean verbose;
+
+    @Override
+    public Integer call() throws Exception {
+        ClientConfig cfg;
+        if (config != null) {
+            CliConfig loaded = ConfigLoader.load(config);
+            if (!(loaded instanceof ClientConfig cc)) throw new IllegalArgumentException("client config expected");
+            cfg = cc;
+        } else {
+            if (command == null) throw new IllegalArgumentException("command required");
+            cfg = new ClientConfig(TransportType.STDIO, command);
+        }
+
+        StdioTransport transport = new StdioTransport(new ProcessBuilder(cfg.command().split(" ")),
+                verbose ? System.err::println : s -> {});
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("cli", "CLI", "0"),
+                EnumSet.noneOf(ClientCapability.class),
+                transport);
+        client.connect();
+        JsonRpcMessage msg = client.request("ping", Json.createObjectBuilder().build());
+        if (verbose && msg instanceof JsonRpcResponse) {
+            System.err.println("Ping OK");
+        }
+        client.disconnect();
+        return 0;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/ClientConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ClientConfig.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.cli;
+
+public record ClientConfig(TransportType transport, String command) implements CliConfig {
+    public ClientConfig {
+        if (transport != TransportType.STDIO) {
+            throw new IllegalArgumentException("only stdio supported");
+        }
+        if (command == null || command.isBlank()) {
+            throw new IllegalArgumentException("command required");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/ConfigLoader.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ConfigLoader.java
@@ -1,0 +1,66 @@
+package com.amannmalik.mcp.cli;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+public final class ConfigLoader {
+    private ConfigLoader() {}
+
+    public static CliConfig load(Path path) throws IOException {
+        String name = path.getFileName().toString().toLowerCase();
+        try (InputStream in = Files.newInputStream(path)) {
+            if (name.endsWith(".json")) {
+                JsonReader r = Json.createReader(in);
+                JsonObject obj = r.readObject();
+                return parseJson(obj);
+            }
+            if (name.endsWith(".yaml") || name.endsWith(".yml")) {
+                Load loader = new Load(LoadSettings.builder().build());
+                Object data = loader.loadFromInputStream(in);
+                if (!(data instanceof Map<?,?> map)) throw new IllegalArgumentException("invalid yaml");
+                return parseMap(map);
+            }
+        }
+        throw new IllegalArgumentException("Unsupported config: " + name);
+    }
+
+    private static CliConfig parseJson(JsonObject obj) {
+        String mode = obj.getString("mode");
+        String transport = obj.getString("transport", "stdio");
+        return switch (mode) {
+            case "server" -> new ServerConfig(parseTransport(transport), obj.getInt("port", 0));
+            case "client" -> new ClientConfig(parseTransport(transport), obj.getString("command"));
+            default -> throw new IllegalArgumentException("Invalid mode: " + mode);
+        };
+    }
+
+    private static CliConfig parseMap(Map<?,?> map) {
+        String mode = map.get("mode").toString();
+        Object tVal = map.get("transport");
+        String transport = tVal == null ? "stdio" : tVal.toString();
+        Object portVal = map.get("port");
+        Object cmdVal = map.get("command");
+        return switch (mode) {
+            case "server" -> new ServerConfig(parseTransport(transport), portVal == null ? 0 : ((Number) portVal).intValue());
+            case "client" -> new ClientConfig(parseTransport(transport), cmdVal.toString());
+            default -> throw new IllegalArgumentException("Invalid mode: " + mode);
+        };
+    }
+
+    private static TransportType parseTransport(String name) {
+        return switch (name) {
+            case "stdio" -> TransportType.STDIO;
+            case "http" -> TransportType.HTTP;
+            default -> throw new IllegalArgumentException("Unknown transport: " + name);
+        };
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -1,0 +1,57 @@
+package com.amannmalik.mcp.cli;
+
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.server.SimpleServer;
+import com.amannmalik.mcp.transport.HttpTransport;
+import com.amannmalik.mcp.transport.StdioTransport;
+import com.amannmalik.mcp.transport.Transport;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "server", description = "Run MCP server", mixinStandardHelpOptions = true)
+public final class ServerCommand implements Callable<Integer> {
+    @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
+    private Path config;
+
+    @CommandLine.Option(names = "--http", description = "HTTP port")
+    private Integer httpPort;
+
+    @CommandLine.Option(names = "--stdio", description = "Use stdio transport")
+    private boolean stdio;
+
+    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
+    private boolean verbose;
+
+    @Override
+    public Integer call() throws Exception {
+        ServerConfig cfg;
+        if (config != null) {
+            CliConfig loaded = ConfigLoader.load(config);
+            if (!(loaded instanceof ServerConfig sc)) throw new IllegalArgumentException("server config expected");
+            cfg = sc;
+        } else {
+            TransportType type = httpPort == null ? TransportType.STDIO : TransportType.HTTP;
+            int port = httpPort == null ? 0 : httpPort;
+            if (stdio) type = TransportType.STDIO;
+            cfg = new ServerConfig(type, port);
+        }
+
+        Transport t;
+        switch (cfg.transport()) {
+            case STDIO -> t = new StdioTransport(System.in, System.out);
+            case HTTP -> {
+                HttpTransport ht = new HttpTransport(cfg.port());
+                if (verbose) System.err.println("Listening on http://127.0.0.1:" + ht.port());
+                t = ht;
+            }
+            default -> throw new IllegalStateException();
+        }
+
+        try (McpServer server = new SimpleServer(t)) {
+            server.serve();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.cli;
+
+public record ServerConfig(TransportType transport, int port) implements CliConfig {
+    public ServerConfig {
+        if (transport == null) throw new IllegalArgumentException("transport");
+        if (transport == TransportType.HTTP && port <= 0) {
+            throw new IllegalArgumentException("port required for HTTP");
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/TransportType.java
+++ b/src/main/java/com/amannmalik/mcp/cli/TransportType.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.cli;
+
+public enum TransportType {
+    STDIO,
+    HTTP
+}

--- a/src/main/java/com/amannmalik/mcp/server/SimpleServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/SimpleServer.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.server;
+
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.transport.Transport;
+
+import java.util.EnumSet;
+
+public final class SimpleServer extends McpServer {
+    public SimpleServer(Transport transport) {
+        super(EnumSet.noneOf(ServerCapability.class), transport);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/cli/ConfigLoaderTest.java
+++ b/src/test/java/com/amannmalik/mcp/cli/ConfigLoaderTest.java
@@ -1,0 +1,32 @@
+package com.amannmalik.mcp.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigLoaderTest {
+    @Test
+    void jsonServer() throws Exception {
+        Path p = Files.createTempFile("cfg", ".json");
+        Files.writeString(p, "{\"mode\":\"server\",\"transport\":\"http\",\"port\":1234}");
+        CliConfig cfg = ConfigLoader.load(p);
+        assertTrue(cfg instanceof ServerConfig);
+        ServerConfig sc = (ServerConfig) cfg;
+        assertEquals(TransportType.HTTP, sc.transport());
+        assertEquals(1234, sc.port());
+    }
+
+    @Test
+    void yamlClient() throws Exception {
+        Path p = Files.createTempFile("cfg", ".yaml");
+        Files.writeString(p, "mode: client\ntransport: stdio\ncommand: echo");
+        CliConfig cfg = ConfigLoader.load(p);
+        assertTrue(cfg instanceof ClientConfig);
+        ClientConfig cc = (ClientConfig) cfg;
+        assertEquals(TransportType.STDIO, cc.transport());
+        assertEquals("echo", cc.command());
+    }
+}


### PR DESCRIPTION
## Summary
- add `snakeyaml` dependency
- implement `CliConfig` with JSON/YAML loader
- add `SimpleServer` base class
- provide `server` and `client` picocli commands
- wire commands into `Main`
- test config loader for JSON and YAML files

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6887719fda20832486e4741e16f32be0