### PR TITLE
Implement blocking elicitation provider

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProvider.java
@@ -1,0 +1,24 @@
+package com.amannmalik.mcp.client.elicitation;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/** Simple in-memory provider that waits for a queued user response. */
+public final class BlockingElicitationProvider implements ElicitationProvider {
+    private final BlockingQueue<ElicitationResponse> responses = new LinkedBlockingQueue<>();
+
+    /** Queue a response to the next {@link #elicit(ElicitationRequest, long)} call. */
+    public void respond(ElicitationResponse response) {
+        if (response == null) throw new IllegalArgumentException("response is required");
+        responses.offer(response);
+    }
+
+    @Override
+    public ElicitationResponse elicit(ElicitationRequest request, long timeoutMillis) throws InterruptedException {
+        ElicitationResponse resp = timeoutMillis <= 0
+                ? responses.take()
+                : responses.poll(timeoutMillis, TimeUnit.MILLISECONDS);
+        return resp != null ? resp : new ElicitationResponse(ElicitationAction.CANCEL, null);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProviderTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProviderTest.java
@@ -1,0 +1,34 @@
+package com.amannmalik.mcp.client.elicitation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BlockingElicitationProviderTest {
+    @Test
+    void respondAndElicit() throws Exception {
+        BlockingElicitationProvider provider = new BlockingElicitationProvider();
+        JsonObject schema = Json.createObjectBuilder().add("type", "object").build();
+        ElicitationRequest req = new ElicitationRequest("msg", schema);
+
+        ElicitationResponse resp = new ElicitationResponse(ElicitationAction.ACCEPT,
+                Json.createObjectBuilder().add("a", 1).build());
+        provider.respond(resp);
+
+        ElicitationResponse result = provider.elicit(req, 10);
+        assertEquals(resp, result);
+    }
+
+    @Test
+    void timeoutReturnsCancel() throws Exception {
+        BlockingElicitationProvider provider = new BlockingElicitationProvider();
+        JsonObject schema = Json.createObjectBuilder().add("type", "object").build();
+        ElicitationRequest req = new ElicitationRequest("msg", schema);
+
+        ElicitationResponse result = provider.elicit(req, 1);
+        assertEquals(ElicitationAction.CANCEL, result.action());
+        assertNull(result.content());
+    }
+}


### PR DESCRIPTION
## Summary
- add `BlockingElicitationProvider` for queuing elicitation responses
- test the blocking provider including timeout behavior

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68877d090c988324a3c7f5a2b8b8542c