### PR TITLE
Add _meta fields for resource and root types

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/Root.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/Root.java
@@ -2,11 +2,14 @@ package com.amannmalik.mcp.client.roots;
 
 import com.amannmalik.mcp.validation.UriValidator;
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
 
-public record Root(String uri, String name) {
+public record Root(String uri, String name, JsonObject _meta) {
     public Root {
         uri = UriValidator.requireFileUri(uri);
         name = name == null ? null : InputSanitizer.requireClean(name);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -39,11 +39,16 @@ public final class RootsCodec {
     public static JsonObject toJsonObject(Root root) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("uri", root.uri());
         if (root.name() != null) b.add("name", root.name());
+        if (root._meta() != null) b.add("_meta", root._meta());
         return b.build();
     }
 
     public static Root toRoot(JsonObject obj) {
-        return new Root(obj.getString("uri"), obj.getString("name", null));
+        return new Root(
+                obj.getString("uri"),
+                obj.getString("name", null),
+                obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null
+        );
     }
 
     public static JsonObject toJsonObject(List<Root> roots) {

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -631,9 +631,9 @@ public final class McpServer implements AutoCloseable {
 
 
     private static ResourceProvider createDefaultResources() {
-        Resource r = new Resource("test://example", "example", null, null, "text/plain", 5L, null);
-        ResourceBlock.Text block = new ResourceBlock.Text("test://example", "example", null, "text/plain", "hello", null);
-        ResourceTemplate t = new ResourceTemplate("test://template", "example_template", null, null, "text/plain", null);
+        Resource r = new Resource("test://example", "example", null, null, "text/plain", 5L, null, null);
+        ResourceBlock.Text block = new ResourceBlock.Text("test://example", "example", null, "text/plain", "hello", null, null);
+        ResourceTemplate t = new ResourceTemplate("test://template", "example_template", null, null, "text/plain", null, null);
         return new InMemoryResourceProvider(List.of(r), Map.of(r.uri(), block), List.of(t));
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
@@ -1,7 +1,9 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriValidator;
+import jakarta.json.JsonObject;
 
 public record Resource(
         String uri,
@@ -10,7 +12,8 @@ public record Resource(
         String description,
         String mimeType,
         Long size,
-        ResourceAnnotations annotations
+        ResourceAnnotations annotations,
+        JsonObject _meta
 ) {
     public Resource {
         uri = UriValidator.requireAbsolute(uri);
@@ -21,5 +24,6 @@ public record Resource(
         if (size != null && size < 0) {
             throw new IllegalArgumentException("size must be >= 0");
         }
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceBlock.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceBlock.java
@@ -1,7 +1,9 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriValidator;
+import jakarta.json.JsonObject;
 
 public sealed interface ResourceBlock permits ResourceBlock.Text, ResourceBlock.Binary {
     String uri();
@@ -9,18 +11,20 @@ public sealed interface ResourceBlock permits ResourceBlock.Text, ResourceBlock.
     String title();
     String mimeType();
     ResourceAnnotations annotations();
+    JsonObject _meta();
 
-    record Text(String uri, String name, String title, String mimeType, String text, ResourceAnnotations annotations) implements ResourceBlock {
+    record Text(String uri, String name, String title, String mimeType, String text, ResourceAnnotations annotations, JsonObject _meta) implements ResourceBlock {
         public Text {
             uri = UriValidator.requireAbsolute(uri);
             name = InputSanitizer.requireClean(name);
             title = title == null ? null : InputSanitizer.requireClean(title);
             mimeType = mimeType == null ? null : InputSanitizer.requireClean(mimeType);
             text = InputSanitizer.requireClean(text);
+            MetaValidator.requireValid(_meta);
         }
     }
 
-    record Binary(String uri, String name, String title, String mimeType, byte[] blob, ResourceAnnotations annotations) implements ResourceBlock {
+    record Binary(String uri, String name, String title, String mimeType, byte[] blob, ResourceAnnotations annotations, JsonObject _meta) implements ResourceBlock {
         public Binary {
             uri = UriValidator.requireAbsolute(uri);
             name = InputSanitizer.requireClean(name);
@@ -30,6 +34,7 @@ public sealed interface ResourceBlock permits ResourceBlock.Text, ResourceBlock.
                 throw new IllegalArgumentException("blob is required");
             }
             blob = blob.clone();
+            MetaValidator.requireValid(_meta);
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
@@ -1,7 +1,9 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriTemplateValidator;
+import jakarta.json.JsonObject;
 
 public record ResourceTemplate(
         String uriTemplate,
@@ -9,7 +11,8 @@ public record ResourceTemplate(
         String title,
         String description,
         String mimeType,
-        ResourceAnnotations annotations
+        ResourceAnnotations annotations,
+        JsonObject _meta
 ) {
     public ResourceTemplate {
         uriTemplate = UriTemplateValidator.requireAbsoluteTemplate(uriTemplate);
@@ -17,5 +20,6 @@ public record ResourceTemplate(
         title = title == null ? null : InputSanitizer.requireClean(title);
         description = description == null ? null : InputSanitizer.requireClean(description);
         mimeType = mimeType == null ? null : InputSanitizer.requireClean(mimeType);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -21,6 +21,7 @@ public final class ResourcesCodec {
         if (r.mimeType() != null) b.add("mimeType", r.mimeType());
         if (r.size() != null) b.add("size", r.size());
         if (r.annotations() != null) b.add("annotations", toJsonObject(r.annotations()));
+        if (r._meta() != null) b.add("_meta", r._meta());
         return b.build();
     }
 
@@ -32,7 +33,8 @@ public final class ResourcesCodec {
                 obj.getString("description", null),
                 obj.getString("mimeType", null),
                 obj.containsKey("size") ? obj.getJsonNumber("size").longValue() : null,
-                obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null
+                obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null,
+                obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null
         );
     }
 
@@ -44,6 +46,7 @@ public final class ResourcesCodec {
         if (t.description() != null) b.add("description", t.description());
         if (t.mimeType() != null) b.add("mimeType", t.mimeType());
         if (t.annotations() != null) b.add("annotations", toJsonObject(t.annotations()));
+        if (t._meta() != null) b.add("_meta", t._meta());
         return b.build();
     }
 
@@ -54,7 +57,8 @@ public final class ResourcesCodec {
                 obj.getString("title", null),
                 obj.getString("description", null),
                 obj.getString("mimeType", null),
-                obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null
+                obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null,
+                obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null
         );
     }
 
@@ -65,6 +69,7 @@ public final class ResourcesCodec {
         if (block.title() != null) b.add("title", block.title());
         if (block.mimeType() != null) b.add("mimeType", block.mimeType());
         if (block.annotations() != null) b.add("annotations", toJsonObject(block.annotations()));
+        if (block._meta() != null) b.add("_meta", block._meta());
         switch (block) {
             case ResourceBlock.Text t -> b.add("text", t.text());
             case ResourceBlock.Binary b2 -> b.add("blob", Base64.getEncoder().encodeToString(b2.blob()));
@@ -78,12 +83,13 @@ public final class ResourcesCodec {
         String title = obj.getString("title", null);
         String mime = obj.getString("mimeType", null);
         ResourceAnnotations ann = obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null;
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
         if (obj.containsKey("text")) {
-            return new ResourceBlock.Text(uri, name, title, mime, obj.getString("text"), ann);
+            return new ResourceBlock.Text(uri, name, title, mime, obj.getString("text"), ann, meta);
         }
         if (obj.containsKey("blob")) {
             byte[] data = Base64.getDecoder().decode(obj.getString("blob"));
-            return new ResourceBlock.Binary(uri, name, title, mime, data, ann);
+            return new ResourceBlock.Binary(uri, name, title, mime, data, ann, meta);
         }
         throw new IllegalArgumentException("unknown content block");
     }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -48,9 +48,10 @@ public record ToolResult(JsonArray content,
     private static JsonObject toResourceLink(JsonObject obj) {
         Resource r = ResourcesCodec.toResource(obj);
         JsonObject base = ResourcesCodec.toJsonObject(r);
-        return Json.createObjectBuilder(base)
-                .add("type", "resource_link")
-                .build();
+        JsonObjectBuilder result = Json.createObjectBuilder(base)
+                .add("type", "resource_link");
+        if (obj.containsKey("_meta")) result.add("_meta", obj.getJsonObject("_meta"));
+        return result.build();
     }
 
     private static JsonObject toEmbeddedResource(JsonObject obj) {
@@ -61,6 +62,7 @@ public record ToolResult(JsonArray content,
                 .add("type", "resource")
                 .add("resource", ResourcesCodec.toJsonObject(block));
         if (obj.containsKey("annotations")) result.add("annotations", obj.getJsonObject("annotations"));
+        if (obj.containsKey("_meta")) result.add("_meta", obj.getJsonObject("_meta"));
         return result.build();
     }
 }


### PR DESCRIPTION
## Summary
- support `_meta` for Resource, ResourceTemplate, ResourceBlock and Root
- propagate meta through codec helpers and tool result utilities

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889128442b48324b658634faf3a788d