### PR TITLE
Allow ephemeral HTTP port

### DIFF
--- a/spec/2025-06-18/basic/transports.mdx
+++ b/spec/2025-06-18/basic/transports.mdx
@@ -78,6 +78,7 @@ When implementing Streamable HTTP transport:
 1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
 2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
 3. Servers **SHOULD** implement proper authentication for all connections
+4. Servers **MAY** bind to port `0` to request an ephemeral port from the operating system
 
 Without these protections, attackers could use DNS rebinding to interact with local MCP servers from remote websites.
 

--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -3,8 +3,11 @@ package com.amannmalik.mcp.cli;
 public record ServerConfig(TransportType transport, int port) implements CliConfig {
     public ServerConfig {
         if (transport == null) throw new IllegalArgumentException("transport");
-        if (transport == TransportType.HTTP && port <= 0) {
-            throw new IllegalArgumentException("port required for HTTP");
+        if (transport == TransportType.HTTP && port < 0) {
+            throw new IllegalArgumentException("port must be >= 0 for HTTP");
+        }
+        if (transport == TransportType.HTTP && port > 65535) {
+            throw new IllegalArgumentException("invalid port: " + port);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow port 0 when using HTTP transport
- document ephemeral port option in Streamable HTTP spec

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ec4b96e88324a3c932c5ed0e9db2