### PR TITLE
Handle resource links in prompts

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -67,7 +67,12 @@ public final class PromptCodec {
                     .add("mimeType", i.mimeType());
             case PromptContent.Audio a -> b.add("data", Base64.getEncoder().encodeToString(a.data()))
                     .add("mimeType", a.mimeType());
-            case PromptContent.ResourceContent r -> b.add("resource", ResourcesCodec.toJsonObject(r.resource()));
+            case PromptContent.EmbeddedResource r -> b.add("resource", ResourcesCodec.toJsonObject(r.resource()));
+            case PromptContent.ResourceLink l -> {
+                for (var e : ResourcesCodec.toJsonObject(l.resource()).entrySet()) {
+                    b.add(e.getKey(), e.getValue());
+                }
+            }
         }
         return b.build();
     }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
@@ -2,10 +2,15 @@ package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.server.resources.Resource;
 import com.amannmalik.mcp.server.resources.ResourceAnnotations;
+import com.amannmalik.mcp.server.resources.ResourceBlock;
 
 /** Supported content types for prompt messages. */
 public sealed interface PromptContent
-        permits PromptContent.Text, PromptContent.Image, PromptContent.Audio, PromptContent.ResourceContent {
+        permits PromptContent.Text,
+        PromptContent.Image,
+        PromptContent.Audio,
+        PromptContent.EmbeddedResource,
+        PromptContent.ResourceLink {
     String type();
     ResourceAnnotations annotations();
 
@@ -38,10 +43,23 @@ public sealed interface PromptContent
     }
 
     /** Embedded resource content. */
-    record ResourceContent(Resource resource, ResourceAnnotations annotations) implements PromptContent {
-        public ResourceContent {
+    record EmbeddedResource(ResourceBlock resource, ResourceAnnotations annotations) implements PromptContent {
+        public EmbeddedResource {
             if (resource == null) throw new IllegalArgumentException("resource is required");
         }
         @Override public String type() { return "resource"; }
+    }
+
+    /** Link to a resource without embedding its contents. */
+    record ResourceLink(Resource resource) implements PromptContent {
+        public ResourceLink {
+            if (resource == null) throw new IllegalArgumentException("resource is required");
+        }
+
+        @Override public ResourceAnnotations annotations() {
+            return resource.annotations();
+        }
+
+        @Override public String type() { return "resource_link"; }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -26,7 +26,8 @@ public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages
             case PromptContent.Text t -> new PromptContent.Text(substitute(t.text(), args), t.annotations());
             case PromptContent.Image i -> new PromptContent.Image(i.data(), i.mimeType(), i.annotations());
             case PromptContent.Audio a -> new PromptContent.Audio(a.data(), a.mimeType(), a.annotations());
-            case PromptContent.ResourceContent r -> new PromptContent.ResourceContent(r.resource(), r.annotations());
+            case PromptContent.EmbeddedResource r -> new PromptContent.EmbeddedResource(r.resource(), r.annotations());
+            case PromptContent.ResourceLink l -> new PromptContent.ResourceLink(l.resource());
         };
     }
 


### PR DESCRIPTION
## Summary
- support `resource_link` blocks in prompt content
- rename ResourceContent -> EmbeddedResource
- allow conversion of links to JSON

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888ee1116208324b6bf80883c3c4de8