### PR TITLE
Fix progress token validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -381,8 +381,14 @@ public final class McpServer implements AutoCloseable {
         var val = meta.get("progressToken");
         return switch (val.getValueType()) {
             case STRING -> new ProgressToken.StringToken(meta.getString("progressToken"));
-            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").doubleValue());
-            default -> null;
+            case NUMBER -> {
+                var num = meta.getJsonNumber("progressToken");
+                if (!num.isIntegral()) {
+                    throw new IllegalArgumentException("progressToken must be an integer");
+                }
+                yield new ProgressToken.NumericToken(num.longValue());
+            }
+            default -> throw new IllegalArgumentException("progressToken must be a string or integer");
         };
     }
 

--- a/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
@@ -34,7 +34,13 @@ public final class ProgressCodec {
     private static ProgressToken toToken(JsonValue value) {
         return switch (value.getValueType()) {
             case STRING -> new ProgressToken.StringToken(((JsonString) value).getString());
-            case NUMBER -> new ProgressToken.NumericToken(((JsonNumber) value).doubleValue());
+            case NUMBER -> {
+                JsonNumber n = (JsonNumber) value;
+                if (!n.isIntegral()) {
+                    throw new IllegalArgumentException("progressToken must be an integer");
+                }
+                yield new ProgressToken.NumericToken(n.longValue());
+            }
             default -> throw new IllegalArgumentException("Invalid token type");
         };
     }

--- a/src/main/java/com/amannmalik/mcp/util/ProgressToken.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressToken.java
@@ -4,6 +4,6 @@ public sealed interface ProgressToken permits ProgressToken.StringToken, Progres
     record StringToken(String value) implements ProgressToken {
     }
 
-    record NumericToken(double value) implements ProgressToken {
+    record NumericToken(long value) implements ProgressToken {
     }
 }


### PR DESCRIPTION
## Summary
- enforce integer progress tokens in server and codec
- model numeric progress tokens as a `long`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889467f995c8324abd3b47a2d0fd6ce