### PR TITLE
Implement sampling annotations

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/Annotations.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/Annotations.java
@@ -1,0 +1,21 @@
+package com.amannmalik.mcp.client.sampling;
+
+import com.amannmalik.mcp.prompts.Role;
+
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.Set;
+
+public record Annotations(Set<Role> audience, Double priority, Instant lastModified) {
+    public Annotations {
+        audience = audience == null || audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience);
+        if (priority != null && (priority < 0.0 || priority > 1.0)) {
+            throw new IllegalArgumentException("priority must be between 0.0 and 1.0");
+        }
+    }
+
+    @Override
+    public Set<Role> audience() {
+        return Set.copyOf(audience);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageResponse.java
@@ -9,8 +9,8 @@ public record CreateMessageResponse(
         String stopReason
 ) {
     public CreateMessageResponse {
-        if (role == null || content == null) {
-            throw new IllegalArgumentException("role and content are required");
+        if (role == null || content == null || model == null) {
+            throw new IllegalArgumentException("role, content, and model are required");
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
@@ -2,10 +2,13 @@ package com.amannmalik.mcp.client.sampling;
 
 public sealed interface MessageContent permits MessageContent.Text, MessageContent.Image, MessageContent.Audio {
     String type();
+    Annotations annotations();
+    jakarta.json.JsonObject _meta();
 
-    record Text(String text) implements MessageContent {
+    record Text(String text, Annotations annotations, jakarta.json.JsonObject _meta) implements MessageContent {
         public Text {
             if (text == null) throw new IllegalArgumentException("text is required");
+            com.amannmalik.mcp.validation.MetaValidator.requireValid(_meta);
         }
 
         @Override
@@ -14,12 +17,13 @@ public sealed interface MessageContent permits MessageContent.Text, MessageConte
         }
     }
 
-    record Image(byte[] data, String mimeType) implements MessageContent {
+    record Image(byte[] data, String mimeType, Annotations annotations, jakarta.json.JsonObject _meta) implements MessageContent {
         public Image {
             if (data == null || mimeType == null) {
                 throw new IllegalArgumentException("data and mimeType are required");
             }
             data = data.clone();
+            com.amannmalik.mcp.validation.MetaValidator.requireValid(_meta);
         }
 
         @Override
@@ -28,12 +32,13 @@ public sealed interface MessageContent permits MessageContent.Text, MessageConte
         }
     }
 
-    record Audio(byte[] data, String mimeType) implements MessageContent {
+    record Audio(byte[] data, String mimeType, Annotations annotations, jakarta.json.JsonObject _meta) implements MessageContent {
         public Audio {
             if (data == null || mimeType == null) {
                 throw new IllegalArgumentException("data and mimeType are required");
             }
             data = data.clone();
+            com.amannmalik.mcp.validation.MetaValidator.requireValid(_meta);
         }
 
         @Override

--- a/src/test/java/com/amannmalik/mcp/SamplingCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/SamplingCodecTest.java
@@ -1,0 +1,38 @@
+package com.amannmalik.mcp;
+
+import com.amannmalik.mcp.client.sampling.*;
+import com.amannmalik.mcp.prompts.Role;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SamplingCodecTest {
+
+    @Test
+    void testContentRoundTrip() {
+        Annotations ann = new Annotations(Set.of(Role.USER), 0.5, Instant.parse("2025-01-01T00:00:00Z"));
+        JsonObject meta = Json.createObjectBuilder().add("a", 1).build();
+        MessageContent.Text content = new MessageContent.Text("hi", ann, meta);
+        CreateMessageResponse resp = new CreateMessageResponse(Role.ASSISTANT, content, "model", null);
+        CreateMessageResponse out = SamplingCodec.toCreateMessageResponse(SamplingCodec.toJsonObject(resp));
+        assertEquals(resp, out);
+    }
+
+    @Test
+    void testResponseModelRequired() {
+        MessageContent.Text content = new MessageContent.Text("hi", null, null);
+        CreateMessageResponse resp = new CreateMessageResponse(Role.ASSISTANT, content, "m", null);
+        JsonObject obj = SamplingCodec.toJsonObject(resp);
+        assertEquals("m", obj.getString("model"));
+        JsonObject noModel = Json.createObjectBuilder()
+                .add("role", obj.getString("role"))
+                .add("content", obj.getJsonObject("content"))
+                .build();
+        assertThrows(IllegalArgumentException.class, () -> SamplingCodec.toCreateMessageResponse(noModel));
+    }
+}


### PR DESCRIPTION
## Summary
- support per-message annotations and metadata per sampling spec
- enforce mandatory `model` field in sampling responses
- test new sampling codec behavior

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688946447878832487e30c678e9f7312