### PR TITLE
Fix Accept header checks for HTTP transport

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -119,6 +119,11 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             }
+            String accept = req.getHeader("Accept");
+            if (accept == null || !(accept.contains("application/json") && accept.contains("text/event-stream"))) {
+                resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                return;
+            }
 
             String session = sessionId.get();
             String header = req.getHeader("Mcp-Session-Id");
@@ -194,6 +199,11 @@ public final class StreamableHttpTransport implements Transport {
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             if (!originValidator.isValid(req.getHeader("Origin"))) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
+            String accept = req.getHeader("Accept");
+            if (accept == null || !accept.contains("text/event-stream")) {
+                resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
                 return;
             }
             String session = sessionId.get();


### PR DESCRIPTION
## Summary
- enforce Accept headers for StreamableHttpTransport POST and GET

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6888e98bfa7883248ddd6ac63d12d79e