### PR TITLE
Fix ID tracker memory leak

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/IdTracker.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/IdTracker.java
@@ -15,4 +15,11 @@ public final class IdTracker {
             throw new IllegalArgumentException("Duplicate id: " + id);
         }
     }
+
+    /**
+     * Releases the ID once processing is finished.
+     */
+    public void release(RequestId id) {
+        seen.remove(id);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -193,6 +193,7 @@ public abstract class McpServer implements AutoCloseable {
         ProgressToken token = progressTokens.remove(id);
         if (token != null) progressTracker.release(token);
         cancellationTracker.release(id);
+        idTracker.release(id);
     }
 
     protected final void sendProgress(ProgressNotification note) throws IOException {

--- a/src/test/java/com/amannmalik/mcp/jsonrpc/IdTrackerTest.java
+++ b/src/test/java/com/amannmalik/mcp/jsonrpc/IdTrackerTest.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdTrackerTest {
+    @Test
+    void testRegisterAndRelease() {
+        IdTracker tracker = new IdTracker();
+        RequestId id = new RequestId.NumericId(1);
+        tracker.register(id);
+        assertThrows(IllegalArgumentException.class, () -> tracker.register(id));
+        tracker.release(id);
+        assertDoesNotThrow(() -> tracker.register(id));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent id reuse memory leak by adding IdTracker.release and using it
- test IdTracker release functionality

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ec4b96e88324a3c932c5ed0e9db2