### PR TITLE
Add roots protocol message classes

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/ListRootsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/ListRootsRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.client.roots;
+
+/** Request asking the client for its current roots. */
+public record ListRootsRequest() {}

--- a/src/main/java/com/amannmalik/mcp/client/roots/ListRootsResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/ListRootsResponse.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.client.roots;
+
+import java.util.List;
+
+/** Response to a ListRootsRequest. */
+public record ListRootsResponse(List<Root> roots) {
+    public ListRootsResponse {
+        roots = roots == null || roots.isEmpty() ? List.of() : List.copyOf(roots);
+    }
+
+    @Override
+    public List<Root> roots() {
+        return List.copyOf(roots);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -12,6 +12,30 @@ import java.util.List;
 public final class RootsCodec {
     private RootsCodec() {}
 
+    public static JsonObject toJsonObject(ListRootsRequest req) {
+        return Json.createObjectBuilder().build();
+    }
+
+    public static ListRootsRequest toListRootsRequest(JsonObject obj) {
+        return new ListRootsRequest();
+    }
+
+    public static JsonObject toJsonObject(ListRootsResponse resp) {
+        return toJsonObject(resp.roots());
+    }
+
+    public static ListRootsResponse toListRootsResponse(JsonObject obj) {
+        return new ListRootsResponse(toRoots(obj));
+    }
+
+    public static JsonObject toJsonObject(RootsListChangedNotification n) {
+        return Json.createObjectBuilder().build();
+    }
+
+    public static RootsListChangedNotification toRootsListChangedNotification(JsonObject obj) {
+        return new RootsListChangedNotification();
+    }
+
     public static JsonObject toJsonObject(Root root) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("uri", root.uri());
         if (root.name() != null) b.add("name", root.name());

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsListChangedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsListChangedNotification.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.client.roots;
+
+/** Notification that the list of roots has changed. */
+public record RootsListChangedNotification() {}

--- a/src/test/java/com/amannmalik/mcp/client/roots/RootsCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/roots/RootsCodecTest.java
@@ -23,4 +23,25 @@ class RootsCodecTest {
         List<Root> parsed = RootsCodec.toRoots(json);
         assertEquals(list, parsed);
     }
+
+    @Test
+    void requestAndResponse() {
+        ListRootsRequest req = new ListRootsRequest();
+        JsonObject reqJson = RootsCodec.toJsonObject(req);
+        assertEquals(0, reqJson.size());
+        assertNotNull(RootsCodec.toListRootsRequest(reqJson));
+
+        ListRootsResponse resp = new ListRootsResponse(List.of(new Root("file:///x", "X")));
+        JsonObject respJson = RootsCodec.toJsonObject(resp);
+        ListRootsResponse parsed = RootsCodec.toListRootsResponse(respJson);
+        assertEquals(resp.roots(), parsed.roots());
+    }
+
+    @Test
+    void notificationRoundTrip() {
+        RootsListChangedNotification n = new RootsListChangedNotification();
+        JsonObject json = RootsCodec.toJsonObject(n);
+        assertEquals(0, json.size());
+        assertNotNull(RootsCodec.toRootsListChangedNotification(json));
+    }
 }


### PR DESCRIPTION
## Summary
- define `ListRootsRequest`, `ListRootsResponse` and `RootsListChangedNotification`
- expand `RootsCodec` for these message types
- test round‐trips for request, response and notification

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68877d051bd48324bdcd5b8539e4f3ab