### PR TITLE
Improve security checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/OriginValidator.java
+++ b/src/main/java/com/amannmalik/mcp/security/OriginValidator.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.security;
 
+import java.net.URI;
 import java.util.Set;
 
 public final class OriginValidator {
@@ -16,7 +17,14 @@ public final class OriginValidator {
         if (origin == null || origin.isBlank()) {
             return false;
         }
-        return allowedOrigins.contains(origin);
+        URI parsed;
+        try {
+            parsed = URI.create(origin).normalize();
+        } catch (Exception e) {
+            return false;
+        }
+        String norm = parsed.getScheme() + "://" + parsed.getAuthority();
+        return allowedOrigins.contains(norm);
     }
 
     public void requireValid(String origin) {

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -188,6 +188,10 @@ public final class StreamableHttpTransport implements Transport {
             String session = sessionId.get();
             String last = lastSessionId.get();
             String header = req.getHeader("Mcp-Session-Id");
+            if (header != null && !isVisibleAscii(header)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
             String version = req.getHeader(PROTOCOL_HEADER);
             JsonObject obj;
             try (JsonReader reader = Json.createReader(req.getInputStream())) {
@@ -485,5 +489,13 @@ public final class StreamableHttpTransport implements Transport {
                 System.err.println("SSE close failed: " + e.getMessage());
             }
         }
+    }
+
+    private static boolean isVisibleAscii(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 0x21 || c > 0x7E) return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- validate `Origin` header by parsing URI and normalizing host
- reject invalid `Mcp-Session-Id` values containing non-visible ASCII

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889553e1adc83249c20ed0791084f0f