### PR TITLE
Implement pagination for resource templates

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/FileSystemResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/FileSystemResourceProvider.java
@@ -61,8 +61,8 @@ public final class FileSystemResourceProvider implements ResourceProvider {
     }
 
     @Override
-    public List<ResourceTemplate> templates() {
-        return List.of();
+    public ResourceTemplatePage listTemplates(String cursor) {
+        return new ResourceTemplatePage(List.of(), null);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -30,8 +30,9 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     @Override
-    public List<ResourceTemplate> templates() {
-        return templates;
+    public ResourceTemplatePage listTemplates(String cursor) {
+        Pagination.Page<ResourceTemplate> page = Pagination.page(templates, cursor, 100);
+        return new ResourceTemplatePage(page.items(), page.nextCursor());
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface ResourceProvider extends AutoCloseable {
     ResourceList list(String cursor) throws IOException;
     ResourceBlock read(String uri) throws IOException;
-    List<ResourceTemplate> templates() throws IOException;
+    ResourceTemplatePage listTemplates(String cursor) throws IOException;
     ResourceSubscription subscribe(String uri, ResourceListener listener) throws IOException;
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplatePage.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplatePage.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.server.resources;
+
+import java.util.List;
+
+/** Result of a resource template listing request. */
+public record ResourceTemplatePage(List<ResourceTemplate> resourceTemplates, String nextCursor) {
+    public ResourceTemplatePage {
+        resourceTemplates = resourceTemplates == null ? List.of() : List.copyOf(resourceTemplates);
+    }
+
+    @Override
+    public List<ResourceTemplate> resourceTemplates() {
+        return List.copyOf(resourceTemplates);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResourceTemplatePage` record
- update `ResourceProvider` to use `listTemplates` with pagination
- implement pagination for `FileSystemResourceProvider` and `InMemoryResourceProvider`
- support pagination in `ResourceServer` and `DefaultMcpServer`

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_6888e98bfa7883248ddd6ac63d12d79e