### PR TITLE
Fix HTTP version header requirement

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -147,7 +147,7 @@ public final class StreamableHttpTransport implements Transport {
             } else if (!session.equals(header)) {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
-            } else if (version != null && !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
+            } else if (version == null || !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -221,7 +221,7 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
-            if (version != null && !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
+            if (version == null || !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -303,7 +303,7 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
-            if (version != null && !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
+            if (version == null || !version.equals(ProtocolLifecycle.SUPPORTED_VERSION)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }


### PR DESCRIPTION
## Summary
- require MCP-Protocol-Version header for HTTP POST/GET/DELETE

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890959042483249d57fbd305566e4c