### PR TITLE
Fix Elicitation request handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationRequest.java
@@ -5,11 +5,12 @@ import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.JsonObject;
 
 public record ElicitationRequest(String message, JsonObject requestedSchema) {
-    public ElicitationRequest {
+    public ElicitationRequest(String message, JsonObject requestedSchema) {
         if (message == null || requestedSchema == null) {
             throw new IllegalArgumentException("message and requestedSchema are required");
         }
-        message = InputSanitizer.requireClean(message);
+        this.message = InputSanitizer.requireClean(message);
         ElicitationSchemaValidator.requireValid(requestedSchema);
+        this.requestedSchema = requestedSchema;
     }
 }


### PR DESCRIPTION
## Summary
- sanitize and store message in `ElicitationRequest`
- validate fields when decoding `Elicitation` requests and responses

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68894c5c59d0832499af87266db60eaa