### PR TITLE
Implement ping response validation and client handler

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -312,6 +312,7 @@ public final class McpClient implements AutoCloseable {
             case "sampling/createMessage" -> handleCreateMessage(req);
             case "roots/list" -> handleListRoots(req);
             case "elicitation/create" -> handleElicit(req);
+            case "ping" -> handlePing(req);
             default -> new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.METHOD_NOT_FOUND.code(),
                     "Unknown method: " + req.method(), null));
@@ -386,6 +387,16 @@ public final class McpClient implements AutoCloseable {
         } catch (Exception e) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
+    }
+
+    private JsonRpcMessage handlePing(JsonRpcRequest req) {
+        try {
+            PingCodec.toPingRequest(req);
+            return PingCodec.toResponse(req.id());
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
         }
     }
 

--- a/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
@@ -16,6 +16,9 @@ public final class PingCodec {
 
     public static PingRequest toPingRequest(JsonRpcRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
+        if (req.params() != null && !req.params().isEmpty()) {
+            throw new IllegalArgumentException("no params expected");
+        }
         return new PingRequest();
     }
 
@@ -26,6 +29,9 @@ public final class PingCodec {
 
     public static PingResponse toPingResponse(JsonRpcResponse resp) {
         if (resp == null) throw new IllegalArgumentException("response required");
+        if (resp.result() == null || !resp.result().isEmpty()) {
+            throw new IllegalArgumentException("expected empty result");
+        }
         return new PingResponse();
     }
 }


### PR DESCRIPTION
## Summary
- validate no params for `ping` requests and enforce empty results
- support server-initiated `ping` requests on the client

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68894688306083248c51c0a65659314e