### PR TITLE
Implement progress and cancellation tracking utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/CancellationTracker.java
+++ b/src/main/java/com/amannmalik/mcp/util/CancellationTracker.java
@@ -1,0 +1,43 @@
+package com.amannmalik.mcp.util;
+
+import com.amannmalik.mcp.jsonrpc.RequestId;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Tracks active requests and cancellations. */
+public final class CancellationTracker {
+    private final Set<RequestId> active = ConcurrentHashMap.newKeySet();
+    private final Map<RequestId, String> cancelled = new ConcurrentHashMap<>();
+
+    /** Registers a request id, throwing if already active. */
+    public void register(RequestId id) {
+        if (!active.add(id)) {
+            throw new IllegalArgumentException("Duplicate request: " + id);
+        }
+    }
+
+    /** Marks a request as cancelled. */
+    public void cancel(RequestId id, String reason) {
+        if (active.contains(id)) {
+            cancelled.put(id, reason);
+        }
+    }
+
+    /** Returns true if the request has been cancelled. */
+    public boolean isCancelled(RequestId id) {
+        return cancelled.containsKey(id);
+    }
+
+    /** Retrieves the cancellation reason or null. */
+    public String reason(RequestId id) {
+        return cancelled.get(id);
+    }
+
+    /** Releases a request once processing finishes. */
+    public void release(RequestId id) {
+        active.remove(id);
+        cancelled.remove(id);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/util/CancellationTrackerTest.java
+++ b/src/test/java/com/amannmalik/mcp/util/CancellationTrackerTest.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp.util;
+
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CancellationTrackerTest {
+    @Test
+    void cancelAndRelease() {
+        CancellationTracker tracker = new CancellationTracker();
+        RequestId id = new RequestId.NumericId(1);
+        tracker.register(id);
+        tracker.cancel(id, "stop");
+        assertTrue(tracker.isCancelled(id));
+        assertEquals("stop", tracker.reason(id));
+        tracker.release(id);
+        assertFalse(tracker.isCancelled(id));
+        assertDoesNotThrow(() -> tracker.register(id));
+    }
+}


### PR DESCRIPTION
## Summary
- add `CancellationTracker` for managing cancelled requests
- integrate progress and cancellation tracking within `McpServer`
- expose helper to send progress notifications
- test cancellation tracking

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68877d0dd8f88324aa73f4fabe42324d