### PR TITLE
Fix resources codec and SSE transport

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -87,14 +87,16 @@ public final class ResourcesCodec {
         String mime = obj.getString("mimeType", null);
         ResourceAnnotations ann = obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null;
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
-        if (obj.containsKey("text")) {
+        boolean hasText = obj.containsKey("text");
+        boolean hasBlob = obj.containsKey("blob");
+        if (hasText == hasBlob) {
+            throw new IllegalArgumentException("exactly one of text or blob must be present");
+        }
+        if (hasText) {
             return new ResourceBlock.Text(uri, name, title, mime, obj.getString("text"), ann, meta);
         }
-        if (obj.containsKey("blob")) {
-            byte[] data = Base64.getDecoder().decode(obj.getString("blob"));
-            return new ResourceBlock.Binary(uri, name, title, mime, data, ann, meta);
-        }
-        throw new IllegalArgumentException("unknown content block");
+        byte[] data = Base64.getDecoder().decode(obj.getString("blob"));
+        return new ResourceBlock.Binary(uri, name, title, mime, data, ann, meta);
     }
 
     public static JsonObject toJsonObject(ResourceAnnotations ann) {

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -76,7 +76,7 @@ public final class StreamableHttpTransport implements Transport {
         if (id != null) {
             SseClient stream = requestStreams.get(id);
             if (stream != null) {
-                stream.send(message, nextEventId.getAndIncrement());
+                stream.send(message);
                 if (method == null) {
                     stream.close();
                     requestStreams.remove(id);
@@ -136,7 +136,7 @@ public final class StreamableHttpTransport implements Transport {
                                     JsonRpcErrorCode.INTERNAL_ERROR.code(),
                                     "Transport closed",
                                     null));
-                    client.send(JsonRpcCodec.toJsonObject(err), nextEventId.getAndIncrement());
+                    client.send(JsonRpcCodec.toJsonObject(err));
                     client.close();
                 } catch (Exception ignore) {
                 }


### PR DESCRIPTION
## Summary
- enforce single content block type when decoding resources
- remove invalid event id argument from SSE transport

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889536941408324926b19777127a1f6