### PR TITLE
Add progress and logging notification handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/DefaultMcpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/DefaultMcpClient.java
@@ -33,6 +33,12 @@ import com.amannmalik.mcp.ping.PingCodec;
 import com.amannmalik.mcp.ping.PingResponse;
 import com.amannmalik.mcp.transport.Transport;
 import com.amannmalik.mcp.validation.SchemaValidator;
+import com.amannmalik.mcp.util.ProgressCodec;
+import com.amannmalik.mcp.util.ProgressListener;
+import com.amannmalik.mcp.util.ProgressNotification;
+import com.amannmalik.mcp.server.logging.LoggingCodec;
+import com.amannmalik.mcp.server.logging.LoggingListener;
+import com.amannmalik.mcp.server.logging.LoggingNotification;
 import jakarta.json.JsonObject;
 
 import java.io.IOException;
@@ -58,6 +64,8 @@ public final class DefaultMcpClient implements McpClient {
     private volatile boolean connected;
     private Set<ServerCapability> serverCapabilities = Set.of();
     private String instructions;
+    private ProgressListener progressListener = n -> {};
+    private LoggingListener loggingListener = n -> {};
 
     public DefaultMcpClient(ClientInfo info, Set<ClientCapability> capabilities, Transport transport) {
         this(info, capabilities, transport, null, null, null);
@@ -250,13 +258,11 @@ public final class DefaultMcpClient implements McpClient {
                 case JsonRpcRequest req -> {
                     try {
                         send(handleRequest(req));
-                    } catch (IOException e) {
-
+                    } catch (IOException ignore) {
                     }
                 }
+                case JsonRpcNotification note -> handleNotification(note);
                 default -> {
-
-
                 }
             }
         }
@@ -346,5 +352,29 @@ public final class DefaultMcpClient implements McpClient {
 
     private void send(JsonRpcMessage msg) throws IOException {
         transport.send(JsonRpcCodec.toJsonObject(msg));
+    }
+
+    public void setProgressListener(ProgressListener listener) {
+        progressListener = listener == null ? n -> {} : listener;
+    }
+
+    public void setLoggingListener(LoggingListener listener) {
+        loggingListener = listener == null ? n -> {} : listener;
+    }
+
+    private void handleNotification(JsonRpcNotification note) {
+        switch (note.method()) {
+            case "notifications/progress" -> {
+                if (note.params() != null) {
+                    progressListener.onProgress(ProgressCodec.toProgressNotification(note.params()));
+                }
+            }
+            case "notifications/message" -> {
+                if (note.params() != null) {
+                    loggingListener.onMessage(LoggingCodec.toLoggingNotification(note.params()));
+                }
+            }
+            default -> { }
+        }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingListener.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.server.logging;
+
+@FunctionalInterface
+public interface LoggingListener {
+    void onMessage(LoggingNotification notification);
+}

--- a/src/main/java/com/amannmalik/mcp/util/ProgressListener.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.util;
+
+@FunctionalInterface
+public interface ProgressListener {
+    void onProgress(ProgressNotification notification);
+}


### PR DESCRIPTION
## Summary
- add `ProgressListener` and `LoggingListener`
- update `DefaultMcpClient` to process server notifications

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688917af98748324b53df2c8f9865b3e