### PR TITLE
Fix SSE headers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -248,6 +248,7 @@ public final class StreamableHttpTransport implements Transport {
             resp.setStatus(HttpServletResponse.SC_OK);
             resp.setContentType("text/event-stream;charset=UTF-8");
             resp.setHeader("Cache-Control", "no-cache");
+            resp.setHeader(PROTOCOL_HEADER, protocolVersion);
             resp.flushBuffer();
             AsyncContext ac = req.startAsync();
             // Keep SSE connections open until explicitly closed


### PR DESCRIPTION
## Summary
- include the `MCP-Protocol-Version` header on SSE GET responses so clients know the negotiated version

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_688930e0421c8324a98b508a1b1aa51e