### PR TITLE
Validate _meta key names

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -170,6 +170,7 @@ public abstract class McpServer implements AutoCloseable {
     private ProgressToken parseProgressToken(JsonObject params) {
         if (params == null || !params.containsKey("_meta")) return null;
         JsonObject meta = params.getJsonObject("_meta");
+        com.amannmalik.mcp.validation.MetaValidator.requireValid(meta);
         if (!meta.containsKey("progressToken")) return null;
         var val = meta.get("progressToken");
         return switch (val.getValueType()) {

--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -1,0 +1,39 @@
+package com.amannmalik.mcp.validation;
+
+import jakarta.json.JsonObject;
+
+import java.util.regex.Pattern;
+
+/** Validates _meta key names. */
+public final class MetaValidator {
+    private MetaValidator() {}
+
+    private static final Pattern LABEL =
+            Pattern.compile("[A-Za-z](?:[A-Za-z0-9-]*[A-Za-z0-9])?");
+    private static final Pattern NAME =
+            Pattern.compile("(?:[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)?");
+
+    public static void requireValid(String key) {
+        if (key == null) throw new IllegalArgumentException("key required");
+        int slash = key.indexOf('/');
+        String prefix = slash >= 0 ? key.substring(0, slash) : null;
+        String name = slash >= 0 ? key.substring(slash + 1) : key;
+
+        if (prefix != null && !prefix.isEmpty()) {
+            for (String label : prefix.split("\\.")) {
+                if (!LABEL.matcher(label).matches()) {
+                    throw new IllegalArgumentException("Invalid _meta prefix: " + key);
+                }
+            }
+        }
+
+        if (!NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Invalid _meta name: " + key);
+        }
+    }
+
+    public static void requireValid(JsonObject obj) {
+        if (obj == null) return;
+        for (String key : obj.keySet()) requireValid(key);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce allowed `_meta` key format
- validate `_meta` object in request handling

## Testing
- `gradle test`
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_6888e48a9bf4832497d8a1b88bdca1bf