### PR TITLE
Implement InMemoryCompletionProvider

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
@@ -1,0 +1,49 @@
+package com.amannmalik.mcp.server.completion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/** Simple CompletionProvider backed by in-memory entries. */
+public final class InMemoryCompletionProvider implements CompletionProvider {
+    private final List<Entry> entries = new CopyOnWriteArrayList<>();
+
+    public void add(CompleteRequest.Ref ref, String argumentName, Map<String, String> context, List<String> values) {
+        entries.add(new Entry(ref, argumentName, context == null ? Map.of() : Map.copyOf(context),
+                values == null ? List.of() : List.copyOf(values)));
+    }
+
+    @Override
+    public CompleteResult complete(CompleteRequest request) throws IOException {
+        List<String> matches = new ArrayList<>();
+        for (Entry e : entries) {
+            if (refEquals(e.ref, request.ref()) && e.argumentName.equals(request.argument().name())) {
+                if (request.context() == null || request.context().arguments().entrySet().containsAll(e.context.entrySet())) {
+                    matches.addAll(e.values);
+                }
+            }
+        }
+        String prefix = request.argument().value();
+        List<String> filtered = matches.stream()
+                .filter(v -> v.startsWith(prefix))
+                .limit(100)
+                .toList();
+        int total = (int) matches.stream().filter(v -> v.startsWith(prefix)).count();
+        boolean hasMore = total > filtered.size();
+        return new CompleteResult(new CompleteResult.Completion(filtered, total, hasMore));
+    }
+
+    private static boolean refEquals(CompleteRequest.Ref a, CompleteRequest.Ref b) {
+        if (a instanceof CompleteRequest.Ref.PromptRef pa && b instanceof CompleteRequest.Ref.PromptRef pb) {
+            return pa.name().equals(pb.name());
+        }
+        if (a instanceof CompleteRequest.Ref.ResourceRef ra && b instanceof CompleteRequest.Ref.ResourceRef rb) {
+            return ra.uri().equals(rb.uri());
+        }
+        return false;
+    }
+
+    private record Entry(CompleteRequest.Ref ref, String argumentName, Map<String, String> context, List<String> values) {}
+}

--- a/src/test/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProviderTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProviderTest.java
@@ -1,0 +1,26 @@
+package com.amannmalik.mcp.server.completion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryCompletionProviderTest {
+    @Test
+    void completesWithContext() throws Exception {
+        InMemoryCompletionProvider provider = new InMemoryCompletionProvider();
+        provider.add(new CompleteRequest.Ref.PromptRef("code"), "language", Map.of(), List.of("java", "python"));
+        provider.add(new CompleteRequest.Ref.PromptRef("code"), "framework", Map.of("language", "python"), List.of("flask"));
+        CompleteRequest req = new CompleteRequest(
+                new CompleteRequest.Ref.PromptRef("code"),
+                new CompleteRequest.Argument("framework", "f"),
+                new CompleteRequest.Context(Map.of("language", "python"))
+        );
+        CompleteResult result = provider.complete(req);
+        assertEquals(List.of("flask"), result.completion().values());
+        assertEquals(1, result.completion().total());
+        assertFalse(result.completion().hasMore());
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple in-memory implementation of `CompletionProvider`
- test context-aware completions

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68877d15789c8324b0c098b83a722066