### PR TITLE
Update MetaValidator with reserved prefix check

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -13,6 +13,9 @@ public final class MetaValidator {
     private static final Pattern NAME =
             Pattern.compile("(?:[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)?");
 
+    private static final Pattern RESERVED_PREFIX =
+            Pattern.compile("(?:^|\\.)((?:modelcontextprotocol)|mcp)(?:\\.|$)", Pattern.CASE_INSENSITIVE);
+
     public static void requireValid(String key) {
         if (key == null) throw new IllegalArgumentException("key required");
         int slash = key.indexOf('/');
@@ -24,6 +27,9 @@ public final class MetaValidator {
                 if (!LABEL.matcher(label).matches()) {
                     throw new IllegalArgumentException("Invalid _meta prefix: " + key);
                 }
+            }
+            if (RESERVED_PREFIX.matcher(prefix).find() && prefix.split("\\.").length > 1) {
+                throw new IllegalArgumentException("Reserved _meta prefix: " + prefix + "/");
             }
         }
 

--- a/src/test/java/com/amannmalik/mcp/validation/MetaValidatorTest.java
+++ b/src/test/java/com/amannmalik/mcp/validation/MetaValidatorTest.java
@@ -1,0 +1,35 @@
+package com.amannmalik.mcp.validation;
+
+import jakarta.json.Json;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetaValidatorTest {
+
+    @Test
+    void allowsValidKey() {
+        MetaValidator.requireValid("foo/bar");
+    }
+
+    @Test
+    void rejectsReservedPrefix() {
+        assertThrows(IllegalArgumentException.class,
+                () -> MetaValidator.requireValid("modelcontextprotocol.io/foo"));
+        assertThrows(IllegalArgumentException.class,
+                () -> MetaValidator.requireValid("api.modelcontextprotocol.org/bar"));
+        assertThrows(IllegalArgumentException.class,
+                () -> MetaValidator.requireValid("mcp.dev/baz"));
+        assertThrows(IllegalArgumentException.class,
+                () -> MetaValidator.requireValid("tools.mcp.com/thing"));
+    }
+
+    @Test
+    void validatesJsonObject() {
+        var obj = Json.createObjectBuilder()
+                .add("foo/bar", 1)
+                .add("baz", 2)
+                .build();
+        MetaValidator.requireValid(obj);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce reserved `_meta` prefixes
- add `MetaValidatorTest` for validation logic

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ee1116208324b6bf80883c3c4de8