### PR TITLE
Fix tool call args and output schema enforcement

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -569,10 +569,19 @@ public final class McpServer implements AutoCloseable {
                     JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing params", null));
         }
         String name = params.getString("name", null);
-        JsonObject args = params.getJsonObject("arguments");
-        if (name == null || args == null) {
+        if (name == null) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
-                    JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing name or arguments", null));
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "name required", null));
+        }
+
+        jakarta.json.JsonValue argsVal = params.get("arguments");
+        JsonObject args = null;
+        if (argsVal != null) {
+            if (argsVal.getValueType() != jakarta.json.JsonValue.ValueType.OBJECT) {
+                return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                        JsonRpcErrorCode.INVALID_PARAMS.code(), "arguments must be object", null));
+            }
+            args = params.getJsonObject("arguments");
         }
         try {
             toolLimiter.requireAllowance(name);

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -38,7 +38,10 @@ public final class InMemoryToolProvider implements ToolProvider {
         JsonObject args = arguments == null ? Json.createObjectBuilder().build() : arguments;
         SchemaValidator.validate(tool.inputSchema(), args);
         ToolResult result = f.apply(args);
-        if (tool.outputSchema() != null && result.structuredContent() != null) {
+        if (tool.outputSchema() != null) {
+            if (result.structuredContent() == null) {
+                throw new IllegalStateException("structured result required");
+            }
             SchemaValidator.validate(tool.outputSchema(), result.structuredContent());
         }
         return result;

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -164,7 +164,6 @@ class McpConformanceTest {
 
             m = client.request("tools/call", Json.createObjectBuilder()
                     .add("name", "test_tool")
-                    .add("arguments", Json.createObjectBuilder().build())
                     .build());
             assertTrue(m instanceof JsonRpcResponse);
             var content = ((JsonRpcResponse) m).result()


### PR DESCRIPTION
## Summary
- accept missing `arguments` when calling tools
- enforce outputSchema expectation in the in-memory provider
- adjust conformance test for optional arguments

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889461d07dc83248ce84ec034843339