### PR TITLE
Agent A: enforce jsonrpc version

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -50,6 +50,11 @@ public final class JsonRpcCodec {
     }
 
     public static JsonRpcMessage fromJsonObject(JsonObject obj) {
+        var version = obj.getString("jsonrpc", null);
+        if (!JsonRpc.VERSION.equals(version)) {
+            throw new IllegalArgumentException("Unsupported jsonrpc version: " + version);
+        }
+
         var idValue = obj.get("id");
         var method = obj.getString("method", null);
         var hasError = obj.containsKey("error");

--- a/src/test/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodecTest.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.jsonrpc;
 
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
@@ -22,5 +23,15 @@ class JsonRpcCodecTest {
         JsonObject json = JsonRpcCodec.toJsonObject(error);
         var parsed = JsonRpcCodec.fromJsonObject(json);
         assertEquals(error, parsed);
+    }
+
+    @Test
+    void rejectsUnsupportedVersion() {
+        var json = Json.createObjectBuilder()
+                .add("jsonrpc", "1.0")
+                .add("id", 1)
+                .add("method", "ping")
+                .build();
+        assertThrows(IllegalArgumentException.class, () -> JsonRpcCodec.fromJsonObject(json));
     }
 }


### PR DESCRIPTION
## Summary
- validate the `jsonrpc` version when decoding messages
- test invalid JSON-RPC version handling

## Testing
- `gradle test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68877cdce7e48324b172113ae6b4b26b