### PR TITLE
Use PaginationCodec for paginated server operations

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -6,6 +6,8 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
+import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.PaginatedResult;
 
 import java.util.Base64;
 
@@ -52,7 +54,7 @@ public final class PromptCodec {
         JsonArrayBuilder arr = Json.createArrayBuilder();
         page.prompts().forEach(p -> arr.add(toJsonObject(p)));
         JsonObjectBuilder builder = Json.createObjectBuilder().add("prompts", arr.build());
-        if (page.nextCursor() != null) builder.add("nextCursor", page.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
         return builder.build();
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -339,7 +339,7 @@ public final class McpServer implements AutoCloseable {
 
 
     private JsonRpcMessage listResources(JsonRpcRequest req) {
-        String cursor = req.params() == null ? null : req.params().getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
         ResourceList list;
         try {
             list = resources.list(cursor);
@@ -355,7 +355,7 @@ public final class McpServer implements AutoCloseable {
             if (allowed(r.annotations())) arr.add(ResourcesCodec.toJsonObject(r));
         }
         var b = Json.createObjectBuilder().add("resources", arr.build());
-        if (list.nextCursor() != null) b.add("nextCursor", list.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(list.nextCursor())).forEach(b::add);
         return new JsonRpcResponse(req.id(), b.build());
     }
 
@@ -388,7 +388,7 @@ public final class McpServer implements AutoCloseable {
     }
 
     private JsonRpcMessage listTemplates(JsonRpcRequest req) {
-        String cursor = req.params() == null ? null : req.params().getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
         ResourceTemplatePage page;
         try {
             page = resources.listTemplates(cursor);
@@ -404,7 +404,7 @@ public final class McpServer implements AutoCloseable {
             if (allowed(t.annotations())) arr.add(ResourcesCodec.toJsonObject(t));
         });
         var b = Json.createObjectBuilder().add("resourceTemplates", arr.build());
-        if (page.nextCursor() != null) b.add("nextCursor", page.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(b::add);
         return new JsonRpcResponse(req.id(), b.build());
     }
 
@@ -457,7 +457,7 @@ public final class McpServer implements AutoCloseable {
 
 
     private JsonRpcMessage listTools(JsonRpcRequest req) {
-        String cursor = req.params() == null ? null : req.params().getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
         ToolPage page;
         try {
             page = tools.list(cursor);
@@ -500,7 +500,7 @@ public final class McpServer implements AutoCloseable {
 
 
     private JsonRpcMessage listPrompts(JsonRpcRequest req) {
-        String cursor = req.params() == null ? null : req.params().getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
         PromptPage page;
         try {
             page = prompts.list(cursor);
@@ -511,7 +511,7 @@ public final class McpServer implements AutoCloseable {
         var arr = Json.createArrayBuilder();
         for (Prompt p : page.prompts()) arr.add(PromptCodec.toJsonObject(p));
         var builder = Json.createObjectBuilder().add("prompts", arr.build());
-        if (page.nextCursor() != null) builder.add("nextCursor", page.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
         return new JsonRpcResponse(req.id(), builder.build());
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -5,6 +5,9 @@ import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
+import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.PaginatedResult;
+
 
 public final class ToolCodec {
     private ToolCodec() {}
@@ -24,7 +27,7 @@ public final class ToolCodec {
         JsonArrayBuilder arr = Json.createArrayBuilder();
         page.tools().forEach(t -> arr.add(toJsonObject(t)));
         JsonObjectBuilder builder = Json.createObjectBuilder().add("tools", arr);
-        if (page.nextCursor() != null) builder.add("nextCursor", page.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
         return builder.build();
     }
 


### PR DESCRIPTION
## Summary
- use `PaginationCodec` in `McpServer` for list operations
- build paginated JSON via `PaginationCodec` in `ToolCodec` and `PromptCodec`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688919f7329c8324ac8e2a778ebf5af2