### PR TITLE
Fix tool result JSON

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -30,9 +30,11 @@ public final class ToolCodec {
 
     public static JsonObject toJsonObject(ToolResult result) {
         JsonObjectBuilder builder = Json.createObjectBuilder()
-                .add("content", result.content())
-                .add("isError", result.isError());
-        if (result.structuredContent() != null) builder.add("structuredContent", result.structuredContent());
+                .add("content", result.content());
+        if (result.isError()) builder.add("isError", true);
+        if (result.structuredContent() != null) {
+            builder.add("structuredContent", result.structuredContent());
+        }
         return builder.build();
     }
 


### PR DESCRIPTION
## Summary
- only include `isError` in tool results when the call failed

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890f8a270c83248538b7d63b50f494