### PR TITLE
Implement config-driven CLI execution

### DIFF
--- a/src/main/java/com/amannmalik/mcp/Main.java
+++ b/src/main/java/com/amannmalik/mcp/Main.java
@@ -1,15 +1,30 @@
 package com.amannmalik.mcp;
 
-import com.amannmalik.mcp.cli.ClientCommand;
-import com.amannmalik.mcp.cli.ServerCommand;
+import com.amannmalik.mcp.cli.*;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
+import java.nio.file.Path;
 
-@CommandLine.Command(name = "mcp", subcommands = {ServerCommand.class, ClientCommand.class}, mixinStandardHelpOptions = true)
+@CommandLine.Command(name = "mcp",
+        subcommands = {ServerCommand.class, ClientCommand.class},
+        mixinStandardHelpOptions = true)
 public final class Main implements Callable<Integer> {
+    @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
+    private Path config;
+
+    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
+    private boolean verbose;
+
     @Override
-    public Integer call() {
+    public Integer call() throws Exception {
+        if (config != null) {
+            CliConfig cfg = ConfigLoader.load(config);
+            return switch (cfg) {
+                case ServerConfig sc -> new ServerCommand(sc, verbose).call();
+                case ClientConfig cc -> new ClientCommand(cc, verbose).call();
+            };
+        }
         CommandLine.usage(this, System.out);
         return 0;
     }

--- a/src/main/java/com/amannmalik/mcp/cli/ClientCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ClientCommand.java
@@ -18,16 +18,27 @@ public final class ClientCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
     private Path config;
 
+    private ClientConfig resolved;
+
     @CommandLine.Option(names = "--command", description = "Server command for stdio")
     private String command;
 
     @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
     private boolean verbose;
 
+    public ClientCommand() {}
+
+    public ClientCommand(ClientConfig config, boolean verbose) {
+        this.resolved = config;
+        this.verbose = verbose;
+    }
+
     @Override
     public Integer call() throws Exception {
         ClientConfig cfg;
-        if (config != null) {
+        if (resolved != null) {
+            cfg = resolved;
+        } else if (config != null) {
             CliConfig loaded = ConfigLoader.load(config);
             if (!(loaded instanceof ClientConfig cc)) throw new IllegalArgumentException("client config expected");
             cfg = cc;

--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -15,6 +15,8 @@ public final class ServerCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
     private Path config;
 
+    private ServerConfig resolved;
+
     @CommandLine.Option(names = "--http", description = "HTTP port")
     private Integer httpPort;
 
@@ -24,10 +26,19 @@ public final class ServerCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
     private boolean verbose;
 
+    public ServerCommand() {}
+
+    public ServerCommand(ServerConfig config, boolean verbose) {
+        this.resolved = config;
+        this.verbose = verbose;
+    }
+
     @Override
     public Integer call() throws Exception {
         ServerConfig cfg;
-        if (config != null) {
+        if (resolved != null) {
+            cfg = resolved;
+        } else if (config != null) {
             CliConfig loaded = ConfigLoader.load(config);
             if (!(loaded instanceof ServerConfig sc)) throw new IllegalArgumentException("server config expected");
             cfg = sc;


### PR DESCRIPTION
## Summary
- support running the CLI directly from a config file
- refactor `ServerCommand` and `ClientCommand` to accept pre-parsed configs

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6887864c14a08324a14a74ae42373ed2