### PR TITLE
Add ping monitor and logging server tests

### DIFF
--- a/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
@@ -1,0 +1,38 @@
+package com.amannmalik.mcp.ping;
+
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import jakarta.json.Json;
+
+import java.util.concurrent.*;
+
+/** Simple connectivity checker using ping requests. */
+public final class PingMonitor {
+    private PingMonitor() {}
+
+    /**
+     * Sends a ping request and waits for a response.
+     *
+     * @param client MCP client
+     * @param timeoutMillis maximum time to wait for a response
+     * @return {@code true} if a response was received within the timeout
+     */
+    public static boolean isAlive(SimpleMcpClient client, long timeoutMillis) {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        Future<JsonRpcMessage> future = exec.submit(() ->
+                client.request("ping", Json.createObjectBuilder().build())
+        );
+        try {
+            JsonRpcMessage msg = future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            return msg instanceof JsonRpcResponse;
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            return false;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            exec.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/ping/PingMonitorTest.java
+++ b/src/test/java/com/amannmalik/mcp/ping/PingMonitorTest.java
@@ -1,0 +1,67 @@
+package com.amannmalik.mcp.ping;
+
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.server.McpServer;
+import com.amannmalik.mcp.transport.StdioTransport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PingMonitorTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private TestServer server;
+    private Thread serverThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        server = new TestServer(serverTransport);
+        serverThread = new Thread(() -> {
+            try {
+                server.serve();
+            } catch (IOException ignored) {
+            }
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void aliveAndDead() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("client", "Client", "1"),
+                EnumSet.noneOf(com.amannmalik.mcp.lifecycle.ClientCapability.class),
+                clientTransport);
+        client.connect();
+        assertTrue(PingMonitor.isAlive(client, 100));
+        server.close();
+        serverThread.join();
+        assertFalse(PingMonitor.isAlive(client, 100));
+    }
+
+    private static class TestServer extends McpServer {
+        TestServer(StdioTransport transport) {
+            super(EnumSet.noneOf(com.amannmalik.mcp.lifecycle.ServerCapability.class), transport);
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/logging/LoggingServerTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/logging/LoggingServerTest.java
@@ -1,0 +1,60 @@
+package com.amannmalik.mcp.server.logging;
+
+import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggingServerTest {
+    @Test
+    void setLevelAndLog() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        StdioTransport transport = new StdioTransport(new ByteArrayInputStream(new byte[0]), out);
+        TestServer server = new TestServer(transport);
+
+        SetLevelRequest req = new SetLevelRequest(LoggingLevel.DEBUG);
+        JsonRpcRequest rpc = new JsonRpcRequest(new RequestId.NumericId(1), "logging/setLevel", LoggingCodec.toJsonObject(req));
+        server.handle(rpc);
+
+        JsonObject respJson = Json.createReader(new ByteArrayInputStream(out.toByteArray())).readObject();
+        JsonRpcResponse resp = (JsonRpcResponse) JsonRpcCodec.fromJsonObject(respJson);
+        assertEquals(new RequestId.NumericId(1), resp.id());
+        out.reset();
+
+        server.log(LoggingLevel.DEBUG, "test", JsonValue.TRUE);
+        JsonObject noteJson = Json.createReader(new ByteArrayInputStream(out.toByteArray())).readObject();
+        JsonRpcNotification note = (JsonRpcNotification) JsonRpcCodec.fromJsonObject(noteJson);
+        assertEquals("notifications/message", note.method());
+        LoggingNotification ln = LoggingCodec.toLoggingNotification(note.params());
+        assertEquals(LoggingLevel.DEBUG, ln.level());
+        assertEquals("test", ln.logger());
+        assertEquals(JsonValue.TRUE, ln.data());
+    }
+
+    @Test
+    void ignoresBelowMinLevel() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        StdioTransport transport = new StdioTransport(new ByteArrayInputStream(new byte[0]), out);
+        TestServer server = new TestServer(transport);
+
+        server.log(LoggingLevel.DEBUG, null, JsonValue.TRUE);
+        assertEquals(0, out.size());
+    }
+
+    private static class TestServer extends LoggingServer {
+        TestServer(StdioTransport transport) {
+            super(transport);
+        }
+        void handle(JsonRpcRequest req) throws IOException {
+            onRequest(req);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PingMonitor` util for checking connection health
- test `PingMonitor` with a running server
- test `LoggingServer` log emission and level filtering

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68877d11f224832480f29ef64e147666