### PR TITLE
Fix protocol version validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -17,6 +17,11 @@ public class ProtocolLifecycle {
     public InitializeResponse initialize(InitializeRequest request) {
         ensureState(LifecycleState.INIT);
 
+        if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
+            throw new UnsupportedProtocolVersionException(
+                request.protocolVersion(), SUPPORTED_VERSION);
+        }
+
         Set<ClientCapability> requested = request.capabilities().client();
         clientCapabilities = requested.isEmpty() ? EnumSet.noneOf(ClientCapability.class) : EnumSet.copyOf(requested);
 

--- a/src/test/java/com/amannmalik/mcp/McpProtocolIntegrationTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpProtocolIntegrationTest.java
@@ -1,8 +1,7 @@
 package com.amannmalik.mcp;
 
 import com.amannmalik.mcp.client.DefaultMcpClient;
-import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
-import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
+import com.amannmalik.mcp.jsonrpc.*;
 import com.amannmalik.mcp.lifecycle.ClientCapability;
 import com.amannmalik.mcp.lifecycle.ClientInfo;
 import com.amannmalik.mcp.transport.StdioTransport;
@@ -55,6 +54,39 @@ class McpProtocolIntegrationTest {
     void cleanup() {
         if (executor != null) {
             executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testProtocolVersionMismatch() throws Exception {
+        ProcessBuilder builder = new ProcessBuilder(
+                JAVA_BIN, "-cp", System.getProperty("java.class.path"),
+                "com.amannmalik.mcp.Main", "server", "--stdio"
+        );
+        Process process = builder.start();
+        try (StdioTransport t = new StdioTransport(process.getInputStream(), process.getOutputStream())) {
+            var init = Json.createObjectBuilder()
+                    .add("protocolVersion", "0")
+                    .add("capabilities", Json.createObjectBuilder().build())
+                    .add("clientInfo", Json.createObjectBuilder()
+                            .add("name", "test")
+                            .add("title", "Test")
+                            .add("version", "0")
+                            .build())
+                    .build();
+            var req = new com.amannmalik.mcp.jsonrpc.JsonRpcRequest(
+                    new com.amannmalik.mcp.jsonrpc.RequestId.NumericId(1),
+                    "initialize", init);
+            t.send(com.amannmalik.mcp.jsonrpc.JsonRpcCodec.toJsonObject(req));
+            var msg = com.amannmalik.mcp.jsonrpc.JsonRpcCodec.fromJsonObject(t.receive());
+            assertTrue(msg instanceof com.amannmalik.mcp.jsonrpc.JsonRpcError);
+            var err = (com.amannmalik.mcp.jsonrpc.JsonRpcError) msg;
+            assertEquals(com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode.INVALID_PARAMS.code(), err.error().code());
+        } finally {
+            if (process.isAlive()) {
+                process.destroyForcibly();
+                process.waitFor(2, TimeUnit.SECONDS);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- enforce protocol version check when initializing the server
- surface an error if the version doesn't match
- test version mismatch handling

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888e0f6f8b8832498d14ccd8a388e5e