### PR TITLE
Fix logging notifications handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -438,7 +438,10 @@ public final class McpClient implements AutoCloseable {
             }
             case "notifications/message" -> {
                 if (note.params() != null) {
-                    loggingListener.onMessage(LoggingCodec.toLoggingNotification(note.params()));
+                    try {
+                        loggingListener.onMessage(LoggingCodec.toLoggingNotification(note.params()));
+                    } catch (IllegalArgumentException ignore) {
+                    }
                 }
             }
             default -> {


### PR DESCRIPTION
## Summary
- avoid crashing client if server sends malformed logging messages

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68894cfde5788324987418c01c1f7cff