### PR TITLE
Implement server-side cancellation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -402,6 +402,11 @@ public final class McpServer implements AutoCloseable {
         if (token != null) {
             progressTracker.release(token);
         }
+        try {
+            sendLog(LoggingLevel.INFO, "cancellation",
+                    cn.reason() == null ? jakarta.json.JsonValue.NULL : Json.createValue(cn.reason()));
+        } catch (IOException ignore) {
+        }
     }
 
     private void cleanup(RequestId id) {
@@ -691,6 +696,12 @@ public final class McpServer implements AutoCloseable {
             if (cause instanceof IOException io) throw io;
             throw new IOException(cause);
         } catch (java.util.concurrent.TimeoutException e) {
+            try {
+                send(new JsonRpcNotification(
+                        "notifications/cancelled",
+                        CancellationCodec.toJsonObject(new CancelledNotification(id, "timeout"))));
+            } catch (IOException ignore) {
+            }
             throw new IOException("Request timed out after 30 seconds");
         } finally {
             pending.remove(id);


### PR DESCRIPTION
## Summary
- send `notifications/cancelled` when server request times out
- log cancellation reasons

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889467394488324b89c8c3ef5daa924