### PR TITLE
Fix spec utilities wiring

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -14,10 +14,14 @@ public final class RootsCodec {
     }
 
     public static JsonObject toJsonObject(ListRootsRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
         return Json.createObjectBuilder().build();
     }
 
     public static ListRootsRequest toListRootsRequest(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) {
+            throw new IllegalArgumentException("unexpected fields");
+        }
         return new ListRootsRequest();
     }
 
@@ -30,10 +34,14 @@ public final class RootsCodec {
     }
 
     public static JsonObject toJsonObject(RootsListChangedNotification n) {
+        if (n == null) throw new IllegalArgumentException("notification required");
         return Json.createObjectBuilder().build();
     }
 
     public static RootsListChangedNotification toRootsListChangedNotification(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) {
+            throw new IllegalArgumentException("unexpected fields");
+        }
         return new RootsListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
@@ -11,18 +11,22 @@ public final class PingCodec {
     }
 
     public static JsonRpcRequest toRequest(RequestId id) {
+        if (id == null) throw new IllegalArgumentException("id required");
         return new JsonRpcRequest(id, "ping", null);
     }
 
     public static PingRequest toPingRequest(JsonRpcRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
         return new PingRequest();
     }
 
     public static JsonRpcResponse toResponse(RequestId id) {
+        if (id == null) throw new IllegalArgumentException("id required");
         return new JsonRpcResponse(id, Json.createObjectBuilder().build());
     }
 
     public static PingResponse toPingResponse(JsonRpcResponse resp) {
+        if (resp == null) throw new IllegalArgumentException("response required");
         return new PingResponse();
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -60,10 +60,14 @@ public final class PromptCodec {
     }
 
     public static JsonObject toJsonObject(PromptsListChangedNotification n) {
+        if (n == null) throw new IllegalArgumentException("notification required");
         return Json.createObjectBuilder().build();
     }
 
     public static PromptsListChangedNotification toPromptsListChangedNotification(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) {
+            throw new IllegalArgumentException("unexpected fields");
+        }
         return new PromptsListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -127,10 +127,14 @@ public final class ResourcesCodec {
     }
 
     public static JsonObject toJsonObject(ResourceListChangedNotification n) {
+        if (n == null) throw new IllegalArgumentException("notification required");
         return Json.createObjectBuilder().build();
     }
 
     public static ResourceListChangedNotification toResourceListChangedNotification(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) {
+            throw new IllegalArgumentException("unexpected fields");
+        }
         return new ResourceListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -42,10 +42,14 @@ public final class ToolCodec {
     }
 
     public static JsonObject toJsonObject(ToolListChangedNotification n) {
+        if (n == null) throw new IllegalArgumentException("notification required");
         return Json.createObjectBuilder().build();
     }
 
     public static ToolListChangedNotification toToolListChangedNotification(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) {
+            throw new IllegalArgumentException("unexpected fields");
+        }
         return new ToolListChangedNotification();
     }
 


### PR DESCRIPTION
## Summary
- wire up codec classes for ping, prompts, resources, tools and roots
- validate parameters when converting to/from JSON

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688923f44268832485274d26943f5498