### PR TITLE
Improve JSON-RPC compliance

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -46,6 +46,7 @@ public final class JsonRpcCodec {
         switch (id) {
             case RequestId.StringId s -> builder.add("id", s.value());
             case RequestId.NumericId n -> builder.add("id", n.value());
+            case RequestId.NullId __ -> builder.addNull("id");
         }
     }
 
@@ -84,6 +85,9 @@ public final class JsonRpcCodec {
     }
 
     private static RequestId toId(JsonValue value) {
+        if (value == null || value.getValueType() == JsonValue.ValueType.NULL) {
+            return RequestId.NullId.INSTANCE;
+        }
         return switch (value.getValueType()) {
             case NUMBER -> new RequestId.NumericId(((JsonNumber) value).longValue());
             case STRING -> new RequestId.StringId(((JsonString) value).getString());

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcRequest.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcRequest.java
@@ -5,7 +5,7 @@ import jakarta.json.JsonObject;
 /** A JSON-RPC request expecting a response. */
 public record JsonRpcRequest(RequestId id, String method, JsonObject params) implements JsonRpcMessage {
     public JsonRpcRequest {
-        if (id == null || method == null) {
+        if (id == null || method == null || id instanceof RequestId.NullId) {
             throw new IllegalArgumentException("id and method are required");
         }
     }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -1,7 +1,8 @@
 package com.amannmalik.mcp.jsonrpc;
 
 /** Identifier for a JSON-RPC request. */
-public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId {
+public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId, RequestId.NullId {
     record StringId(String value) implements RequestId {}
     record NumericId(long value) implements RequestId {}
+    enum NullId implements RequestId { INSTANCE }
 }

--- a/src/main/java/com/amannmalik/mcp/util/CancellationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/CancellationCodec.java
@@ -17,6 +17,7 @@ public final class CancellationCodec {
         switch (note.requestId()) {
             case RequestId.StringId s -> b.add("requestId", s.value());
             case RequestId.NumericId n -> b.add("requestId", n.value());
+            default -> throw new IllegalArgumentException("Invalid requestId type");
         }
         if (note.reason() != null) b.add("reason", note.reason());
         return b.build();
@@ -29,6 +30,9 @@ public final class CancellationCodec {
     }
 
     private static RequestId toId(JsonValue v) {
+        if (v == null || v.getValueType() == JsonValue.ValueType.NULL) {
+            throw new IllegalArgumentException("requestId is required");
+        }
         return switch (v.getValueType()) {
             case STRING -> new RequestId.StringId(((JsonString) v).getString());
             case NUMBER -> new RequestId.NumericId(((JsonNumber) v).longValue());


### PR DESCRIPTION
## Summary
- add `NullId` sentinel for handling `null` JSON-RPC IDs
- validate request IDs and respond to malformed messages
- reject cancellation notifications with invalid IDs

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888de6bf2b4832496042f28d34cc027