### PR TITLE
Add _meta support for tools

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -697,7 +697,7 @@ public final class McpServer implements AutoCloseable {
 
     private static ToolProvider createDefaultTools() {
         var schema = Json.createObjectBuilder().add("type", "object").build();
-        Tool tool = new Tool("test_tool", "Test Tool", null, schema, null, null);
+        Tool tool = new Tool("test_tool", "Test Tool", null, schema, null, null, null);
         return new InMemoryToolProvider(
                 List.of(tool),
                 Map.of("test_tool", a -> new ToolResult(

--- a/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.tools;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
 public record Tool(String name,
@@ -8,7 +9,8 @@ public record Tool(String name,
                    String description,
                    JsonObject inputSchema,
                    JsonObject outputSchema,
-                   ToolAnnotations annotations) {
+                   ToolAnnotations annotations,
+                   JsonObject _meta) {
     public Tool {
         name = InputSanitizer.requireClean(name);
         if (inputSchema == null) {
@@ -23,5 +25,6 @@ public record Tool(String name,
                         annotations.idempotentHint() == null &&
                         annotations.openWorldHint() == null
         ) ? null : annotations;
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -19,6 +19,7 @@ public final class ToolCodec {
         builder.add("inputSchema", tool.inputSchema());
         if (tool.outputSchema() != null) builder.add("outputSchema", tool.outputSchema());
         if (tool.annotations() != null) builder.add("annotations", toJsonObject(tool.annotations()));
+        if (tool._meta() != null) builder.add("_meta", tool._meta());
         return builder.build();
     }
 


### PR DESCRIPTION
## Summary
- support `_meta` metadata on `Tool`
- include metadata in `ToolCodec`
- adjust default tool setup for new record signature

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688930c940608324bd9e361546f26d82