### PR TITLE
Implement monotonic progress validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -171,9 +171,7 @@ public abstract class McpServer implements AutoCloseable {
     }
 
     protected final void sendProgress(ProgressNotification note) throws IOException {
-        if (!progressTracker.isActive(note.token())) {
-            throw new IllegalStateException("Unknown progress token: " + note.token());
-        }
+        progressTracker.update(note);
         send(new JsonRpcNotification("notifications/progress", ProgressCodec.toJsonObject(note)));
     }
 

--- a/src/main/java/com/amannmalik/mcp/util/ProgressTracker.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressTracker.java
@@ -1,26 +1,45 @@
 package com.amannmalik.mcp.util;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Tracks active progress tokens to ensure uniqueness. */
 public final class ProgressTracker {
     private final Set<ProgressToken> active = ConcurrentHashMap.newKeySet();
+    private final Map<ProgressToken, Double> progress = new ConcurrentHashMap<>();
 
     /** Registers a token, throwing if already active. */
     public void register(ProgressToken token) {
         if (!active.add(token)) {
             throw new IllegalArgumentException("Duplicate token: " + token);
         }
+        progress.put(token, Double.NEGATIVE_INFINITY);
     }
 
     /** Releases a token once the request completes. */
     public void release(ProgressToken token) {
         active.remove(token);
+        progress.remove(token);
     }
 
     /** Returns true if the token is currently registered. */
     public boolean isActive(ProgressToken token) {
         return active.contains(token);
+    }
+
+    /**
+     * Records progress for the given token, ensuring it increases.
+     */
+    public void update(ProgressNotification note) {
+        ProgressToken token = note.token();
+        if (!active.contains(token)) {
+            throw new IllegalStateException("Unknown progress token: " + token);
+        }
+        double prev = progress.get(token);
+        if (note.progress() <= prev) {
+            throw new IllegalArgumentException("progress must increase");
+        }
+        progress.put(token, note.progress());
     }
 }

--- a/src/test/java/com/amannmalik/mcp/util/ProgressTrackerTest.java
+++ b/src/test/java/com/amannmalik/mcp/util/ProgressTrackerTest.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProgressTrackerTest {
+    @Test
+    void progressMustIncrease() {
+        ProgressTracker tracker = new ProgressTracker();
+        ProgressToken token = new ProgressToken.StringToken("t");
+        tracker.register(token);
+        tracker.update(new ProgressNotification(token, 0.1, 1.0, null));
+        assertThrows(IllegalArgumentException.class, () ->
+                tracker.update(new ProgressNotification(token, 0.05, 1.0, null)));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce monotonic progress values via `ProgressTracker`
- validate progress in `McpServer.sendProgress`
- add unit test for progress tracking

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888d53fb4e88324aba7511bd2525a24