### PR TITLE
Adjust SSE timeout

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -250,7 +250,8 @@ public final class StreamableHttpTransport implements Transport {
             resp.setHeader("Cache-Control", "no-cache");
             resp.flushBuffer();
             AsyncContext ac = req.startAsync();
-            ac.setTimeout(60000);
+            // Keep SSE connections open until explicitly closed
+            ac.setTimeout(0);
 
             String lastIdHeader = req.getHeader("Last-Event-ID");
             long lastId = -1;


### PR DESCRIPTION
## Summary
- keep the Streamable HTTP SSE connection open until explicitly closed

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68892979d6048324b4de0746146b2d4d