### PR TITLE
Implement ping monitoring

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -41,6 +41,9 @@ public final class HostProcess implements AutoCloseable {
             throw new IllegalArgumentException("Client already registered: " + id);
         }
         try {
+            if (client instanceof com.amannmalik.mcp.client.DefaultMcpClient dc) {
+                dc.configurePing(30000, 5000);
+            }
             client.connect();
         } catch (IOException e) {
             clients.remove(id);


### PR DESCRIPTION
## Summary
- add `configurePing` and periodic ping to `DefaultMcpClient`
- configure ping when host registers clients

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688918b6bf208324b990a1dec6b214ac