### PR TITLE
Fix initialize cancellation handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -97,9 +97,12 @@ public abstract class McpServer implements AutoCloseable {
             progressTracker.register(token);
             progressTokens.put(req.id(), token);
         }
-        cancellationTracker.register(req.id());
+        boolean cancellable = !"initialize".equals(req.method());
+        if (cancellable) {
+            cancellationTracker.register(req.id());
+        }
         JsonRpcMessage resp = handler.handle(req);
-        if (!cancellationTracker.isCancelled(req.id()) && resp != null) {
+        if ((!cancellable || !cancellationTracker.isCancelled(req.id())) && resp != null) {
             send(resp);
         }
         cleanup(req.id());


### PR DESCRIPTION
## Summary
- ensure initialize request cannot be cancelled

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688836afa04083248f6d61d8ae8943d7