### PR TITLE
Relax HTTP version header check

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -147,7 +147,7 @@ public final class StreamableHttpTransport implements Transport {
             } else if (!session.equals(header)) {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
-            } else if (version == null || !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
+            } else if (version != null && !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -221,7 +221,7 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
-            if (version == null || !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
+            if (version != null && !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -303,7 +303,7 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
-            if (version == null || !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
+            if (version != null && !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }


### PR DESCRIPTION
## Summary
- allow HTTP requests when `MCP-Protocol-Version` header is omitted but session is valid

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688905e94ea08324bfeb21d9c96f6f75