### PR TITLE
Fix prompts meta fields

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
@@ -1,6 +1,8 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
 import java.util.List;
 
@@ -8,12 +10,14 @@ public record Prompt(
         String name,
         String title,
         String description,
-        List<PromptArgument> arguments
+        List<PromptArgument> arguments,
+        JsonObject _meta
 ) {
     public Prompt {
         name = InputSanitizer.requireClean(name);
         arguments = arguments == null || arguments.isEmpty() ? List.of() : List.copyOf(arguments);
         title = title == null ? null : InputSanitizer.requireClean(title);
         description = description == null ? null : InputSanitizer.requireClean(description);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
@@ -1,16 +1,20 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
 public record PromptArgument(
         String name,
         String title,
         String description,
-        boolean required
+        boolean required,
+        JsonObject _meta
 ) {
     public PromptArgument {
         name = InputSanitizer.requireClean(name);
         title = title == null ? null : InputSanitizer.requireClean(title);
         description = description == null ? null : InputSanitizer.requireClean(description);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -23,6 +23,7 @@ public final class PromptCodec {
                 .add("name", prompt.name());
         if (prompt.title() != null) builder.add("title", prompt.title());
         if (prompt.description() != null) builder.add("description", prompt.description());
+        if (prompt._meta() != null) builder.add("_meta", prompt._meta());
         if (!prompt.arguments().isEmpty()) {
             JsonArrayBuilder args = Json.createArrayBuilder();
             for (PromptArgument a : prompt.arguments()) {
@@ -30,6 +31,7 @@ public final class PromptCodec {
                 if (a.title() != null) ab.add("title", a.title());
                 if (a.description() != null) ab.add("description", a.description());
                 if (a.required()) ab.add("required", true);
+                if (a._meta() != null) ab.add("_meta", a._meta());
                 args.add(ab.build());
             }
             builder.add("arguments", args.build());
@@ -75,6 +77,7 @@ public final class PromptCodec {
         if (content.annotations() != null) {
             b.add("annotations", ResourcesCodec.toJsonObject(content.annotations()));
         }
+        if (content._meta() != null) b.add("_meta", content._meta());
         switch (content) {
             case PromptContent.Text t -> b.add("text", t.text());
             case PromptContent.Image i -> b.add("data", Base64.getEncoder().encodeToString(i.data()))

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptContent.java
@@ -4,6 +4,8 @@ import com.amannmalik.mcp.server.resources.Resource;
 import com.amannmalik.mcp.server.resources.ResourceAnnotations;
 import com.amannmalik.mcp.server.resources.ResourceBlock;
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
 public sealed interface PromptContent
         permits PromptContent.Text,
@@ -15,10 +17,13 @@ public sealed interface PromptContent
 
     ResourceAnnotations annotations();
 
-    record Text(String text, ResourceAnnotations annotations) implements PromptContent {
+    JsonObject _meta();
+
+    record Text(String text, ResourceAnnotations annotations, JsonObject _meta) implements PromptContent {
         public Text {
             if (text == null) throw new IllegalArgumentException("text is required");
             text = InputSanitizer.requireClean(text);
+            MetaValidator.requireValid(_meta);
         }
 
         @Override
@@ -27,13 +32,14 @@ public sealed interface PromptContent
         }
     }
 
-    record Image(byte[] data, String mimeType, ResourceAnnotations annotations) implements PromptContent {
+    record Image(byte[] data, String mimeType, ResourceAnnotations annotations, JsonObject _meta) implements PromptContent {
         public Image {
             if (data == null || mimeType == null) {
                 throw new IllegalArgumentException("data and mimeType are required");
             }
             data = data.clone();
             mimeType = InputSanitizer.requireClean(mimeType);
+            MetaValidator.requireValid(_meta);
         }
 
         @Override
@@ -42,13 +48,14 @@ public sealed interface PromptContent
         }
     }
 
-    record Audio(byte[] data, String mimeType, ResourceAnnotations annotations) implements PromptContent {
+    record Audio(byte[] data, String mimeType, ResourceAnnotations annotations, JsonObject _meta) implements PromptContent {
         public Audio {
             if (data == null || mimeType == null) {
                 throw new IllegalArgumentException("data and mimeType are required");
             }
             data = data.clone();
             mimeType = InputSanitizer.requireClean(mimeType);
+            MetaValidator.requireValid(_meta);
         }
 
         @Override
@@ -57,9 +64,10 @@ public sealed interface PromptContent
         }
     }
 
-    record EmbeddedResource(ResourceBlock resource, ResourceAnnotations annotations) implements PromptContent {
+    record EmbeddedResource(ResourceBlock resource, ResourceAnnotations annotations, JsonObject _meta) implements PromptContent {
         public EmbeddedResource {
             if (resource == null) throw new IllegalArgumentException("resource is required");
+            MetaValidator.requireValid(_meta);
         }
 
         @Override
@@ -76,6 +84,11 @@ public sealed interface PromptContent
         @Override
         public ResourceAnnotations annotations() {
             return resource.annotations();
+        }
+
+        @Override
+        public JsonObject _meta() {
+            return resource._meta();
         }
 
         @Override

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -24,10 +24,10 @@ public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages
 
     private static PromptContent instantiate(PromptContent tmpl, Map<String, String> args) {
         return switch (tmpl) {
-            case PromptContent.Text t -> new PromptContent.Text(substitute(t.text(), args), t.annotations());
-            case PromptContent.Image i -> new PromptContent.Image(i.data(), i.mimeType(), i.annotations());
-            case PromptContent.Audio a -> new PromptContent.Audio(a.data(), a.mimeType(), a.annotations());
-            case PromptContent.EmbeddedResource r -> new PromptContent.EmbeddedResource(r.resource(), r.annotations());
+            case PromptContent.Text t -> new PromptContent.Text(substitute(t.text(), args), t.annotations(), t._meta());
+            case PromptContent.Image i -> new PromptContent.Image(i.data(), i.mimeType(), i.annotations(), i._meta());
+            case PromptContent.Audio a -> new PromptContent.Audio(a.data(), a.mimeType(), a.annotations(), a._meta());
+            case PromptContent.EmbeddedResource r -> new PromptContent.EmbeddedResource(r.resource(), r.annotations(), r._meta());
             case PromptContent.ResourceLink l -> new PromptContent.ResourceLink(l.resource());
         };
     }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -900,9 +900,9 @@ public final class McpServer implements AutoCloseable {
 
     private static PromptProvider createDefaultPrompts() {
         InMemoryPromptProvider p = new InMemoryPromptProvider();
-        PromptArgument arg = new PromptArgument("test_arg", null, null, true);
-        Prompt prompt = new Prompt("test_prompt", "Test Prompt", null, List.of(arg));
-        PromptMessageTemplate msg = new PromptMessageTemplate(Role.USER, new PromptContent.Text("hello", null));
+        PromptArgument arg = new PromptArgument("test_arg", null, null, true, null);
+        Prompt prompt = new Prompt("test_prompt", "Test Prompt", null, List.of(arg), null);
+        PromptMessageTemplate msg = new PromptMessageTemplate(Role.USER, new PromptContent.Text("hello", null, null));
         p.add(new PromptTemplate(prompt, List.of(msg)));
         return p;
     }


### PR DESCRIPTION
## Summary
- support `_meta` on prompts, prompt arguments, and prompt content
- include the metadata in default prompt definitions

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895513e6ec83249bb38d70ae974478