### PR TITLE
Fix mutable lists in memory providers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -15,9 +15,9 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     private final List<ResourceListListener> listListeners = new CopyOnWriteArrayList<>();
 
     public InMemoryResourceProvider(List<Resource> resources, Map<String, ResourceBlock> contents, List<ResourceTemplate> templates) {
-        this.resources = resources == null ? List.of() : List.copyOf(resources);
-        this.contents = contents == null ? Map.of() : Map.copyOf(contents);
-        this.templates = templates == null ? List.of() : List.copyOf(templates);
+        this.resources = resources == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(resources);
+        this.contents = contents == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(contents);
+        this.templates = templates == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(templates);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -7,6 +7,8 @@ import jakarta.json.JsonObject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
 
@@ -16,8 +18,8 @@ public final class InMemoryToolProvider implements ToolProvider {
     private final List<ToolListListener> listeners = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     public InMemoryToolProvider(List<Tool> tools, Map<String, Function<JsonObject, ToolResult>> handlers) {
-        this.tools = tools == null ? List.of() : List.copyOf(tools);
-        this.handlers = handlers == null ? Map.of() : Map.copyOf(handlers);
+        this.tools = tools == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(tools);
+        this.handlers = handlers == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(handlers);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- store modifiable lists and maps in `InMemoryResourceProvider`
- store modifiable lists and maps in `InMemoryToolProvider`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688923f44268832485274d26943f5498