### PR TITLE
Add reference server implementations

### DIFF
--- a/src/main/java/com/amannmalik/mcp/example/DatabaseServerExample.java
+++ b/src/main/java/com/amannmalik/mcp/example/DatabaseServerExample.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp.example;
+
+import com.amannmalik.mcp.server.tools.DatabaseToolProvider;
+import com.amannmalik.mcp.server.tools.ToolServer;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+
+import java.util.Map;
+
+/** Example database tool server using stdio. */
+public final class DatabaseServerExample {
+    public static void main(String[] args) throws Exception {
+        var rows = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder().add("name", "bob"))
+                .build();
+        try (ToolServer server = new ToolServer(new DatabaseToolProvider(Map.of("select *", rows)),
+                new StdioTransport(System.in, System.out))) {
+            server.serve();
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/example/FileServerExample.java
+++ b/src/main/java/com/amannmalik/mcp/example/FileServerExample.java
@@ -1,0 +1,18 @@
+package com.amannmalik.mcp.example;
+
+import com.amannmalik.mcp.server.resources.FileSystemResourceProvider;
+import com.amannmalik.mcp.server.resources.ResourceServer;
+import com.amannmalik.mcp.transport.StdioTransport;
+
+import java.nio.file.Paths;
+
+/** Example standalone file resource server using stdio. */
+public final class FileServerExample {
+    public static void main(String[] args) throws Exception {
+        try (ResourceServer server = new ResourceServer(
+                new FileSystemResourceProvider(Paths.get(args.length > 0 ? args[0] : ".")),
+                new StdioTransport(System.in, System.out))) {
+            server.serve();
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/example/WebApiServerExample.java
+++ b/src/main/java/com/amannmalik/mcp/example/WebApiServerExample.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.example;
+
+import com.amannmalik.mcp.server.tools.ToolServer;
+import com.amannmalik.mcp.server.tools.WebApiToolProvider;
+import com.amannmalik.mcp.transport.StdioTransport;
+
+/** Example web API tool server using stdio. */
+public final class WebApiServerExample {
+    public static void main(String[] args) throws Exception {
+        try (ToolServer server = new ToolServer(new WebApiToolProvider(),
+                new StdioTransport(System.in, System.out))) {
+            server.serve();
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/FileSystemResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/FileSystemResourceProvider.java
@@ -1,0 +1,73 @@
+package com.amannmalik.mcp.server.resources;
+
+import com.amannmalik.mcp.validation.UriValidator;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Simple ResourceProvider backed by the filesystem. */
+public final class FileSystemResourceProvider implements ResourceProvider {
+    private final Path root;
+
+    public FileSystemResourceProvider(Path root) {
+        this.root = root.toAbsolutePath().normalize();
+    }
+
+    @Override
+    public ResourceList list(String cursor) throws IOException {
+        List<Resource> list = new ArrayList<>();
+        Files.walk(root).filter(Files::isRegularFile).forEach(p -> {
+            String uri = p.toUri().toString();
+            String name = p.getFileName().toString();
+            String mime = probeMime(p);
+            long size;
+            try {
+                size = Files.size(p);
+            } catch (IOException e) {
+                size = -1;
+            }
+            Resource r = new Resource(uri, name, null, null, mime, size < 0 ? null : size, null);
+            list.add(r);
+        });
+        return new ResourceList(list, null);
+    }
+
+    @Override
+    public ResourceBlock read(String uri) throws IOException {
+        UriValidator.requireFileUri(uri);
+        Path p = Path.of(URI.create(uri));
+        p = root.resolve(root.relativize(p)).normalize();
+        if (!p.startsWith(root) || !Files.exists(p)) return null;
+        String name = p.getFileName().toString();
+        String mime = probeMime(p);
+        if (mime != null && mime.startsWith("text")) {
+            String text = Files.readString(p, StandardCharsets.UTF_8);
+            return new ResourceBlock.Text(uri, name, null, mime, text, null);
+        }
+        byte[] data = Files.readAllBytes(p);
+        return new ResourceBlock.Binary(uri, name, null, mime, data, null);
+    }
+
+    @Override
+    public List<ResourceTemplate> templates() {
+        return List.of();
+    }
+
+    @Override
+    public ResourceSubscription subscribe(String uri, ResourceListener listener) {
+        return () -> {};
+    }
+
+    private static String probeMime(Path p) {
+        try {
+            return Files.probeContentType(p);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceServer.java
@@ -1,0 +1,105 @@
+package com.amannmalik.mcp.server.resources;
+
+import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+/** McpServer extension that exposes resource operations. */
+public class ResourceServer extends McpServer {
+    private final ResourceProvider provider;
+
+    public ResourceServer(ResourceProvider provider, Transport transport) {
+        super(EnumSet.of(ServerCapability.RESOURCES), transport);
+        this.provider = provider;
+        registerRequestHandler("resources/list", this::listResources);
+        registerRequestHandler("resources/read", this::readResource);
+        registerRequestHandler("resources/templates/list", this::listTemplates);
+        registerRequestHandler("resources/subscribe", this::subscribe);
+    }
+
+    private JsonRpcMessage listResources(JsonRpcRequest req) {
+        String cursor = req.params() == null ? null : req.params().getString("cursor", null);
+        ResourceList list;
+        try {
+            list = provider.list(cursor);
+        } catch (IOException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (Resource r : list.resources()) arr.add(ResourcesCodec.toJsonObject(r));
+        var builder = Json.createObjectBuilder().add("resources", arr.build());
+        if (list.nextCursor() != null) builder.add("nextCursor", list.nextCursor());
+        return new JsonRpcResponse(req.id(), builder.build());
+    }
+
+    private JsonRpcMessage readResource(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        if (params == null || !params.containsKey("uri")) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "uri required", null));
+        }
+        String uri = params.getString("uri");
+        ResourceBlock block;
+        try {
+            block = provider.read(uri);
+        } catch (IOException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+        if (block == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "unknown resource", null));
+        }
+        JsonObject result = Json.createObjectBuilder()
+                .add("contents", Json.createArrayBuilder().add(ResourcesCodec.toJsonObject(block)).build())
+                .build();
+        return new JsonRpcResponse(req.id(), result);
+    }
+
+    private JsonRpcMessage listTemplates(JsonRpcRequest req) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        try {
+            for (ResourceTemplate t : provider.templates()) arr.add(ResourcesCodec.toJsonObject(t));
+        } catch (IOException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+        JsonObject result = Json.createObjectBuilder().add("resourceTemplates", arr.build()).build();
+        return new JsonRpcResponse(req.id(), result);
+    }
+
+    private JsonRpcMessage subscribe(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        if (params == null || !params.containsKey("uri")) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "uri required", null));
+        }
+        String uri = params.getString("uri");
+        try {
+            provider.subscribe(uri, update -> {
+                try {
+                    var b = Json.createObjectBuilder().add("uri", update.uri());
+                    if (update.title() != null) b.add("title", update.title());
+                    send(new JsonRpcNotification("notifications/resources/updated", b.build()));
+                } catch (IOException ignored) {}
+            });
+            return new JsonRpcResponse(req.id(), Json.createObjectBuilder().build());
+        } catch (IOException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+    }
+
+    /** Notify clients that the list of resources has changed. */
+    public void listChanged() throws IOException {
+        send(new JsonRpcNotification("notifications/resources/list_changed", null));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/DatabaseToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/DatabaseToolProvider.java
@@ -1,0 +1,43 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.validation.SchemaValidator;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+import java.util.List;
+import java.util.Map;
+
+/** Minimal ToolProvider that returns canned results for SQL queries. */
+public final class DatabaseToolProvider implements ToolProvider {
+    private final Tool tool;
+    private final Map<String, JsonArray> queries;
+
+    public DatabaseToolProvider(Map<String, JsonArray> queries) {
+        JsonObject schema = Json.createObjectBuilder()
+                .add("type", "object")
+                .add("properties", Json.createObjectBuilder().add("sql", Json.createObjectBuilder().add("type", "string")))
+                .add("required", Json.createArrayBuilder().add("sql"))
+                .build();
+        this.tool = new Tool("query", "Database Query", "Execute SQL", schema, null);
+        this.queries = Map.copyOf(queries);
+    }
+
+    @Override
+    public ToolPage list(String cursor) {
+        return new ToolPage(List.of(tool), null);
+    }
+
+    @Override
+    public ToolResult call(String name, JsonObject arguments) {
+        if (!tool.name().equals(name)) throw new IllegalArgumentException("Unknown tool");
+        SchemaValidator.validate(tool.inputSchema(), arguments);
+        String sql = arguments.getString("sql");
+        JsonArray rows = queries.get(sql);
+        if (rows == null) {
+            return new ToolResult(JsonValue.EMPTY_JSON_ARRAY, null, true);
+        }
+        return new ToolResult(rows, null, false);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/WebApiToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/WebApiToolProvider.java
@@ -1,0 +1,50 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.validation.SchemaValidator;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+/** Minimal ToolProvider performing HTTP GET requests. */
+public final class WebApiToolProvider implements ToolProvider {
+    private final Tool tool;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    public WebApiToolProvider() {
+        JsonObject schema = Json.createObjectBuilder()
+                .add("type", "object")
+                .add("properties", Json.createObjectBuilder().add("url", Json.createObjectBuilder().add("type", "string")))
+                .add("required", Json.createArrayBuilder().add("url"))
+                .build();
+        this.tool = new Tool("http_get", "HTTP GET", "Fetch URL", schema, null);
+    }
+
+    @Override
+    public ToolPage list(String cursor) {
+        return new ToolPage(List.of(tool), null);
+    }
+
+    @Override
+    public ToolResult call(String name, JsonObject arguments) {
+        if (!tool.name().equals(name)) throw new IllegalArgumentException("Unknown tool");
+        SchemaValidator.validate(tool.inputSchema(), arguments);
+        try {
+            HttpRequest req = HttpRequest.newBuilder(URI.create(arguments.getString("url"))).GET().build();
+            HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+            JsonArray content = Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder().add("type", "text").add("text", resp.body()).build())
+                    .build();
+            return new ToolResult(content, null, false);
+        } catch (IOException | InterruptedException e) {
+            return new ToolResult(JsonValue.EMPTY_JSON_ARRAY, null, true);
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/resources/FileSystemResourceProviderTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/resources/FileSystemResourceProviderTest.java
@@ -1,0 +1,24 @@
+package com.amannmalik.mcp.server.resources;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileSystemResourceProviderTest {
+    @Test
+    void listAndRead() throws Exception {
+        Path dir = Files.createTempDirectory("fsprov");
+        Path file = Files.writeString(dir.resolve("a.txt"), "hi");
+        FileSystemResourceProvider p = new FileSystemResourceProvider(dir);
+        ResourceList list = p.list(null);
+        assertEquals(1, list.resources().size());
+        Resource r = list.resources().getFirst();
+        assertEquals(file.toUri().toString(), r.uri());
+        ResourceBlock block = p.read(r.uri());
+        assertTrue(block instanceof ResourceBlock.Text);
+        assertEquals("hi", ((ResourceBlock.Text) block).text());
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/tools/DatabaseToolProviderTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/tools/DatabaseToolProviderTest.java
@@ -1,0 +1,23 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatabaseToolProviderTest {
+    @Test
+    void listAndCall() {
+        JsonArray rows = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder().add("name", "bob"))
+                .build();
+        DatabaseToolProvider p = new DatabaseToolProvider(Map.of("select *", rows));
+        ToolPage page = p.list(null);
+        assertEquals(1, page.tools().size());
+        ToolResult result = p.call("query", Json.createObjectBuilder().add("sql", "select *").build());
+        assertFalse(result.isError());
+        assertEquals(rows, result.content());
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/tools/WebApiToolProviderTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/tools/WebApiToolProviderTest.java
@@ -1,0 +1,45 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.sun.net.httpserver.HttpServer;
+import jakarta.json.Json;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WebApiToolProviderTest {
+    private HttpServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            byte[] data = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, data.length);
+            exchange.getResponseBody().write(data);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void listAndCall() {
+        WebApiToolProvider p = new WebApiToolProvider();
+        ToolPage page = p.list(null);
+        assertEquals(1, page.tools().size());
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        ToolResult result = p.call("http_get", Json.createObjectBuilder().add("url", url).build());
+        assertFalse(result.isError());
+        assertEquals("ok", result.content().getJsonObject(0).getString("text"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ResourceServer` with filesystem-backed provider
- add `FileSystemResourceProvider` for reading resources from disk
- add simple `DatabaseToolProvider` and `WebApiToolProvider`
- provide example servers using these providers
- test new providers

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688774a69dd88324b5ea2c08c6428f5b