### PR TITLE
Improve pagination stability

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/Pagination.java
+++ b/src/main/java/com/amannmalik/mcp/util/Pagination.java
@@ -8,27 +8,42 @@ public final class Pagination {
     }
 
     public static <T> Page<T> page(List<T> items, String cursor, int size) {
-        int start = decode(cursor);
+        return page(items, cursor, size, -1L);
+    }
+
+    public static <T> Page<T> page(List<T> items, String cursor, int size, long version) {
+        Token t = decode(cursor);
+        if (version >= 0 && t.version >= 0 && t.version != version) {
+            throw new IllegalArgumentException("Invalid cursor");
+        }
+        int start = t.index;
         if (start < 0 || start > items.size()) throw new IllegalArgumentException("Invalid cursor");
         int end = Math.min(items.size(), start + size);
         List<T> slice = items.subList(start, end);
-        String next = end < items.size() ? encode(end) : null;
+        String next = end < items.size() ? encode(version, end) : null;
         return new Page<>(List.copyOf(slice), next);
     }
 
-    private static String encode(int index) {
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(Integer.toString(index).getBytes());
+    private static String encode(long version, int index) {
+        String raw = version >= 0 ? version + ":" + index : Integer.toString(index);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes());
     }
 
-    private static int decode(String cursor) {
-        if (cursor == null) return 0;
+    private static Token decode(String cursor) {
+        if (cursor == null) return new Token(-1L, 0);
         try {
             String s = new String(Base64.getUrlDecoder().decode(cursor));
-            return Integer.parseInt(s);
+            int colon = s.indexOf(':');
+            if (colon < 0) return new Token(-1L, Integer.parseInt(s));
+            long v = Long.parseLong(s.substring(0, colon));
+            int idx = Integer.parseInt(s.substring(colon + 1));
+            return new Token(v, idx);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid cursor");
         }
     }
+
+    private record Token(long version, int index) {}
 
     public record Page<T>(List<T> items, String nextCursor) {
         public Page {


### PR DESCRIPTION
## Summary
- make pagination cursors encode versioned offsets
- track list changes in in-memory providers and invalidate cursors when lists change

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_68894ce5f6cc83248481e4f210751b5b