### PR TITLE
Fix prompt argument parsing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -87,10 +87,13 @@ public final class PromptCodec {
 
     public static Map<String, String> toArguments(JsonObject obj) {
         if (obj == null) return Map.of();
-        return obj.entrySet().stream().collect(java.util.stream.Collectors.toMap(
-                Map.Entry::getKey,
-                e -> e.getValue().getValueType() == jakarta.json.JsonValue.ValueType.STRING
-                        ? ((jakarta.json.JsonString) e.getValue()).getString()
-                        : e.getValue().toString()));
+        java.util.Map<String, String> args = new java.util.HashMap<>();
+        obj.forEach((k, v) -> {
+            if (v.getValueType() != jakarta.json.JsonValue.ValueType.STRING) {
+                throw new IllegalArgumentException("argument values must be strings");
+            }
+            args.put(k, ((jakarta.json.JsonString) v).getString());
+        });
+        return args;
     }
 }


### PR DESCRIPTION
## Summary
- enforce string-only prompt arguments

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688913a8f4648324a62e6d5b0261e045