### PR TITLE
Add schema validation for tools and elicitation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
@@ -5,6 +5,11 @@ import jakarta.json.JsonObject;
 
 public record ElicitationResponse(ElicitationAction action, JsonObject content) {
     public ElicitationResponse {
-        if (action == null) throw new IllegalArgumentException("action is required");
+        if (action == null) {
+            throw new IllegalArgumentException("action is required");
+        }
+        if (action == ElicitationAction.ACCEPT && content == null) {
+            throw new IllegalArgumentException("content required for ACCEPT action");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate elicitation responses when action is `accept`
- enforce tool input/output schemas in the in-memory provider

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688903295f8883249bad92160be82379