### PR TITLE
Fix completion context parsing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
@@ -36,7 +36,12 @@ public final class CompletionCodec {
             JsonObject argsObj = obj.getJsonObject("context").getJsonObject("arguments");
             Map<String, String> args = new HashMap<>();
             if (argsObj != null) {
-                argsObj.forEach((k, v) -> args.put(k, v.toString().replace("\"", "")));
+                argsObj.forEach((k, v) -> {
+                    if (v.getValueType() != jakarta.json.JsonValue.ValueType.STRING) {
+                        throw new IllegalArgumentException("context arguments must be strings");
+                    }
+                    args.put(k, ((jakarta.json.JsonString) v).getString());
+                });
             }
             ctx = new CompleteRequest.Context(args);
         }


### PR DESCRIPTION
## Summary
- sanitize completion context arguments as strings

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ee1116208324b6bf80883c3c4de8