### PR TITLE
Fix initialization of RootsServer

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsServer.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsServer.java
@@ -22,7 +22,12 @@ public class RootsServer extends McpServer {
     public RootsServer(RootsProvider provider, Transport transport) {
         super(EnumSet.noneOf(ServerCapability.class), transport);
         this.provider = provider;
-        registerRequestHandler("roots/list", this::listRoots);
+    }
+
+    public static RootsServer create(RootsProvider provider, Transport transport) {
+        RootsServer server = new RootsServer(provider, transport);
+        server.registerRequestHandler("roots/list", server::listRoots);
+        return server;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- create a factory method for `RootsServer` to avoid `this` escape

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888d53fb4e88324aba7511bd2525a24