### PR TITLE
Add annotation support and priority validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -58,6 +58,9 @@ public final class PromptCodec {
 
     static JsonObject toJsonObject(PromptContent content) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("type", content.type());
+        if (content.annotations() != null) {
+            b.add("annotations", ResourcesCodec.toJsonObject(content.annotations()));
+        }
         switch (content) {
             case PromptContent.Text t -> b.add("text", t.text());
             case PromptContent.Image i -> b.add("data", Base64.getEncoder().encodeToString(i.data()))

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
@@ -1,14 +1,16 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.server.resources.Resource;
+import com.amannmalik.mcp.server.resources.ResourceAnnotations;
 
 /** Supported content types for prompt messages. */
 public sealed interface PromptContent
         permits PromptContent.Text, PromptContent.Image, PromptContent.Audio, PromptContent.ResourceContent {
     String type();
+    ResourceAnnotations annotations();
 
     /** Text content. */
-    record Text(String text) implements PromptContent {
+    record Text(String text, ResourceAnnotations annotations) implements PromptContent {
         public Text {
             if (text == null) throw new IllegalArgumentException("text is required");
         }
@@ -16,7 +18,7 @@ public sealed interface PromptContent
     }
 
     /** Image content. */
-    record Image(byte[] data, String mimeType) implements PromptContent {
+    record Image(byte[] data, String mimeType, ResourceAnnotations annotations) implements PromptContent {
         public Image {
             if (data == null || mimeType == null) {
                 throw new IllegalArgumentException("data and mimeType are required");
@@ -26,7 +28,7 @@ public sealed interface PromptContent
     }
 
     /** Audio content. */
-    record Audio(byte[] data, String mimeType) implements PromptContent {
+    record Audio(byte[] data, String mimeType, ResourceAnnotations annotations) implements PromptContent {
         public Audio {
             if (data == null || mimeType == null) {
                 throw new IllegalArgumentException("data and mimeType are required");
@@ -36,7 +38,7 @@ public sealed interface PromptContent
     }
 
     /** Embedded resource content. */
-    record ResourceContent(Resource resource) implements PromptContent {
+    record ResourceContent(Resource resource, ResourceAnnotations annotations) implements PromptContent {
         public ResourceContent {
             if (resource == null) throw new IllegalArgumentException("resource is required");
         }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -23,8 +23,10 @@ public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages
 
     private static PromptContent instantiate(PromptContent tmpl, Map<String, String> args) {
         return switch (tmpl) {
-            case PromptContent.Text t -> new PromptContent.Text(substitute(t.text(), args));
-            default -> tmpl;
+            case PromptContent.Text t -> new PromptContent.Text(substitute(t.text(), args), t.annotations());
+            case PromptContent.Image i -> new PromptContent.Image(i.data(), i.mimeType(), i.annotations());
+            case PromptContent.Audio a -> new PromptContent.Audio(a.data(), a.mimeType(), a.annotations());
+            case PromptContent.ResourceContent r -> new PromptContent.ResourceContent(r.resource(), r.annotations());
         };
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceAnnotations.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceAnnotations.java
@@ -7,6 +7,9 @@ import java.util.Set;
 public record ResourceAnnotations(Set<Audience> audience, Double priority, Instant lastModified) {
     public ResourceAnnotations {
         audience = audience == null || audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience);
+        if (priority != null && (priority < 0.0 || priority > 1.0)) {
+            throw new IllegalArgumentException("priority must be between 0.0 and 1.0");
+        }
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -88,7 +88,7 @@ public final class ResourcesCodec {
         throw new IllegalArgumentException("unknown content block");
     }
 
-    private static JsonObject toJsonObject(ResourceAnnotations ann) {
+    public static JsonObject toJsonObject(ResourceAnnotations ann) {
         JsonObjectBuilder b = Json.createObjectBuilder();
         if (!ann.audience().isEmpty()) {
             var arr = Json.createArrayBuilder();

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolAnnotations.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolAnnotations.java
@@ -10,6 +10,9 @@ import java.util.Set;
 public record ToolAnnotations(Set<Audience> audience, Double priority, Instant lastModified) {
     public ToolAnnotations {
         audience = audience == null || audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience);
+        if (priority != null && (priority < 0.0 || priority > 1.0)) {
+            throw new IllegalArgumentException("priority must be between 0.0 and 1.0");
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- validate priority ranges for resource and tool annotations
- expose annotations on prompt content blocks
- propagate annotations when instantiating prompts
- include annotations in prompt JSON
- allow external access to ResourcesCodec annotation helper

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688836afa04083248f6d61d8ae8943d7