### PR TITLE
Ensure sampling capability validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -104,6 +104,9 @@ public final class McpClient implements AutoCloseable {
         this.roots = roots;
         this.rootsListChangedSupported = roots != null && roots.supportsListChanged();
         this.elicitation = elicitation;
+        if (this.capabilities.contains(ClientCapability.SAMPLING) && this.sampling == null) {
+            throw new IllegalArgumentException("sampling capability requires provider");
+        }
         if (this.capabilities.contains(ClientCapability.ELICITATION) && this.elicitation == null) {
             throw new IllegalArgumentException("elicitation capability requires provider");
         }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -475,7 +475,6 @@ public final class StreamableHttpTransport implements Transport {
             this.out = context.getResponse().getWriter();
             byte[] bytes = new byte[16];
             RANDOM.nextBytes(bytes);
-            this.streamId = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         }
 
         void send(JsonObject msg, long id) {

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -4,11 +4,15 @@ import com.amannmalik.mcp.client.McpClient;
 import com.amannmalik.mcp.client.elicitation.BlockingElicitationProvider;
 import com.amannmalik.mcp.client.elicitation.ElicitationAction;
 import com.amannmalik.mcp.client.elicitation.ElicitationResponse;
+import com.amannmalik.mcp.client.sampling.CreateMessageResponse;
+import com.amannmalik.mcp.client.sampling.MessageContent;
+import com.amannmalik.mcp.client.sampling.SamplingProvider;
 import com.amannmalik.mcp.jsonrpc.JsonRpcError;
 import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
 import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
 import com.amannmalik.mcp.lifecycle.ClientCapability;
 import com.amannmalik.mcp.lifecycle.ClientInfo;
+import com.amannmalik.mcp.prompts.Role;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.transport.StdioTransport;
 import com.amannmalik.mcp.util.ProgressNotification;
@@ -98,11 +102,17 @@ class McpConformanceTest {
 
             BlockingElicitationProvider elicitation = new BlockingElicitationProvider();
             elicitation.respond(new ElicitationResponse(ElicitationAction.CANCEL, null));
+            SamplingProvider sampling = r -> new CreateMessageResponse(
+                    Role.ASSISTANT,
+                    new MessageContent.Text("ok", null, null),
+                    "mock-model",
+                    "endTurn"
+            );
             McpClient client = new McpClient(
                     new ClientInfo("test-client", "Test Client", "1.0"),
                     EnumSet.allOf(ClientCapability.class),
                     clientTransport,
-                    null,
+                    sampling,
                     null,
                     elicitation
             );


### PR DESCRIPTION
## Summary
- require a SamplingProvider when declaring the `sampling` capability
- clean up unused field in `StreamableHttpTransport`
- adjust the conformance test with a simple SamplingProvider

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895889f920832494258f7918188f1f