### PR TITLE
Fix _meta prefix rules

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -28,9 +28,14 @@ public final class MetaValidator {
         }
 
         if (prefix != null) {
-            for (String label : prefix.split("\\.")) {
+            String[] labels = prefix.split("\\.");
+            for (int i = 0; i < labels.length; i++) {
+                String label = labels[i];
                 if (!LABEL.matcher(label).matches()) {
                     throw new IllegalArgumentException("Invalid _meta prefix: " + key);
+                }
+                if (i < labels.length - 1 && ("mcp".equals(label) || "modelcontextprotocol".equals(label))) {
+                    throw new IllegalArgumentException("Reserved _meta prefix: " + prefix + "/");
                 }
             }
         }

--- a/src/test/java/com/amannmalik/mcp/MetaValidatorTest.java
+++ b/src/test/java/com/amannmalik/mcp/MetaValidatorTest.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp;
+
+import com.amannmalik.mcp.validation.MetaValidator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MetaValidatorTest {
+    @Test
+    void reservedPrefixRejected() {
+        assertThrows(IllegalArgumentException.class, () -> MetaValidator.requireValid("mcp.dev/foo"));
+        assertThrows(IllegalArgumentException.class, () -> MetaValidator.requireValid("api.modelcontextprotocol.org/bar"));
+    }
+
+    @Test
+    void nonReservedPrefixAccepted() {
+        assertDoesNotThrow(() -> MetaValidator.requireValid("mcp/foo"));
+        assertDoesNotThrow(() -> MetaValidator.requireValid("example.com/foo"));
+    }
+}


### PR DESCRIPTION
## Summary
- reserve `mcp` and `modelcontextprotocol` prefixes in `MetaValidator`
- add tests for `_meta` prefix validation

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688944e707408324ab8d6522ad6aa445