### PR TITLE
Improve capability negotiation features

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/InMemoryRootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/InMemoryRootsProvider.java
@@ -22,6 +22,11 @@ public final class InMemoryRootsProvider implements RootsProvider {
         return () -> listeners.remove(listener);
     }
 
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
     public void add(Root root) {
         roots.add(root);
         notifyListeners();

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsProvider.java
@@ -11,4 +11,8 @@ public interface RootsProvider extends AutoCloseable {
     @Override
     default void close() {
     }
+
+    default boolean supportsListChanged() {
+        return false;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -47,6 +47,11 @@ public final class InMemoryPromptProvider implements PromptProvider {
         return () -> listeners.remove(listener);
     }
 
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
     private void notifyListeners() {
         listeners.forEach(PromptsListener::listChanged);
     }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
@@ -11,4 +11,8 @@ public interface PromptProvider {
         return () -> {
         };
     }
+
+    default boolean supportsListChanged() {
+        return false;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -49,6 +49,16 @@ public final class InMemoryResourceProvider implements ResourceProvider {
         return () -> listListeners.remove(listener);
     }
 
+    @Override
+    public boolean supportsSubscribe() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
     public void notifyUpdate(String uri, String title) {
         ResourceUpdate update = new ResourceUpdate(uri, title);
         listeners.getOrDefault(uri, List.of()).forEach(l -> l.updated(update));

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -14,6 +14,14 @@ public interface ResourceProvider extends AutoCloseable {
         };
     }
 
+    default boolean supportsSubscribe() {
+        return true;
+    }
+
+    default boolean supportsListChanged() {
+        return false;
+    }
+
     @Override
     default void close() {
     }


### PR DESCRIPTION
## Summary
- expand provider interfaces with optional feature checks
- advertise capability features accurately when initializing
- respect roots `listChanged` when notifying servers

## Testing
- `bash verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68894c8d17788324b133723150f69c27