### PR TITLE
Fix Origin header validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/OriginValidator.java
+++ b/src/main/java/com/amannmalik/mcp/security/OriginValidator.java
@@ -2,7 +2,10 @@ package com.amannmalik.mcp.security;
 
 import java.util.Set;
 
-/** Validates HTTP Origin headers. */
+/**
+ * Validates the HTTP {@code Origin} header according to the allowed origin list.
+ * The header MUST be present and match one of the configured origins.
+ */
 public final class OriginValidator {
     private final Set<String> allowedOrigins;
 
@@ -14,7 +17,9 @@ public final class OriginValidator {
     }
 
     public boolean isValid(String origin) {
-        if (origin == null || origin.isBlank()) return true;
+        if (origin == null || origin.isBlank()) {
+            return false;
+        }
         return allowedOrigins.contains(origin);
     }
 

--- a/src/test/java/com/amannmalik/mcp/security/OriginValidatorTest.java
+++ b/src/test/java/com/amannmalik/mcp/security/OriginValidatorTest.java
@@ -1,0 +1,23 @@
+package com.amannmalik.mcp.security;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+class OriginValidatorTest {
+    @Test
+    void testValidatesOriginHeaderPresence() {
+        OriginValidator validator = new OriginValidator(Set.of("http://localhost"));
+        assertFalse(validator.isValid(null));
+        assertFalse(validator.isValid(""));
+        assertTrue(validator.isValid("http://localhost"));
+        assertFalse(validator.isValid("http://evil.com"));
+    }
+
+    @Test
+    void testRequireValidThrows() {
+        OriginValidator validator = new OriginValidator(Set.of("http://localhost"));
+        assertThrows(SecurityException.class, () -> validator.requireValid("http://evil.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce `Origin` header presence in `OriginValidator`
- add OriginValidator unit tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888e48a9bf4832497d8a1b88bdca1bf