### PR TITLE
Improve logging codec validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingLevel.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingLevel.java
@@ -8,5 +8,14 @@ public enum LoggingLevel {
     ERROR,
     CRITICAL,
     ALERT,
-    EMERGENCY
+    EMERGENCY;
+
+    public static LoggingLevel fromString(String raw) {
+        if (raw == null) throw new IllegalArgumentException("level required");
+        try {
+            return valueOf(raw.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("invalid level", e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- validate logging level strings centrally via `LoggingLevel.fromString`
- enforce required fields and type checks when decoding logging messages

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68894cfde5788324987418c01c1f7cff