### PR TITLE
Fix InMemoryResourceProvider resource null check

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -55,7 +55,10 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     public void addResource(Resource resource, ResourceBlock content) {
-        if (resource != null) resources.add(resource);
+        if (resource == null) {
+            throw new IllegalArgumentException("resource required");
+        }
+        resources.add(resource);
         if (content != null) contents.put(resource.uri(), content);
         notifyListListeners();
     }


### PR DESCRIPTION
## Summary
- guard against null resources when adding a resource

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688930e0421c8324a98b508a1b1aa51e