### PR TITLE
Handle version mismatch and fix SSE send

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -20,13 +20,13 @@ public class ProtocolLifecycle {
         clientCapabilities = requested.isEmpty()
                 ? EnumSet.noneOf(ClientCapability.class)
                 : EnumSet.copyOf(requested);
-        String negotiatedVersion = request.protocolVersion();
         if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
-            negotiatedVersion = SUPPORTED_VERSION;
+            throw new UnsupportedProtocolVersionException(
+                    request.protocolVersion(), SUPPORTED_VERSION);
         }
 
         return new InitializeResponse(
-                negotiatedVersion,
+                SUPPORTED_VERSION,
                 new Capabilities(clientCapabilities, serverCapabilities),
                 new ServerInfo("mcp-java", "MCP Java Reference", "0.1.0"),
                 null

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -76,7 +76,7 @@ public final class StreamableHttpTransport implements Transport {
         if (id != null) {
             SseClient stream = requestStreams.get(id);
             if (stream != null) {
-                stream.send(message, nextEventId.getAndIncrement());
+                stream.send(message);
                 if (method == null) {
                     stream.close();
                     requestStreams.remove(id);
@@ -136,7 +136,7 @@ public final class StreamableHttpTransport implements Transport {
                                     JsonRpcErrorCode.INTERNAL_ERROR.code(),
                                     "Transport closed",
                                     null));
-                    client.send(JsonRpcCodec.toJsonObject(err), nextEventId.getAndIncrement());
+                    client.send(JsonRpcCodec.toJsonObject(err));
                     client.close();
                 } catch (Exception ignore) {
                 }


### PR DESCRIPTION
## Summary
- enforce protocol version check during initialization
- surface unsupported version as JSON-RPC error
- correct HTTP transport SSE send implementation

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_688953585ca88324b54b540787cf2fea