### PR TITLE
fix HTTP header tolerance

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -159,7 +159,7 @@ public final class StreamableHttpTransport implements Transport {
             } else if (!session.equals(header)) {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
-            } else if (version == null || !version.equals(protocolVersion)) {
+            } else if (version != null && !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -241,7 +241,7 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
 
-            if (version == null || !version.equals(protocolVersion)) {
+            if (version != null && !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -320,7 +320,7 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
-            if (version == null || !version.equals(protocolVersion)) {
+            if (version != null && !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }


### PR DESCRIPTION
## Summary
- tolerate missing MCP-Protocol-Version header when HTTP session already negotiated version

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68892979d6048324b4de0746146b2d4d