### PR TITLE
Wire logging codec

### DIFF
--- a/src/test/java/com/amannmalik/mcp/server/logging/LoggingCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/server/logging/LoggingCodecTest.java
@@ -1,0 +1,33 @@
+package com.amannmalik.mcp.server.logging;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggingCodecTest {
+    @Test
+    void roundTripNotification() {
+        LoggingNotification note = new LoggingNotification(
+                LoggingLevel.WARNING,
+                "test",
+                Json.createValue("message"));
+        JsonObject obj = LoggingCodec.toJsonObject(note);
+        assertEquals("warning", obj.getString("level"));
+        assertEquals("test", obj.getString("logger"));
+        assertEquals("message", obj.getString("data"));
+
+        LoggingNotification parsed = LoggingCodec.toLoggingNotification(obj);
+        assertEquals(note, parsed);
+    }
+
+    @Test
+    void roundTripSetLevel() {
+        SetLevelRequest req = new SetLevelRequest(LoggingLevel.ERROR);
+        JsonObject obj = LoggingCodec.toJsonObject(req);
+        assertEquals("error", obj.getString("level"));
+        SetLevelRequest parsed = LoggingCodec.toSetLevelRequest(obj);
+        assertEquals(req, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `LoggingCodec` with `McpServer`
- expose helper methods to send log messages
- use the codec when parsing log level requests
- emit structured log notifications on server errors
- add unit tests for `LoggingCodec`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888f3acf9fc8324928ad913deca4dd8