### PR TITLE
Fix pagination errors and annotation parsing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptServer.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptServer.java
@@ -36,7 +36,13 @@ public class PromptServer extends McpServer {
 
     private JsonRpcMessage listPrompts(JsonRpcRequest req) {
         String cursor = req.params() == null ? null : req.params().getString("cursor", null);
-        PromptPage page = provider.list(cursor);
+        PromptPage page;
+        try {
+            page = provider.list(cursor);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
         var arr = Json.createArrayBuilder();
         for (Prompt p : page.prompts()) arr.add(PromptCodec.toJsonObject(p));
         JsonObjectBuilder builder = Json.createObjectBuilder().add("prompts", arr.build());

--- a/src/main/java/com/amannmalik/mcp/server/DefaultMcpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/DefaultMcpServer.java
@@ -71,6 +71,9 @@ public final class DefaultMcpServer extends McpServer {
         ResourceList list;
         try {
             list = resources.list(cursor);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
         } catch (IOException e) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
@@ -126,7 +129,13 @@ public final class DefaultMcpServer extends McpServer {
 
     private JsonRpcMessage listTools(JsonRpcRequest req) {
         String cursor = req.params() == null ? null : req.params().getString("cursor", null);
-        ToolPage page = tools.list(cursor);
+        ToolPage page;
+        try {
+            page = tools.list(cursor);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
         JsonObject result = ToolCodec.toJsonObject(page);
         return new JsonRpcResponse(req.id(), result);
     }
@@ -156,7 +165,13 @@ public final class DefaultMcpServer extends McpServer {
 
     private JsonRpcMessage listPrompts(JsonRpcRequest req) {
         String cursor = req.params() == null ? null : req.params().getString("cursor", null);
-        PromptPage page = prompts.list(cursor);
+        PromptPage page;
+        try {
+            page = prompts.list(cursor);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
         var arr = Json.createArrayBuilder();
         for (Prompt p : page.prompts()) arr.add(PromptCodec.toJsonObject(p));
         JsonObjectBuilder builder = Json.createObjectBuilder().add("prompts", arr.build());

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceServer.java
@@ -52,6 +52,9 @@ public class ResourceServer extends McpServer {
         ResourceList list;
         try {
             list = provider.list(cursor);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
         } catch (IOException e) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -104,7 +104,8 @@ public final class ResourcesCodec {
         Set<Audience> audience = EnumSet.noneOf(Audience.class);
         var audienceArr = obj.getJsonArray("audience");
         if (audienceArr != null) {
-            audienceArr.forEach(v -> audience.add(Audience.valueOf(v.toString().replace("\"", "").toUpperCase())));
+            audienceArr.getValuesAs(jakarta.json.JsonString.class)
+                    .forEach(js -> audience.add(Audience.valueOf(js.getString().toUpperCase())));
         }
         Double priority = obj.containsKey("priority") ? obj.getJsonNumber("priority").doubleValue() : null;
         Instant lastModified = obj.containsKey("lastModified") ? Instant.parse(obj.getString("lastModified")) : null;

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolServer.java
@@ -47,7 +47,13 @@ public class ToolServer extends McpServer {
 
     private JsonRpcMessage listTools(JsonRpcRequest req) {
         String cursor = req.params() == null ? null : req.params().getString("cursor", null);
-        ToolPage page = provider.list(cursor);
+        ToolPage page;
+        try {
+            page = provider.list(cursor);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
         JsonObject result = ToolCodec.toJsonObject(page);
         return new JsonRpcResponse(req.id(), result);
     }


### PR DESCRIPTION
## Summary
- map pagination cursor errors to INVALID_PARAMS
- sanitize audience annotations using JsonString

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888e0f6f8b8832498d14ccd8a388e5e