### PR TITLE
Add pagination codec and integrate cursor-based paging

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import com.amannmalik.mcp.util.Pagination;
 
 /** Simple PromptProvider backed by in-memory templates. */
 public final class InMemoryPromptProvider implements PromptProvider {
@@ -15,11 +16,12 @@ public final class InMemoryPromptProvider implements PromptProvider {
 
     @Override
     public PromptPage list(String cursor) {
-        List<Prompt> list = new ArrayList<>();
+        List<Prompt> all = new ArrayList<>();
         for (PromptTemplate t : templates.values()) {
-            list.add(t.prompt());
+            all.add(t.prompt());
         }
-        return new PromptPage(list, null);
+        Pagination.Page<Prompt> page = Pagination.page(all, cursor, 100);
+        return new PromptPage(page.items(), page.nextCursor());
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/FileSystemResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/FileSystemResourceProvider.java
@@ -13,6 +13,7 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.ArrayList;
 import java.util.List;
+import com.amannmalik.mcp.util.Pagination;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /** Simple ResourceProvider backed by the filesystem. */
@@ -25,7 +26,7 @@ public final class FileSystemResourceProvider implements ResourceProvider {
 
     @Override
     public ResourceList list(String cursor) throws IOException {
-        List<Resource> list = new ArrayList<>();
+        List<Resource> all = new ArrayList<>();
         Files.walk(root).filter(Files::isRegularFile).forEach(p -> {
             String uri = p.toUri().toString();
             String name = p.getFileName().toString();
@@ -37,9 +38,10 @@ public final class FileSystemResourceProvider implements ResourceProvider {
                 size = -1;
             }
             Resource r = new Resource(uri, name, null, null, mime, size < 0 ? null : size, null);
-            list.add(r);
+            all.add(r);
         });
-        return new ResourceList(list, null);
+        Pagination.Page<Resource> page = Pagination.page(all, cursor, 100);
+        return new ResourceList(page.items(), page.nextCursor());
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import com.amannmalik.mcp.util.Pagination;
 
 public final class InMemoryResourceProvider implements ResourceProvider {
     private final List<Resource> resources;
@@ -19,7 +20,8 @@ public final class InMemoryResourceProvider implements ResourceProvider {
 
     @Override
     public ResourceList list(String cursor) {
-        return new ResourceList(resources, null);
+        Pagination.Page<Resource> page = Pagination.page(resources, cursor, 100);
+        return new ResourceList(page.items(), page.nextCursor());
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/tools/DatabaseToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/DatabaseToolProvider.java
@@ -8,6 +8,7 @@ import jakarta.json.JsonValue;
 
 import java.util.List;
 import java.util.Map;
+import com.amannmalik.mcp.util.Pagination;
 
 /** Minimal ToolProvider that returns canned results for SQL queries. */
 public final class DatabaseToolProvider implements ToolProvider {
@@ -26,7 +27,8 @@ public final class DatabaseToolProvider implements ToolProvider {
 
     @Override
     public ToolPage list(String cursor) {
-        return new ToolPage(List.of(tool), null);
+        Pagination.Page<Tool> page = Pagination.page(List.of(tool), cursor, 100);
+        return new ToolPage(page.items(), page.nextCursor());
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/tools/WebApiToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/WebApiToolProvider.java
@@ -12,6 +12,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
+import com.amannmalik.mcp.util.Pagination;
 
 /** Minimal ToolProvider performing HTTP GET requests. */
 public final class WebApiToolProvider implements ToolProvider {
@@ -29,7 +30,8 @@ public final class WebApiToolProvider implements ToolProvider {
 
     @Override
     public ToolPage list(String cursor) {
-        return new ToolPage(List.of(tool), null);
+        Pagination.Page<Tool> page = Pagination.page(List.of(tool), cursor, 100);
+        return new ToolPage(page.items(), page.nextCursor());
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/util/PaginationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginationCodec.java
@@ -1,0 +1,32 @@
+package com.amannmalik.mcp.util;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/** JSON utilities for paginated request/response payloads. */
+public final class PaginationCodec {
+    private PaginationCodec() {}
+
+    public static JsonObject toJsonObject(PaginatedRequest req) {
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (req.cursor() != null) b.add("cursor", req.cursor());
+        return b.build();
+    }
+
+    public static PaginatedRequest toPaginatedRequest(JsonObject obj) {
+        String cursor = obj == null ? null : obj.getString("cursor", null);
+        return new PaginatedRequest(cursor);
+    }
+
+    public static JsonObject toJsonObject(PaginatedResult result) {
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (result.nextCursor() != null) b.add("nextCursor", result.nextCursor());
+        return b.build();
+    }
+
+    public static PaginatedResult toPaginatedResult(JsonObject obj) {
+        String cursor = obj == null ? null : obj.getString("nextCursor", null);
+        return new PaginatedResult(cursor);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/util/PaginationCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/util/PaginationCodecTest.java
@@ -1,0 +1,24 @@
+package com.amannmalik.mcp.util;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PaginationCodecTest {
+    @Test
+    void roundTripRequest() {
+        PaginatedRequest req = new PaginatedRequest("c1");
+        JsonObject json = PaginationCodec.toJsonObject(req);
+        PaginatedRequest parsed = PaginationCodec.toPaginatedRequest(json);
+        assertEquals(req, parsed);
+    }
+
+    @Test
+    void roundTripResult() {
+        PaginatedResult res = new PaginatedResult("c2");
+        JsonObject json = PaginationCodec.toJsonObject(res);
+        PaginatedResult parsed = PaginationCodec.toPaginatedResult(json);
+        assertEquals(res, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- support paginated request/response encoding via `PaginationCodec`
- add round-trip tests for pagination codec
- paginate in memory providers for prompts, resources and tools
- paginate filesystem resource listing

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6887869a0d8c83249f843d8e60579e15