### PR TITLE
Fix host cleanup and progress token errors

### DIFF
--- a/src/main/java/com/amannmalik/mcp/host/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/host/HostProcess.java
@@ -34,7 +34,12 @@ public final class HostProcess implements AutoCloseable {
         if (clients.putIfAbsent(id, client) != null) {
             throw new IllegalArgumentException("Client already registered: " + id);
         }
-        client.connect();
+        try {
+            client.connect();
+        } catch (IOException e) {
+            clients.remove(id);
+            throw e;
+        }
     }
 
     public void unregister(String id) throws IOException {


### PR DESCRIPTION
## Summary
- avoid leaving stray clients in HostProcess when connect fails
- surface progress token issues as INVALID_PARAMS errors

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ec4b96e88324a3c932c5ed0e9db2