### PR TITLE
Fix ResourceTemplate validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
@@ -1,7 +1,7 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
-import com.amannmalik.mcp.validation.UriValidator;
+import com.amannmalik.mcp.validation.UriTemplateValidator;
 
 public record ResourceTemplate(
         String uriTemplate,
@@ -12,7 +12,7 @@ public record ResourceTemplate(
         ResourceAnnotations annotations
 ) {
     public ResourceTemplate {
-        uriTemplate = UriValidator.requireAbsolute(uriTemplate);
+        uriTemplate = UriTemplateValidator.requireAbsoluteTemplate(uriTemplate);
         name = InputSanitizer.requireClean(name);
         title = title == null ? null : InputSanitizer.requireClean(title);
         description = description == null ? null : InputSanitizer.requireClean(description);

--- a/src/main/java/com/amannmalik/mcp/validation/UriTemplateValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/UriTemplateValidator.java
@@ -1,0 +1,37 @@
+package com.amannmalik.mcp.validation;
+
+import java.net.URI;
+
+/** Utility for validating RFC6570 URI templates. */
+public final class UriTemplateValidator {
+    private UriTemplateValidator() {}
+
+    public static String requireAbsoluteTemplate(String template) {
+        if (template == null) throw new IllegalArgumentException("uriTemplate is required");
+        checkBraces(template);
+        String replaced = template.replaceAll("\\{[^}]*}", "x");
+        URI parsed;
+        try {
+            parsed = URI.create(replaced).normalize();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid URI template: " + template, e);
+        }
+        if (!parsed.isAbsolute()) {
+            throw new IllegalArgumentException("URI template must be absolute: " + template);
+        }
+        if (parsed.getFragment() != null) {
+            throw new IllegalArgumentException("URI template must not contain fragment: " + template);
+        }
+        return template;
+    }
+
+    private static void checkBraces(String template) {
+        int depth = 0;
+        for (int i = 0; i < template.length(); i++) {
+            char c = template.charAt(i);
+            if (c == '{') depth++; else if (c == '}') depth--;
+            if (depth < 0) throw new IllegalArgumentException("Unmatched braces in URI template: " + template);
+        }
+        if (depth != 0) throw new IllegalArgumentException("Unmatched braces in URI template: " + template);
+    }
+}


### PR DESCRIPTION
## Summary
- allow RFC6570-style URI templates
- validate URI templates rather than normal URIs

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688903295f8883249bad92160be82379