### PR TITLE
Add client roots support

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
@@ -13,8 +13,13 @@ public final class LifecycleCodec {
 
     public static JsonObject toJsonObject(InitializeRequest req) {
         var caps = Json.createObjectBuilder();
-        req.capabilities().client()
-                .forEach(c -> caps.add(c.name().toLowerCase(), JsonValue.EMPTY_JSON_OBJECT));
+        for (var c : req.capabilities().client()) {
+            var b = Json.createObjectBuilder();
+            if (c == ClientCapability.ROOTS) {
+                b.add("listChanged", true);
+            }
+            caps.add(c.name().toLowerCase(), b.build());
+        }
         var info = Json.createObjectBuilder()
                 .add("name", req.clientInfo().name())
                 .add("version", req.clientInfo().version());


### PR DESCRIPTION
## Summary
- advertise `listChanged` under the `roots` capability
- handle `roots/list` requests in `DefaultMcpClient`
- send `notifications/roots/list_changed` when provider fires

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888fbefa85c83248d0c4c194f649560