### PR TITLE
Add list changed notification support

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -56,6 +56,14 @@ public final class PromptCodec {
         return builder.build();
     }
 
+    public static JsonObject toJsonObject(PromptsListChangedNotification n) {
+        return Json.createObjectBuilder().build();
+    }
+
+    public static PromptsListChangedNotification toPromptsListChangedNotification(JsonObject obj) {
+        return new PromptsListChangedNotification();
+    }
+
     static JsonObject toJsonObject(PromptContent content) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("type", content.type());
         if (content.annotations() != null) {

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
@@ -7,4 +7,8 @@ public interface PromptProvider {
     PromptPage list(String cursor);
 
     PromptInstance get(String name, Map<String, String> arguments);
+
+    default PromptsSubscription subscribe(PromptsListener listener) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptsListChangedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptsListChangedNotification.java
@@ -1,0 +1,3 @@
+package com.amannmalik.mcp.prompts;
+
+public record PromptsListChangedNotification() {}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptsListener.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptsListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.prompts;
+
+@FunctionalInterface
+public interface PromptsListener {
+    void listChanged();
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptsSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptsSubscription.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.prompts;
+
+public interface PromptsSubscription extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -40,6 +40,9 @@ public final class McpServer implements AutoCloseable {
     private final PromptProvider prompts;
     private final CompletionProvider completions;
     private final Map<String, ResourceSubscription> resourceSubscriptions = new ConcurrentHashMap<>();
+    private ResourceListSubscription resourceListSubscription;
+    private ToolListSubscription toolListSubscription;
+    private PromptsSubscription promptsSubscription;
     private final ResourceAccessController resourceAccess;
     private final Principal principal;
     private volatile LoggingLevel logLevel = LoggingLevel.INFO;
@@ -87,6 +90,33 @@ public final class McpServer implements AutoCloseable {
         this.completions = completions;
         this.resourceAccess = resourceAccess;
         this.principal = principal;
+
+        try {
+            resourceListSubscription = resources.subscribeList(() -> {
+                try {
+                    send(new JsonRpcNotification("notifications/resources/list_changed", null));
+                } catch (IOException ignore) {
+                }
+            });
+        } catch (Exception ignore) {}
+
+        try {
+            toolListSubscription = tools.subscribeList(() -> {
+                try {
+                    send(new JsonRpcNotification("notifications/tools/list_changed", null));
+                } catch (IOException ignore) {
+                }
+            });
+        } catch (Exception ignore) {}
+
+        try {
+            promptsSubscription = prompts.subscribe(() -> {
+                try {
+                    send(new JsonRpcNotification("notifications/prompts/list_changed", null));
+                } catch (IOException ignore) {
+                }
+            });
+        } catch (Exception ignore) {}
 
         registerRequestHandler("initialize", this::initialize);
         registerNotificationHandler("notifications/initialized", this::initialized);
@@ -577,6 +607,18 @@ public final class McpServer implements AutoCloseable {
             try { sub.close(); } catch (Exception ignore) {}
         }
         resourceSubscriptions.clear();
+        if (resourceListSubscription != null) {
+            try { resourceListSubscription.close(); } catch (Exception ignore) {}
+            resourceListSubscription = null;
+        }
+        if (toolListSubscription != null) {
+            try { toolListSubscription.close(); } catch (Exception ignore) {}
+            toolListSubscription = null;
+        }
+        if (promptsSubscription != null) {
+            try { promptsSubscription.close(); } catch (Exception ignore) {}
+            promptsSubscription = null;
+        }
         resources.close();
         completions.close();
         transport.close();

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceListChangedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceListChangedNotification.java
@@ -1,0 +1,3 @@
+package com.amannmalik.mcp.server.resources;
+
+public record ResourceListChangedNotification() {}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceListListener.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceListListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.server.resources;
+
+@FunctionalInterface
+public interface ResourceListListener {
+    void listChanged();
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceListSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceListSubscription.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.server.resources;
+
+public interface ResourceListSubscription extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -8,6 +8,9 @@ public interface ResourceProvider extends AutoCloseable {
     ResourceBlock read(String uri) throws IOException;
     ResourceTemplatePage listTemplates(String cursor) throws IOException;
     ResourceSubscription subscribe(String uri, ResourceListener listener) throws IOException;
+    default ResourceListSubscription subscribeList(ResourceListListener listener) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     default void close() throws IOException {}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -111,4 +111,12 @@ public final class ResourcesCodec {
         Instant lastModified = obj.containsKey("lastModified") ? Instant.parse(obj.getString("lastModified")) : null;
         return new ResourceAnnotations(audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience), priority, lastModified);
     }
+
+    public static JsonObject toJsonObject(ResourceListChangedNotification n) {
+        return Json.createObjectBuilder().build();
+    }
+
+    public static ResourceListChangedNotification toResourceListChangedNotification(JsonObject obj) {
+        return new ResourceListChangedNotification();
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -36,6 +36,14 @@ public final class ToolCodec {
         return builder.build();
     }
 
+    public static JsonObject toJsonObject(ToolListChangedNotification n) {
+        return Json.createObjectBuilder().build();
+    }
+
+    public static ToolListChangedNotification toToolListChangedNotification(JsonObject obj) {
+        return new ToolListChangedNotification();
+    }
+
     private static JsonObject toJsonObject(ToolAnnotations ann) {
         JsonObjectBuilder b = Json.createObjectBuilder();
         if (ann.title() != null) b.add("title", ann.title());

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolListChangedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolListChangedNotification.java
@@ -1,0 +1,3 @@
+package com.amannmalik.mcp.server.tools;
+
+public record ToolListChangedNotification() {}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolListListener.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolListListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.server.tools;
+
+@FunctionalInterface
+public interface ToolListListener {
+    void listChanged();
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolListSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolListSubscription.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.server.tools;
+
+public interface ToolListSubscription extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
@@ -7,4 +7,8 @@ public interface ToolProvider {
     ToolPage list(String cursor);
 
     ToolResult call(String name, JsonObject arguments);
+
+    default ToolListSubscription subscribeList(ToolListListener listener) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
## Summary
- allow subscribing to prompt, resource, and tool list changes
- fire notifications from `McpServer` when lists change
- add simple records/codec helpers for list_changed notifications

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890877916c832486e72397a6a6a887