### PR TITLE
Wire host process for JSON-RPC calls

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/DefaultMcpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/DefaultMcpClient.java
@@ -90,6 +90,7 @@ public final class DefaultMcpClient implements McpClient {
         return instructions == null ? "" : instructions;
     }
 
+    @Override
     public JsonRpcMessage request(String method, JsonObject params) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
         RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
@@ -117,6 +118,7 @@ public final class DefaultMcpClient implements McpClient {
         }
     }
 
+    @Override
     public void notify(String method, JsonObject params) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
         JsonRpcNotification notification = new JsonRpcNotification(method, params);

--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -1,6 +1,8 @@
 package com.amannmalik.mcp.client;
 
 import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import jakarta.json.JsonObject;
 import java.io.IOException;
 
 /** Basic client contract managed by a HostProcess. */
@@ -15,6 +17,10 @@ public interface McpClient extends AutoCloseable {
 
     /** Context currently held by the client for aggregation. */
     String context();
+
+    JsonRpcMessage request(String method, JsonObject params) throws IOException;
+
+    void notify(String method, JsonObject params) throws IOException;
 
     @Override
     default void close() throws IOException {

--- a/src/main/java/com/amannmalik/mcp/host/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/host/HostProcess.java
@@ -2,7 +2,9 @@ package com.amannmalik.mcp.host;
 
 import com.amannmalik.mcp.client.McpClient;
 import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
 import com.amannmalik.mcp.security.ConsentManager;
+import jakarta.json.JsonObject;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -65,6 +67,20 @@ public final class HostProcess implements AutoCloseable {
         return clients.values().stream()
                 .map(McpClient::context)
                 .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    public JsonRpcMessage request(String id, String method, JsonObject params) throws IOException {
+        McpClient client = clients.get(id);
+        if (client == null) throw new IllegalArgumentException("Unknown client: " + id);
+        if (!client.connected()) throw new IllegalStateException("Client not connected: " + id);
+        return client.request(method, params);
+    }
+
+    public void notify(String id, String method, JsonObject params) throws IOException {
+        McpClient client = clients.get(id);
+        if (client == null) throw new IllegalArgumentException("Unknown client: " + id);
+        if (!client.connected()) throw new IllegalStateException("Client not connected: " + id);
+        client.notify(method, params);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- let `McpClient` expose `request` and `notify`
- implement the methods in `DefaultMcpClient`
- allow `HostProcess` to forward requests and notifications to managed clients

## Testing
- `gradle test --no-daemon`
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888f41f85d4832497bfbac16d45930c