### PR TITLE
Implement tool safety measures

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/RateLimiter.java
+++ b/src/main/java/com/amannmalik/mcp/security/RateLimiter.java
@@ -1,0 +1,36 @@
+package com.amannmalik.mcp.security;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Simple fixed-window rate limiter. */
+public final class RateLimiter {
+    private final Map<String, Window> windows = new ConcurrentHashMap<>();
+    private final int limit;
+    private final long windowMs;
+
+    public RateLimiter(int limit, long windowMs) {
+        if (limit <= 0) throw new IllegalArgumentException("limit must be positive");
+        if (windowMs <= 0) throw new IllegalArgumentException("windowMs must be positive");
+        this.limit = limit;
+        this.windowMs = windowMs;
+    }
+
+    public void requireAllowance(String key) {
+        Window w = windows.computeIfAbsent(key, k -> new Window());
+        long now = System.currentTimeMillis();
+        synchronized (w) {
+            if (now - w.start >= windowMs) {
+                w.start = now;
+                w.count = 0;
+            }
+            if (w.count >= limit) throw new SecurityException("Rate limit exceeded: " + key);
+            w.count++;
+        }
+    }
+
+    private static final class Window {
+        long start;
+        int count;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -1,12 +1,34 @@
 package com.amannmalik.mcp.server.tools;
 
+import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
+import com.amannmalik.mcp.validation.InputSanitizer;
 
 /** Result of a tool invocation. */
-public record ToolResult(JsonArray content, JsonObject structuredContent, boolean isError) {
+public record ToolResult(JsonArray content,
+                         JsonObject structuredContent,
+                         boolean isError) {
     public ToolResult {
-        content = content == null ? JsonValue.EMPTY_JSON_ARRAY : content;
+        content = sanitize(content == null ? JsonValue.EMPTY_JSON_ARRAY : content);
+    }
+
+    private static JsonArray sanitize(JsonArray arr) {
+        JsonArrayBuilder b = Json.createArrayBuilder();
+        for (JsonValue v : arr) {
+            if (v.getValueType() == JsonValue.ValueType.OBJECT) {
+                JsonObject o = v.asJsonObject();
+                if ("text".equals(o.getString("type", null)) && o.containsKey("text")) {
+                    b.add(Json.createObjectBuilder(o)
+                            .add("text", InputSanitizer.requireClean(o.getString("text")))
+                            .build());
+                    continue;
+                }
+            }
+            b.add(v);
+        }
+        return b.build();
     }
 }

--- a/src/test/java/com/amannmalik/mcp/security/RateLimiterTest.java
+++ b/src/test/java/com/amannmalik/mcp/security/RateLimiterTest.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimiterTest {
+    @Test
+    void limitsWithinWindow() throws Exception {
+        RateLimiter r = new RateLimiter(1, 50);
+        assertDoesNotThrow(() -> r.requireAllowance("t"));
+        assertThrows(SecurityException.class, () -> r.requireAllowance("t"));
+        Thread.sleep(60);
+        assertDoesNotThrow(() -> r.requireAllowance("t"));
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/tools/ToolResultTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/tools/ToolResultTest.java
@@ -1,0 +1,25 @@
+package com.amannmalik.mcp.server.tools;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ToolResultTest {
+    @Test
+    void sanitizesText() {
+        JsonArray arr = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder().add("type", "text").add("text", "ok").build())
+                .build();
+        assertDoesNotThrow(() -> new ToolResult(arr, null, false));
+    }
+
+    @Test
+    void rejectsControlChars() {
+        JsonArray arr = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder().add("type", "text").add("text", "bad\u0001").build())
+                .build();
+        assertThrows(IllegalArgumentException.class, () -> new ToolResult(arr, null, false));
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/tools/ToolServerRateLimitTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/tools/ToolServerRateLimitTest.java
@@ -1,0 +1,106 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.security.RateLimiter;
+import com.amannmalik.mcp.transport.StdioTransport;
+import com.amannmalik.mcp.validation.SchemaValidator;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ToolServerRateLimitTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private ToolServer server;
+    private Thread serverThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        server = ToolServer.create(new EchoProvider(), serverTransport, new RateLimiter(1, 1000));
+        serverThread = new Thread(() -> {
+            try {
+                server.serve();
+            } catch (IOException ignored) {
+            }
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void rateLimitsCalls() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("client", "Client", "1"),
+                EnumSet.of(ClientCapability.EXPERIMENTAL),
+                clientTransport);
+        client.connect();
+        JsonObject args = Json.createObjectBuilder().add("message", "hi").build();
+        JsonRpcMessage first = client.request("tools/call", Json.createObjectBuilder()
+                .add("name", "echo")
+                .add("arguments", args)
+                .build());
+        assertTrue(first instanceof JsonRpcResponse);
+        JsonRpcMessage second = client.request("tools/call", Json.createObjectBuilder()
+                .add("name", "echo")
+                .add("arguments", args)
+                .build());
+        assertTrue(second instanceof JsonRpcError);
+        client.disconnect();
+    }
+
+    private static class EchoProvider implements ToolProvider {
+        private final Tool tool;
+
+        EchoProvider() {
+            JsonObject schema = Json.createObjectBuilder()
+                    .add("type", "object")
+                    .add("properties", Json.createObjectBuilder()
+                            .add("message", Json.createObjectBuilder().add("type", "string")))
+                    .add("required", Json.createArrayBuilder().add("message"))
+                    .build();
+            tool = new Tool("echo", "Echo", "Echo text", schema, null);
+        }
+
+        @Override
+        public ToolPage list(String cursor) {
+            return new ToolPage(java.util.List.of(tool), null);
+        }
+
+        @Override
+        public ToolResult call(String name, JsonObject arguments) {
+            if (!tool.name().equals(name)) throw new IllegalArgumentException("Unknown tool");
+            SchemaValidator.validate(tool.inputSchema(), arguments);
+            JsonArray content = Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder().add("type", "text").add("text", arguments.getString("message")).build())
+                    .build();
+            return new ToolResult(content, null, false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple fixed-window `RateLimiter`
- sanitize text results in `ToolResult`
- support optional rate limiting in `ToolServer`
- test rate limiter, sanitized results, and tool call throttling

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68877cf96d48832481d8ade563344a02