### PR TITLE
Harden completion requests

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.completion;
 
+import com.amannmalik.mcp.validation.InputSanitizer;
 import java.util.Map;
 
 public record CompleteRequest(
@@ -18,12 +19,22 @@ public record CompleteRequest(
             if (name == null || value == null) {
                 throw new IllegalArgumentException("name and value are required");
             }
+            name = InputSanitizer.requireClean(name);
+            value = InputSanitizer.requireClean(value);
         }
     }
 
     public record Context(Map<String, String> arguments) {
         public Context {
-            arguments = arguments == null ? Map.of() : Map.copyOf(arguments);
+            if (arguments == null || arguments.isEmpty()) {
+                arguments = Map.of();
+            } else {
+                Map<String, String> copy = new java.util.HashMap<>();
+                arguments.forEach((k, v) -> {
+                    copy.put(InputSanitizer.requireClean(k), InputSanitizer.requireClean(v));
+                });
+                arguments = Map.copyOf(copy);
+            }
         }
 
         @Override
@@ -38,6 +49,7 @@ public record CompleteRequest(
         record PromptRef(String name) implements Ref {
             public PromptRef {
                 if (name == null) throw new IllegalArgumentException("name required");
+                name = InputSanitizer.requireClean(name);
             }
 
             @Override
@@ -49,6 +61,7 @@ public record CompleteRequest(
         record ResourceRef(String uri) implements Ref {
             public ResourceRef {
                 if (uri == null) throw new IllegalArgumentException("uri required");
+                uri = InputSanitizer.requireClean(uri);
             }
 
             @Override

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.completion;
 
+import com.amannmalik.mcp.validation.InputSanitizer;
 import java.util.List;
 
 public record CompleteResult(Completion completion) {
@@ -9,7 +10,13 @@ public record CompleteResult(Completion completion) {
 
     public record Completion(List<String> values, Integer total, Boolean hasMore) {
         public Completion {
-            values = values == null ? List.of() : List.copyOf(values);
+            if (values == null || values.isEmpty()) {
+                values = List.of();
+            } else {
+                values = values.stream()
+                        .map(InputSanitizer::requireClean)
+                        .toList();
+            }
         }
 
         @Override


### PR DESCRIPTION
## Summary
- sanitize completion request fields
- sanitize completion suggestions
- validate completion context and error on unknown refs

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68894cf616bc83248d88f12d30b36f84