### PR TITLE
Add required prompt argument validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -11,6 +11,11 @@ public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages
     }
 
     PromptInstance instantiate(Map<String, String> args) {
+        for (PromptArgument a : prompt.arguments()) {
+            if (a.required() && (args == null || !args.containsKey(a.name()))) {
+                throw new IllegalArgumentException("missing argument: " + a.name());
+            }
+        }
         List<PromptMessage> list = new ArrayList<>();
         for (PromptMessageTemplate t : messages) {
             list.add(new PromptMessage(t.role(), instantiate(t.content(), args)));

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -654,7 +654,7 @@ public final class McpServer implements AutoCloseable {
 
     private static PromptProvider createDefaultPrompts() {
         InMemoryPromptProvider p = new InMemoryPromptProvider();
-        PromptArgument arg = new PromptArgument("test_arg", null, null, false);
+        PromptArgument arg = new PromptArgument("test_arg", null, null, true);
         Prompt prompt = new Prompt("test_prompt", "Test Prompt", null, List.of(arg));
         PromptMessageTemplate msg = new PromptMessageTemplate(Role.USER, new PromptContent.Text("hello", null));
         p.add(new PromptTemplate(prompt, List.of(msg)));

--- a/src/test/java/com/amannmalik/mcp/McpProtocolIntegrationTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpProtocolIntegrationTest.java
@@ -207,10 +207,19 @@ class McpProtocolIntegrationTest {
         JsonRpcMessage promptGetResponse = testProtocolOperationWithTimeout(() -> client.request("prompts/get",
                 Json.createObjectBuilder()
                         .add("name", "test_prompt")
-                        .add("arguments", Json.createObjectBuilder().build())
+                        .add("arguments", Json.createObjectBuilder()
+                                .add("test_arg", "value")
+                                .build())
                         .build()), "prompts/get", 3000);
         JsonObject result = ((JsonRpcResponse) promptGetResponse).result();
         assertTrue(result.containsKey("messages"), "Prompt get should return messages");
+
+        JsonRpcMessage missingArgResponse = testProtocolOperationWithTimeout(() -> client.request("prompts/get",
+                Json.createObjectBuilder()
+                        .add("name", "test_prompt")
+                        .add("arguments", Json.createObjectBuilder().build())
+                        .build()), "prompts/get", 3000);
+        assertInstanceOf(JsonRpcError.class, missingArgResponse, "Missing arguments should return error");
     }
 
     private void testLoggingFeatures(DefaultMcpClient client) {


### PR DESCRIPTION
## Summary
- enforce required prompt arguments
- make default prompt argument required and update tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688913a8f4648324a62e6d5b0261e045