### PR TITLE
Fix prompt listChanged capability

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -47,6 +47,11 @@ public final class InMemoryPromptProvider implements PromptProvider {
         return () -> listeners.remove(listener);
     }
 
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
     private void notifyListeners() {
         listeners.forEach(PromptsListener::listChanged);
     }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
@@ -11,4 +11,11 @@ public interface PromptProvider {
         return () -> {
         };
     }
+
+    /**
+     * Whether {@link #subscribe(PromptsListener)} delivers notifications.
+     */
+    default boolean supportsListChanged() {
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- allow prompts providers to declare listChanged support
- expose provider capability to `McpServer`
- only subscribe/send prompt list change notifications when supported
- advertise `prompts.listChanged` capability accurately

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68894dd277388324bf4847ae5e61621d