### PR TITLE
Enforce access check on resource subscriptions

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -501,6 +501,15 @@ public final class McpServer implements AutoCloseable {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
         }
+        ResourceBlock existing = resources.read(uri);
+        if (existing == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    -32002, "Resource not found", Json.createObjectBuilder().add("uri", uri).build()));
+        }
+        if (!allowed(existing.annotations())) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), "Access denied", null));
+        }
         try {
             ResourceSubscription sub = resources.subscribe(uri, update -> {
                 try {


### PR DESCRIPTION
## Summary
- validate resource existence and permissions when handling `resources/subscribe`

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6889460ec44483248d8c6b8ee8be6ee6