### PR TITLE
Fix MCP initialization handshake

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -17,10 +17,6 @@ public class ProtocolLifecycle {
     public InitializeResponse initialize(InitializeRequest request) {
         ensureState(LifecycleState.INIT);
 
-        if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
-            throw new UnsupportedProtocolVersionException(request.protocolVersion(), SUPPORTED_VERSION);
-        }
-
         Set<ClientCapability> requested = request.capabilities().client();
         clientCapabilities = requested.isEmpty() ? EnumSet.noneOf(ClientCapability.class) : EnumSet.copyOf(requested);
 


### PR DESCRIPTION
## Summary
- align version negotiation with MCP spec
- encode initialization messages without redundant `client`/`server` wrappers

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68882bf9d708832489baf9b3e7785995