### PR TITLE
Refine lifecycle handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -191,7 +191,13 @@ public final class McpClient implements AutoCloseable {
         return instructions == null ? "" : instructions;
     }
 
+    private static final long DEFAULT_TIMEOUT = 30_000L;
+
     public PingResponse ping() throws IOException {
+        return ping(DEFAULT_TIMEOUT);
+    }
+
+    public PingResponse ping(long timeoutMillis) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
         RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
         CompletableFuture<JsonRpcMessage> future = new CompletableFuture<>();
@@ -204,7 +210,7 @@ public final class McpClient implements AutoCloseable {
         }
         JsonRpcMessage msg;
         try {
-            msg = future.get(30, java.util.concurrent.TimeUnit.SECONDS);
+            msg = future.get(timeoutMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
@@ -213,7 +219,7 @@ public final class McpClient implements AutoCloseable {
                 notify("notifications/cancelled", CancellationCodec.toJsonObject(new CancelledNotification(reqId, "timeout")));
             } catch (IOException ignore) {
             }
-            throw new IOException("Request timed out after 30 seconds");
+            throw new IOException("Request timed out after " + timeoutMillis + " ms");
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof IOException io) throw io;
@@ -231,6 +237,10 @@ public final class McpClient implements AutoCloseable {
     }
 
     public JsonRpcMessage request(String method, JsonObject params) throws IOException {
+        return request(method, params, DEFAULT_TIMEOUT);
+    }
+
+    public JsonRpcMessage request(String method, JsonObject params, long timeoutMillis) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
         RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
         CompletableFuture<JsonRpcMessage> future = new CompletableFuture<>();
@@ -242,7 +252,7 @@ public final class McpClient implements AutoCloseable {
             throw e;
         }
         try {
-            return future.get(30, java.util.concurrent.TimeUnit.SECONDS);
+            return future.get(timeoutMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
@@ -251,7 +261,7 @@ public final class McpClient implements AutoCloseable {
                 notify("notifications/cancelled", CancellationCodec.toJsonObject(new CancelledNotification(reqId, "timeout")));
             } catch (IOException ignore) {
             }
-            throw new IOException("Request timed out after 30 seconds");
+            throw new IOException("Request timed out after " + timeoutMillis + " ms");
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof IOException io) throw io;

--- a/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/LifecycleCodec.java
@@ -31,6 +31,12 @@ public final class LifecycleCodec {
     }
 
     public static InitializeRequest toInitializeRequest(JsonObject obj) {
+        if (!obj.containsKey("protocolVersion")) {
+            throw new IllegalArgumentException("protocolVersion required");
+        }
+        if (!obj.containsKey("protocolVersion")) {
+            throw new IllegalArgumentException("protocolVersion required");
+        }
         String version = obj.getString("protocolVersion");
         JsonObject capsObj = obj.getJsonObject("capabilities");
         Set<ClientCapability> client = EnumSet.noneOf(ClientCapability.class);
@@ -48,6 +54,9 @@ public final class LifecycleCodec {
                 server.isEmpty() ? Set.of() : EnumSet.copyOf(server)
         );
         JsonObject ci = obj.getJsonObject("clientInfo");
+        if (ci == null) {
+            throw new IllegalArgumentException("clientInfo required");
+        }
         ClientInfo info = new ClientInfo(
                 ci.getString("name"),
                 ci.containsKey("title") ? ci.getString("title") : null,
@@ -101,6 +110,9 @@ public final class LifecycleCodec {
                 server.isEmpty() ? Set.of() : EnumSet.copyOf(server)
         );
         JsonObject si = obj.getJsonObject("serverInfo");
+        if (si == null) {
+            throw new IllegalArgumentException("serverInfo required");
+        }
         ServerInfo info = new ServerInfo(
                 si.getString("name"),
                 si.containsKey("title") ? si.getString("title") : null,

--- a/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
@@ -14,7 +14,7 @@ public final class PingMonitor {
 
     public static boolean isAlive(McpClient client, long timeoutMillis) {
         ExecutorService exec = Executors.newSingleThreadExecutor();
-        Future<PingResponse> future = exec.submit(client::ping);
+        Future<PingResponse> future = exec.submit(() -> client.ping(timeoutMillis));
         try {
             future.get(timeoutMillis, TimeUnit.MILLISECONDS);
             return true;

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -5,6 +5,11 @@ import com.amannmalik.mcp.lifecycle.ClientCapability;
 import com.amannmalik.mcp.lifecycle.ClientInfo;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.transport.StdioTransport;
+import com.amannmalik.mcp.jsonrpc.JsonRpcCodec;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.RequestId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -114,7 +119,7 @@ class McpConformanceTest {
                     ServerCapability.COMPLETIONS
             );
             assertEquals(expected, client.serverCapabilities(), "Server capabilities should match");
-            assertDoesNotThrow(client::ping, "ping should succeed");
+            assertDoesNotThrow(() -> client.ping(), "ping should succeed");
 
             // TODO: Compactly test all features in various realistic MCP usage scenarios...
 
@@ -137,6 +142,36 @@ class McpConformanceTest {
                 if (!terminated) {
                     fail("Server process failed to terminate within 2 seconds");
                 }
+            }
+        }
+    }
+
+    @Test
+    void testRejectRequestBeforeInitialization() throws Exception {
+        ProcessBuilder serverBuilder = new ProcessBuilder(
+                JAVA_BIN, "-cp", System.getProperty("java.class.path"),
+                "com.amannmalik.mcp.Main", "server", "--stdio", "-v"
+        );
+        Process serverProcess = serverBuilder.start();
+        try {
+            long endTime = System.currentTimeMillis() + 500;
+            while (!serverProcess.isAlive() && System.currentTimeMillis() < endTime) {
+                Thread.sleep(10);
+            }
+            StdioTransport transport = new StdioTransport(
+                    serverProcess.getInputStream(),
+                    serverProcess.getOutputStream()
+            );
+            JsonRpcRequest req = new JsonRpcRequest(
+                    new RequestId.NumericId(1), "roots/list", null);
+            transport.send(JsonRpcCodec.toJsonObject(req));
+            JsonRpcMessage msg = JsonRpcCodec.fromJsonObject(transport.receive());
+            assertTrue(msg instanceof JsonRpcError);
+            assertEquals(-32000, ((JsonRpcError) msg).error().code());
+        } finally {
+            if (serverProcess.isAlive()) {
+                serverProcess.destroyForcibly();
+                serverProcess.waitFor(2, TimeUnit.SECONDS);
             }
         }
     }


### PR DESCRIPTION
## Summary
- tighten initialization lifecycle checks
- validate required fields in lifecycle codec helpers
- allow configurable timeouts for client and server requests
- forward ping timeouts through PingMonitor
- test pre-initialization request rejection

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6889458228688324b570c5b89f00f4af