### PR TITLE
Implement optional resources subscription features

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -49,6 +49,16 @@ public final class InMemoryResourceProvider implements ResourceProvider {
         return () -> listListeners.remove(listener);
     }
 
+    @Override
+    public boolean supportsSubscribe() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
     public void notifyUpdate(String uri, String title) {
         ResourceUpdate update = new ResourceUpdate(uri, title);
         listeners.getOrDefault(uri, List.of()).forEach(l -> l.updated(update));

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -9,9 +9,23 @@ public interface ResourceProvider extends AutoCloseable {
 
     ResourceSubscription subscribe(String uri, ResourceListener listener);
 
+    /**
+     * Whether {@link #subscribe(String, ResourceListener)} is supported.
+     */
+    default boolean supportsSubscribe() {
+        return false;
+    }
+
     default ResourceListSubscription subscribeList(ResourceListListener listener) {
         return () -> {
         };
+    }
+
+    /**
+     * Whether {@link #subscribeList(ResourceListListener)} delivers notifications.
+     */
+    default boolean supportsListChanged() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add `supportsSubscribe` and `supportsListChanged` to `ResourceProvider`
- implement these capabilities for `InMemoryResourceProvider`
- expose optional resource subscription/listChanged support in `McpServer`
- advertise capabilities correctly and register handlers conditionally
- guard subscribe/unsubscribe handlers when unsupported

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68894dca0b688324960c35f7baf0338a