### PR TITLE
Implement protocol version negotiation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -17,10 +17,9 @@ public class ProtocolLifecycle {
     public InitializeResponse initialize(InitializeRequest request) {
         ensureState(LifecycleState.INIT);
 
-        if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
-            throw new UnsupportedProtocolVersionException(
-                request.protocolVersion(), SUPPORTED_VERSION);
-        }
+        // Always respond with the server's supported version. If the client
+        // does not support this version, it should disconnect according to
+        // the specification.
 
         Set<ClientCapability> requested = request.capabilities().client();
         clientCapabilities = requested.isEmpty() ? EnumSet.noneOf(ClientCapability.class) : EnumSet.copyOf(requested);

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -15,7 +15,6 @@ import com.amannmalik.mcp.lifecycle.InitializeResponse;
 import com.amannmalik.mcp.lifecycle.LifecycleCodec;
 import com.amannmalik.mcp.lifecycle.LifecycleState;
 import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
-import com.amannmalik.mcp.lifecycle.UnsupportedProtocolVersionException;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.transport.Transport;
 import com.amannmalik.mcp.util.*;
@@ -129,18 +128,8 @@ public abstract class McpServer implements AutoCloseable {
 
     private JsonRpcMessage initialize(JsonRpcRequest req) {
         InitializeRequest init = LifecycleCodec.toInitializeRequest(req.params());
-        try {
-            InitializeResponse resp = lifecycle.initialize(init);
-            return new JsonRpcResponse(req.id(), LifecycleCodec.toJsonObject(resp));
-        } catch (UnsupportedProtocolVersionException e) {
-            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
-                    JsonRpcErrorCode.INVALID_PARAMS.code(),
-                    "Unsupported protocol version",
-                    jakarta.json.Json.createObjectBuilder()
-                            .add("supported", ProtocolLifecycle.SUPPORTED_VERSION)
-                            .add("requested", e.requested())
-                            .build()));
-        }
+        InitializeResponse resp = lifecycle.initialize(init);
+        return new JsonRpcResponse(req.id(), LifecycleCodec.toJsonObject(resp));
     }
 
     private void initialized(JsonRpcNotification note) {

--- a/src/test/java/com/amannmalik/mcp/McpProtocolIntegrationTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpProtocolIntegrationTest.java
@@ -80,9 +80,10 @@ class McpProtocolIntegrationTest {
                     "initialize", init);
             t.send(com.amannmalik.mcp.jsonrpc.JsonRpcCodec.toJsonObject(req));
             var msg = com.amannmalik.mcp.jsonrpc.JsonRpcCodec.fromJsonObject(t.receive());
-            assertTrue(msg instanceof com.amannmalik.mcp.jsonrpc.JsonRpcError);
-            var err = (com.amannmalik.mcp.jsonrpc.JsonRpcError) msg;
-            assertEquals(com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode.INVALID_PARAMS.code(), err.error().code());
+            assertTrue(msg instanceof com.amannmalik.mcp.jsonrpc.JsonRpcResponse);
+            var resp = (com.amannmalik.mcp.jsonrpc.JsonRpcResponse) msg;
+            var initResp = com.amannmalik.mcp.lifecycle.LifecycleCodec.toInitializeResponse(resp.result());
+            assertEquals(com.amannmalik.mcp.lifecycle.ProtocolLifecycle.SUPPORTED_VERSION, initResp.protocolVersion());
         } finally {
             if (process.isAlive()) {
                 process.destroyForcibly();


### PR DESCRIPTION
## Summary
- adjust lifecycle initialization to always respond with the server's supported MCP version
- simplify server initialization handler
- update integration test to expect version negotiation

## Testing
- `./verify.sh`
- `gradle test --tests com.amannmalik.mcp.McpProtocolIntegrationTest.testProtocolVersionMismatch`

------
https://chatgpt.com/codex/tasks/task_e_6888ec4b96e88324a3c932c5ed0e9db2