### PR TITLE
Add missing sampling fields

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.client.sampling;
 
+import jakarta.json.JsonObject;
 import java.util.List;
 
 
@@ -7,9 +8,19 @@ public record CreateMessageRequest(
         List<SamplingMessage> messages,
         ModelPreferences modelPreferences,
         String systemPrompt,
-        Integer maxTokens
+        IncludeContext includeContext,
+        Double temperature,
+        int maxTokens,
+        List<String> stopSequences,
+        JsonObject metadata
 ) {
+    public enum IncludeContext { NONE, THIS_SERVER, ALL_SERVERS }
+
     public CreateMessageRequest {
         messages = messages == null || messages.isEmpty() ? List.of() : List.copyOf(messages);
+        stopSequences = stopSequences == null || stopSequences.isEmpty() ? List.of() : List.copyOf(stopSequences);
+        if (maxTokens <= 0) {
+            throw new IllegalArgumentException("maxTokens must be > 0");
+        }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/ModelPreferences.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/ModelPreferences.java
@@ -11,5 +11,14 @@ public record ModelPreferences(
 ) {
     public ModelPreferences {
         hints = hints == null || hints.isEmpty() ? List.of() : List.copyOf(hints);
+        if (costPriority != null && (costPriority < 0.0 || costPriority > 1.0)) {
+            throw new IllegalArgumentException("costPriority must be between 0.0 and 1.0");
+        }
+        if (speedPriority != null && (speedPriority < 0.0 || speedPriority > 1.0)) {
+            throw new IllegalArgumentException("speedPriority must be between 0.0 and 1.0");
+        }
+        if (intelligencePriority != null && (intelligencePriority < 0.0 || intelligencePriority > 1.0)) {
+            throw new IllegalArgumentException("intelligencePriority must be between 0.0 and 1.0");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate ModelPreferences priority ranges
- extend CreateMessageRequest with include context, temperature, stop sequences and metadata
- encode/decode new sampling fields in SamplingCodec

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_68890959042483249d57fbd305566e4c