### PR TITLE
Handle tool listChanged capability

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -112,6 +112,7 @@ public final class McpServer implements AutoCloseable {
     private ResourceListSubscription resourceListSubscription;
     private ToolListSubscription toolListSubscription;
     private PromptsSubscription promptsSubscription;
+    private final boolean toolListChangedSupported;
     private final ResourceAccessController resourceAccess;
     private final Principal principal;
     private volatile LoggingLevel logLevel = LoggingLevel.INFO;
@@ -161,6 +162,7 @@ public final class McpServer implements AutoCloseable {
         this.completions = completions;
         this.resourceAccess = resourceAccess;
         this.principal = principal;
+        this.toolListChangedSupported = tools.supportsListChanged();
 
         try {
             resourceListSubscription = resources.subscribeList(() -> {
@@ -172,14 +174,16 @@ public final class McpServer implements AutoCloseable {
         } catch (Exception ignore) {
         }
 
-        try {
-            toolListSubscription = tools.subscribeList(() -> {
-                try {
-                    send(new JsonRpcNotification("notifications/tools/list_changed", null));
-                } catch (IOException ignore) {
-                }
-            });
-        } catch (Exception ignore) {
+        if (toolListChangedSupported) {
+            try {
+                toolListSubscription = tools.subscribeList(() -> {
+                    try {
+                        send(new JsonRpcNotification("notifications/tools/list_changed", null));
+                    } catch (IOException ignore) {
+                    }
+                });
+            } catch (Exception ignore) {
+            }
         }
 
         try {
@@ -345,7 +349,23 @@ public final class McpServer implements AutoCloseable {
     private JsonRpcMessage initialize(JsonRpcRequest req) {
         InitializeRequest init = LifecycleCodec.toInitializeRequest(req.params());
         InitializeResponse resp = lifecycle.initialize(init);
-        return new JsonRpcResponse(req.id(), LifecycleCodec.toJsonObject(resp));
+        var json = LifecycleCodec.toJsonObject(resp);
+        if (!toolListChangedSupported) {
+            var caps = json.getJsonObject("capabilities");
+            if (caps != null && caps.containsKey("tools")) {
+                var toolsCaps = caps.getJsonObject("tools");
+                toolsCaps = jakarta.json.Json.createObjectBuilder(toolsCaps)
+                        .add("listChanged", false)
+                        .build();
+                caps = jakarta.json.Json.createObjectBuilder(caps)
+                        .add("tools", toolsCaps)
+                        .build();
+                json = jakarta.json.Json.createObjectBuilder(json)
+                        .add("capabilities", caps)
+                        .build();
+            }
+        }
+        return new JsonRpcResponse(req.id(), json);
     }
 
     private void initialized(JsonRpcNotification ignored) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -53,6 +53,11 @@ public final class InMemoryToolProvider implements ToolProvider {
         return () -> listeners.remove(listener);
     }
 
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
     public void addTool(Tool tool, Function<JsonObject, ToolResult> handler) {
         tools.add(tool);
         if (handler != null) handlers.put(tool.name(), handler);

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
@@ -11,4 +11,11 @@ public interface ToolProvider {
         return () -> {
         };
     }
+
+    /**
+     * Whether {@link #subscribeList(ToolListListener)} delivers notifications.
+     */
+    default boolean supportsListChanged() {
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- add `supportsListChanged()` API for ToolProvider
- advertise `tools` capability accurately based on provider support
- subscribe to tool list changes only when supported

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_6889478e79a883249e48e197cc3534aa