### PR TITLE
Ensure Streamable HTTP sends on a single SSE stream

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -65,7 +65,10 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
         }
-        sseClients.forEach(c -> c.send(message));
+        for (SseClient c : sseClients) {
+            c.send(message);
+            break;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- prevent HTTP transport from broadcasting each JSON-RPC message to every SSE connection

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890f8a270c83248538b7d63b50f494