### PR TITLE
Fix test toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ tasks.withType<JavaCompile>().configureEach {
 
 tasks.test {
     useJUnitPlatform()
+    javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
     finalizedBy(tasks.jacocoTestReport)
 }
 


### PR DESCRIPTION
## Summary
- ensure tests use the configured Java toolchain

## Testing
- `./verify.sh` *(fails: McpProtocolIntegrationTest ping timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6887fed8cd1483248690a26002d964c6