### PR TITLE
Fix _meta prefix validator

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -14,7 +14,7 @@ public final class MetaValidator {
             Pattern.compile("(?:[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)?");
 
     private static final Pattern RESERVED_PREFIX =
-            Pattern.compile("(?:^|\\.)((?:modelcontextprotocol)|mcp)(?:\\.|$)", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("(?:^|\\.)(?:modelcontextprotocol|mcp)\\.", Pattern.CASE_INSENSITIVE);
 
     public static void requireValid(String key) {
         if (key == null) throw new IllegalArgumentException("key required");
@@ -28,7 +28,7 @@ public final class MetaValidator {
                     throw new IllegalArgumentException("Invalid _meta prefix: " + key);
                 }
             }
-            if (RESERVED_PREFIX.matcher(prefix).find() && prefix.split("\\.").length > 1) {
+            if (RESERVED_PREFIX.matcher(prefix).find()) {
                 throw new IllegalArgumentException("Reserved _meta prefix: " + prefix + "/");
             }
         }


### PR DESCRIPTION
## Summary
- update regex for reserved `_meta` prefixes to match spec

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890c877f0c83249b32772850674b50