### PR TITLE
Add prompt content types and pagination

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -14,16 +14,16 @@ public final class InMemoryPromptProvider implements PromptProvider {
     }
 
     @Override
-    public List<Prompt> listPrompts() {
+    public PromptPage list(String cursor) {
         List<Prompt> list = new ArrayList<>();
         for (PromptTemplate t : templates.values()) {
             list.add(t.prompt());
         }
-        return list;
+        return new PromptPage(list, null);
     }
 
     @Override
-    public PromptInstance getPrompt(String name, Map<String, String> arguments) {
+    public PromptInstance get(String name, Map<String, String> arguments) {
         PromptTemplate tmpl = templates.get(name);
         if (tmpl == null) throw new IllegalArgumentException("unknown prompt: " + name);
         return tmpl.instantiate(arguments);

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
@@ -1,0 +1,45 @@
+package com.amannmalik.mcp.prompts;
+
+import com.amannmalik.mcp.server.resources.Resource;
+
+/** Supported content types for prompt messages. */
+public sealed interface PromptContent
+        permits PromptContent.Text, PromptContent.Image, PromptContent.Audio, PromptContent.ResourceContent {
+    String type();
+
+    /** Text content. */
+    record Text(String text) implements PromptContent {
+        public Text {
+            if (text == null) throw new IllegalArgumentException("text is required");
+        }
+        @Override public String type() { return "text"; }
+    }
+
+    /** Image content. */
+    record Image(byte[] data, String mimeType) implements PromptContent {
+        public Image {
+            if (data == null || mimeType == null) {
+                throw new IllegalArgumentException("data and mimeType are required");
+            }
+        }
+        @Override public String type() { return "image"; }
+    }
+
+    /** Audio content. */
+    record Audio(byte[] data, String mimeType) implements PromptContent {
+        public Audio {
+            if (data == null || mimeType == null) {
+                throw new IllegalArgumentException("data and mimeType are required");
+            }
+        }
+        @Override public String type() { return "audio"; }
+    }
+
+    /** Embedded resource content. */
+    record ResourceContent(Resource resource) implements PromptContent {
+        public ResourceContent {
+            if (resource == null) throw new IllegalArgumentException("resource is required");
+        }
+        @Override public String type() { return "resource"; }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptMessage.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptMessage.java
@@ -1,10 +1,10 @@
 package com.amannmalik.mcp.prompts;
 
-/** A single message in a prompt. Only text content is currently supported. */
-public record PromptMessage(Role role, String text) {
+/** A single message in a prompt. */
+public record PromptMessage(Role role, PromptContent content) {
     public PromptMessage {
-        if (role == null || text == null) {
-            throw new IllegalArgumentException("role and text are required");
+        if (role == null || content == null) {
+            throw new IllegalArgumentException("role and content are required");
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptMessageTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptMessageTemplate.java
@@ -1,10 +1,10 @@
 package com.amannmalik.mcp.prompts;
 
 /** Template for a single message in a prompt. */
-public record PromptMessageTemplate(Role role, String template) {
+public record PromptMessageTemplate(Role role, PromptContent content) {
     public PromptMessageTemplate {
-        if (role == null || template == null) {
-            throw new IllegalArgumentException("role and template are required");
+        if (role == null || content == null) {
+            throw new IllegalArgumentException("role and content are required");
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptPage.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptPage.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.List;
+
+/** Result of a prompt listing request. */
+public record PromptPage(List<Prompt> prompts, String nextCursor) {
+    public PromptPage {
+        prompts = prompts == null ? List.of() : List.copyOf(prompts);
+    }
+
+    @Override
+    public List<Prompt> prompts() {
+        return List.copyOf(prompts);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
@@ -1,11 +1,10 @@
 package com.amannmalik.mcp.prompts;
 
-import java.util.List;
 import java.util.Map;
 
 /** Mechanism for a server to expose prompts to clients. */
 public interface PromptProvider {
-    List<Prompt> listPrompts();
+    PromptPage list(String cursor);
 
-    PromptInstance getPrompt(String name, Map<String, String> arguments);
+    PromptInstance get(String name, Map<String, String> arguments);
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -16,9 +16,16 @@ public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages
     PromptInstance instantiate(Map<String, String> args) {
         List<PromptMessage> list = new ArrayList<>();
         for (PromptMessageTemplate t : messages) {
-            list.add(new PromptMessage(t.role(), substitute(t.template(), args)));
+            list.add(new PromptMessage(t.role(), instantiate(t.content(), args)));
         }
         return new PromptInstance(prompt.description(), list);
+    }
+
+    private static PromptContent instantiate(PromptContent tmpl, Map<String, String> args) {
+        return switch (tmpl) {
+            case PromptContent.Text t -> new PromptContent.Text(substitute(t.text(), args));
+            default -> tmpl;
+        };
     }
 
     private static String substitute(String template, Map<String, String> args) {

--- a/src/test/java/com/amannmalik/mcp/prompts/PromptCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/prompts/PromptCodecTest.java
@@ -1,0 +1,25 @@
+package com.amannmalik.mcp.prompts;
+
+import com.amannmalik.mcp.server.resources.Resource;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PromptCodecTest {
+    @Test
+    void instanceSerialization() {
+        Resource r = new Resource("file:///a.txt", "a.txt", "A", null, "text/plain", 5L, null);
+        PromptInstance inst = new PromptInstance("desc", List.of(
+                new PromptMessage(Role.USER, new PromptContent.Text("hi")),
+                new PromptMessage(Role.ASSISTANT, new PromptContent.ResourceContent(r))
+        ));
+        JsonObject json = PromptCodec.toJsonObject(inst);
+        assertEquals(2, json.getJsonArray("messages").size());
+        assertEquals("hi", json.getJsonArray("messages").getJsonObject(0).getJsonObject("content").getString("text"));
+        JsonObject resJson = json.getJsonArray("messages").getJsonObject(1).getJsonObject("content").getJsonObject("resource");
+        assertEquals("file:///a.txt", resJson.getString("uri"));
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/prompts/PromptServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/prompts/PromptServerTest.java
@@ -28,7 +28,7 @@ class PromptServerTest {
         );
         PromptTemplate tmpl = new PromptTemplate(
                 meta,
-                List.of(new PromptMessageTemplate(Role.USER, "Hello {name}!"))
+                List.of(new PromptMessageTemplate(Role.USER, new PromptContent.Text("Hello {name}!")))
         );
         provider.add(tmpl);
 


### PR DESCRIPTION
## Summary
- introduce `PromptContent` sealed interface for text, image, audio, and resource content
- return paginated results from `PromptProvider`
- update `PromptServer` and `PromptCodec` to handle new structures
- adjust in-memory provider and tests
- add `PromptCodecTest` for coverage

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68877cfcdde08324a84c262213b05956