### PR TITLE
Implement sampling server

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingServer.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingServer.java
@@ -1,0 +1,39 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.Transport;
+import jakarta.json.JsonObject;
+
+import java.util.EnumSet;
+
+/** McpServer extension providing sampling support. */
+public class SamplingServer extends McpServer {
+    private final SamplingProvider provider;
+
+    public SamplingServer(SamplingProvider provider, Transport transport) {
+        super(EnumSet.noneOf(ServerCapability.class), transport);
+        this.provider = provider;
+        registerRequestHandler("sampling/createMessage", this::createMessage);
+    }
+
+    private JsonRpcMessage createMessage(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        if (params == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing params", null));
+        }
+        try {
+            CreateMessageRequest cmr = SamplingCodec.toCreateMessageRequest(params);
+            CreateMessageResponse resp = provider.createMessage(cmr);
+            return new JsonRpcResponse(req.id(), SamplingCodec.toJsonObject(resp));
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        } catch (Exception e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/client/sampling/SamplingServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/sampling/SamplingServerTest.java
@@ -1,0 +1,89 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.prompts.Role;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SamplingServerTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private SamplingServer server;
+    private Thread serverThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        server = new SamplingServer(new EchoProvider(), serverTransport);
+        serverThread = new Thread(() -> {
+            try {
+                server.serve();
+            } catch (IOException ignored) {
+            }
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void createMessage() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("client", "Client", "1"),
+                EnumSet.of(ClientCapability.EXPERIMENTAL),
+                clientTransport);
+        client.connect();
+        CreateMessageRequest req = new CreateMessageRequest(
+                List.of(new SamplingMessage(Role.USER, new MessageContent.Text("hi"))),
+                null,
+                null,
+                null
+        );
+        JsonRpcMessage msg = client.request("sampling/createMessage", SamplingCodec.toJsonObject(req));
+        assertTrue(msg instanceof JsonRpcResponse);
+        JsonObject result = ((JsonRpcResponse) msg).result();
+        CreateMessageResponse resp = SamplingCodec.toCreateMessageResponse(result);
+        assertEquals("hi", ((MessageContent.Text) resp.content()).text());
+        client.disconnect();
+    }
+
+    private static class EchoProvider implements SamplingProvider {
+        @Override
+        public CreateMessageResponse createMessage(CreateMessageRequest request) {
+            SamplingMessage last = request.messages().isEmpty() ?
+                    new SamplingMessage(Role.USER, new MessageContent.Text("")) :
+                    request.messages().get(request.messages().size() - 1);
+            return new CreateMessageResponse(
+                    Role.ASSISTANT,
+                    new MessageContent.Text(((MessageContent.Text) last.content()).text()),
+                    null,
+                    "endTurn"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SamplingServer` to handle `sampling/createMessage`
- test sampling server with echo provider

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68877d0100d88324b812acad75c7c4f8