### PR TITLE
Introduce Host command using HostProcess

### DIFF
--- a/src/main/java/com/amannmalik/mcp/Main.java
+++ b/src/main/java/com/amannmalik/mcp/Main.java
@@ -7,7 +7,7 @@ import java.util.concurrent.Callable;
 import java.nio.file.Path;
 
 @CommandLine.Command(name = "mcp",
-        subcommands = {ServerCommand.class, ClientCommand.class},
+        subcommands = {ServerCommand.class, ClientCommand.class, HostCommand.class},
         mixinStandardHelpOptions = true)
 public final class Main implements Callable<Integer> {
     @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
@@ -23,6 +23,7 @@ public final class Main implements Callable<Integer> {
             return switch (cfg) {
                 case ServerConfig sc -> new ServerCommand(sc, verbose).call();
                 case ClientConfig cc -> new ClientCommand(cc, verbose).call();
+                case HostConfig hc -> new HostCommand(hc, verbose).call();
             };
         }
         CommandLine.usage(this, System.out);

--- a/src/main/java/com/amannmalik/mcp/cli/CliConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/CliConfig.java
@@ -1,4 +1,4 @@
 package com.amannmalik.mcp.cli;
 
-public sealed interface CliConfig permits ServerConfig, ClientConfig {
+public sealed interface CliConfig permits ServerConfig, ClientConfig, HostConfig {
 }

--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -1,0 +1,79 @@
+package com.amannmalik.mcp.cli;
+
+import com.amannmalik.mcp.client.DefaultMcpClient;
+import com.amannmalik.mcp.lifecycle.ClientCapability;
+import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.security.*;
+import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.transport.StdioTransport;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "host", description = "Run MCP host", mixinStandardHelpOptions = true)
+public final class HostCommand implements Callable<Integer> {
+    @CommandLine.Option(names = {"-c", "--config"}, description = "Config file")
+    private Path config;
+
+    private HostConfig resolved;
+
+    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
+    private boolean verbose;
+
+    @CommandLine.Option(names = "--client", description = "Client as id:command", split = ",")
+    private List<String> clientSpecs;
+
+    public HostCommand() {}
+
+    public HostCommand(HostConfig config, boolean verbose) {
+        this.resolved = config;
+        this.verbose = verbose;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        HostConfig cfg;
+        if (resolved != null) {
+            cfg = resolved;
+        } else if (config != null) {
+            CliConfig loaded = ConfigLoader.load(config);
+            if (!(loaded instanceof HostConfig hc)) throw new IllegalArgumentException("host config expected");
+            cfg = hc;
+        } else {
+            if (clientSpecs == null || clientSpecs.isEmpty()) {
+                throw new IllegalArgumentException("--client required");
+            }
+            Map<String, String> map = new LinkedHashMap<>();
+            for (String spec : clientSpecs) {
+                int idx = spec.indexOf(':');
+                if (idx <= 0 || idx == spec.length() - 1) throw new IllegalArgumentException("id:command expected: " + spec);
+                map.put(spec.substring(0, idx), spec.substring(idx + 1));
+            }
+            cfg = new HostConfig(map);
+        }
+
+        ConsentManager consents = new ConsentManager();
+        ToolAccessController tools = new ToolAccessController();
+        SecurityPolicy policy = c -> true;
+        Principal principal = new Principal("user", Set.of());
+
+        try (HostProcess host = new HostProcess(policy, consents, tools, principal)) {
+            for (var entry : cfg.clients().entrySet()) {
+                host.grantConsent(entry.getKey());
+                var pb = new ProcessBuilder(entry.getValue().split(" "));
+                StdioTransport t = new StdioTransport(pb, verbose ? System.err::println : s -> {});
+                DefaultMcpClient client = new DefaultMcpClient(
+                        new ClientInfo(entry.getKey(), entry.getKey(), "0"),
+                        EnumSet.noneOf(ClientCapability.class),
+                        t);
+                host.register(entry.getKey(), client);
+                if (verbose) System.err.println("Registered client: " + entry.getKey());
+            }
+            System.out.println(host.aggregateContext());
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/HostConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostConfig.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.cli;
+
+import java.util.Map;
+
+public record HostConfig(Map<String, String> clients) implements CliConfig {
+    public HostConfig {
+        if (clients == null || clients.isEmpty()) {
+            throw new IllegalArgumentException("clients required");
+        }
+        clients = Map.copyOf(clients);
+    }
+}


### PR DESCRIPTION
## Summary
- add `HostConfig` and `HostCommand` for running a host process
- extend `CliConfig` and `ConfigLoader` to support host mode
- wire up new command in `Main`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890179e73c8324ab2c6d21061a2857