### PR TITLE
Implement server security checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/PrivacyBoundaryEnforcer.java
+++ b/src/main/java/com/amannmalik/mcp/security/PrivacyBoundaryEnforcer.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Enforces audience-based privacy boundaries. */
-public final class PrivacyBoundaryEnforcer {
+public final class PrivacyBoundaryEnforcer implements ResourceAccessController {
     private final Map<String, Set<Audience>> permissions = new ConcurrentHashMap<>();
 
     public void allow(String principalId, Audience audience) {
@@ -23,6 +23,7 @@ public final class PrivacyBoundaryEnforcer {
         if (set != null) set.remove(audience);
     }
 
+    @Override
     public void requireAllowed(Principal principal, ResourceAnnotations ann) {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (ann == null || ann.audience().isEmpty()) return; // no restriction

--- a/src/main/java/com/amannmalik/mcp/security/ResourceAccessController.java
+++ b/src/main/java/com/amannmalik/mcp/security/ResourceAccessController.java
@@ -1,0 +1,11 @@
+package com.amannmalik.mcp.security;
+
+import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.server.resources.ResourceAnnotations;
+
+@FunctionalInterface
+public interface ResourceAccessController {
+    void requireAllowed(Principal principal, ResourceAnnotations annotations);
+
+    ResourceAccessController ALLOW_ALL = (p, a) -> {};
+}

--- a/src/main/java/com/amannmalik/mcp/security/ToolAccessController.java
+++ b/src/main/java/com/amannmalik/mcp/security/ToolAccessController.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Enforces which tools a principal may invoke. */
-public final class ToolAccessController {
+public final class ToolAccessController implements ToolAccessPolicy {
     private final Map<String, Set<String>> permissions = new ConcurrentHashMap<>();
 
     public void allow(String principalId, String tool) {
@@ -20,6 +20,7 @@ public final class ToolAccessController {
         if (set != null) set.remove(tool);
     }
 
+    @Override
     public void requireAllowed(Principal principal, String tool) {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (tool == null || tool.isBlank()) throw new IllegalArgumentException("tool required");

--- a/src/main/java/com/amannmalik/mcp/security/ToolAccessPolicy.java
+++ b/src/main/java/com/amannmalik/mcp/security/ToolAccessPolicy.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.security;
+
+import com.amannmalik.mcp.auth.Principal;
+
+@FunctionalInterface
+public interface ToolAccessPolicy {
+    void requireAllowed(Principal principal, String tool);
+
+    ToolAccessPolicy PERMISSIVE = (p, t) -> {};
+}

--- a/src/test/java/com/amannmalik/mcp/server/resources/ResourceServerAccessTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/resources/ResourceServerAccessTest.java
@@ -1,0 +1,82 @@
+package com.amannmalik.mcp.server.resources;
+
+import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.security.PrivacyBoundaryEnforcer;
+import com.amannmalik.mcp.transport.StdioTransport;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourceServerAccessTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private ResourceServer server;
+    private Thread serverThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Resource r1 = new Resource("file:///a.txt", "a.txt", null, null, "text/plain", null,
+                new ResourceAnnotations(Set.of(Audience.USER), null, Instant.now()));
+        Resource r2 = new Resource("file:///b.txt", "b.txt", null, null, "text/plain", null,
+                new ResourceAnnotations(Set.of(Audience.ASSISTANT), null, Instant.now()));
+        Map<String, ResourceBlock> contents = Map.of(
+                r1.uri(), new ResourceBlock.Text(r1.uri(), r1.name(), null, r1.mimeType(), "a", r1.annotations()),
+                r2.uri(), new ResourceBlock.Text(r2.uri(), r2.name(), null, r2.mimeType(), "b", r2.annotations())
+        );
+        InMemoryResourceProvider provider = new InMemoryResourceProvider(java.util.List.of(r1, r2), contents, java.util.List.of());
+        PrivacyBoundaryEnforcer enforcer = new PrivacyBoundaryEnforcer();
+        enforcer.allow("u", Audience.USER);
+
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        server = new ResourceServer(provider, serverTransport, enforcer, new Principal("u", Set.of()));
+        serverThread = new Thread(() -> {
+            try { server.serve(); } catch (IOException ignored) {}
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void enforcesAudience() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(new ClientInfo("c", "C", "1"),
+                EnumSet.of(ClientCapability.EXPERIMENTAL), clientTransport);
+        client.connect();
+        JsonRpcMessage listMsg = client.request("resources/list", Json.createObjectBuilder().build());
+        JsonArray resources = ((JsonRpcResponse) listMsg).result().getJsonArray("resources");
+        assertEquals(1, resources.size());
+
+        JsonRpcMessage err = client.request("resources/read", Json.createObjectBuilder().add("uri", "file:///b.txt").build());
+        assertTrue(err instanceof JsonRpcError);
+        client.disconnect();
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/server/tools/ToolServerAccessPolicyTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/tools/ToolServerAccessPolicyTest.java
@@ -1,0 +1,104 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.client.SimpleMcpClient;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.security.ToolAccessController;
+import com.amannmalik.mcp.transport.StdioTransport;
+import com.amannmalik.mcp.validation.SchemaValidator;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ToolServerAccessPolicyTest {
+    private StdioTransport clientTransport;
+    private StdioTransport serverTransport;
+    private ToolServer server;
+    private Thread serverThread;
+    private ToolAccessController controller;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
+        clientTransport = new StdioTransport(clientIn, clientOut);
+        serverTransport = new StdioTransport(serverIn, serverOut);
+        controller = new ToolAccessController();
+        controller.allow("u", "echo");
+        server = ToolServer.create(new EchoProvider(), serverTransport, new com.amannmalik.mcp.security.RateLimiter(Integer.MAX_VALUE,1), controller, new Principal("u", Set.of()));
+        serverThread = new Thread(() -> {
+            try {
+                server.serve();
+            } catch (IOException ignored) {}
+        });
+        serverThread.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clientTransport.close();
+        server.close();
+        serverThread.join();
+    }
+
+    @Test
+    void deniesUnauthorizedTool() throws Exception {
+        SimpleMcpClient client = new SimpleMcpClient(
+                new ClientInfo("client", "Client", "1"),
+                EnumSet.of(ClientCapability.EXPERIMENTAL),
+                clientTransport);
+        client.connect();
+        JsonObject args = Json.createObjectBuilder().add("message", "hi").build();
+        JsonRpcMessage msg = client.request("tools/call", Json.createObjectBuilder()
+                .add("name", "other")
+                .add("arguments", args)
+                .build());
+        assertTrue(msg instanceof JsonRpcError);
+        client.disconnect();
+    }
+
+    private static class EchoProvider implements ToolProvider {
+        private final Tool tool;
+
+        EchoProvider() {
+            JsonObject schema = Json.createObjectBuilder()
+                    .add("type", "object")
+                    .add("properties", Json.createObjectBuilder()
+                            .add("message", Json.createObjectBuilder().add("type", "string")))
+                    .add("required", Json.createArrayBuilder().add("message"))
+                    .build();
+            tool = new Tool("echo", "Echo", "Echo text", schema, null);
+        }
+
+        @Override
+        public ToolPage list(String cursor) {
+            return new ToolPage(java.util.List.of(tool), null);
+        }
+
+        @Override
+        public ToolResult call(String name, JsonObject arguments) {
+            if (!tool.name().equals(name)) throw new IllegalArgumentException("Unknown tool");
+            SchemaValidator.validate(tool.inputSchema(), arguments);
+            JsonArray content = Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder().add("type", "text").add("text", arguments.getString("message")).build())
+                    .build();
+            return new ToolResult(content, null, false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ResourceAccessController` and `ToolAccessPolicy`
- integrate privacy and tool access checks in `ResourceServer` and `ToolServer`
- adapt `PrivacyBoundaryEnforcer` and `ToolAccessController` to new interfaces
- add tests for access enforcement

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688786c04a3083249825a23403eb4f1e