### PR TITLE
Add configurable server instructions

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ConfigLoader.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ConfigLoader.java
@@ -39,7 +39,10 @@ public final class ConfigLoader {
         String mode = obj.getString("mode");
         String transport = obj.getString("transport", "stdio");
         return switch (mode) {
-            case "server" -> new ServerConfig(parseTransport(transport), obj.getInt("port", 0));
+            case "server" -> new ServerConfig(
+                    parseTransport(transport),
+                    obj.getInt("port", 0),
+                    obj.containsKey("instructions") ? obj.getString("instructions") : null);
             case "client" -> new ClientConfig(parseTransport(transport), obj.getString("command"));
             case "host" -> {
                 var cObj = obj.getJsonObject("clients");
@@ -59,7 +62,10 @@ public final class ConfigLoader {
         Object cmdVal = map.get("command");
         Object clientsVal = map.get("clients");
         return switch (mode) {
-            case "server" -> new ServerConfig(parseTransport(transport), portVal == null ? 0 : ((Number) portVal).intValue());
+            case "server" -> new ServerConfig(
+                    parseTransport(transport),
+                    portVal == null ? 0 : ((Number) portVal).intValue(),
+                    map.get("instructions") == null ? null : map.get("instructions").toString());
             case "client" -> new ClientConfig(parseTransport(transport), cmdVal.toString());
             case "host" -> {
                 if (!(clientsVal instanceof Map<?, ?> cMap) || cMap.isEmpty()) {

--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -22,6 +22,9 @@ public final class ServerCommand implements Callable<Integer> {
     @CommandLine.Option(names = "--stdio", description = "Use stdio transport")
     private boolean stdio;
 
+    @CommandLine.Option(names = "--instructions", description = "Instructions file")
+    private Path instructionsFile;
+
     @CommandLine.Option(names = {"-v", "--verbose"}, description = "Verbose logging")
     private boolean verbose;
 
@@ -46,7 +49,7 @@ public final class ServerCommand implements Callable<Integer> {
             TransportType type = httpPort == null ? TransportType.STDIO : TransportType.HTTP;
             int port = httpPort == null ? 0 : httpPort;
             if (stdio) type = TransportType.STDIO;
-            cfg = new ServerConfig(type, port);
+            cfg = new ServerConfig(type, port, null);
         }
 
         Transport t;
@@ -60,7 +63,12 @@ public final class ServerCommand implements Callable<Integer> {
             default -> throw new IllegalStateException();
         }
 
-        try (McpServer server = new McpServer(t)) {
+        String instructions = cfg.instructions();
+        if (instructionsFile != null) {
+            instructions = java.nio.file.Files.readString(instructionsFile);
+        }
+
+        try (McpServer server = new McpServer(t, instructions)) {
             server.serve();
         }
         return 0;

--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.cli;
 
-public record ServerConfig(TransportType transport, int port) implements CliConfig {
+public record ServerConfig(TransportType transport, int port, String instructions) implements CliConfig {
     public ServerConfig {
         if (transport == null) throw new IllegalArgumentException("transport");
         if (transport == TransportType.HTTP && port <= 0) {

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -3,15 +3,24 @@ package com.amannmalik.mcp.lifecycle;
 import java.util.EnumSet;
 import java.util.Set;
 
+
 public class ProtocolLifecycle {
     public static final String SUPPORTED_VERSION = "2025-06-18";
 
     private final Set<ServerCapability> serverCapabilities;
+    private final ServerInfo serverInfo;
+    private final String instructions;
     private LifecycleState state = LifecycleState.INIT;
     private Set<ClientCapability> clientCapabilities = Set.of();
 
     public ProtocolLifecycle(Set<ServerCapability> serverCapabilities) {
+        this(serverCapabilities, new ServerInfo("mcp-java", "MCP Java Reference", "0.1.0"), null);
+    }
+
+    public ProtocolLifecycle(Set<ServerCapability> serverCapabilities, ServerInfo serverInfo, String instructions) {
         this.serverCapabilities = EnumSet.copyOf(serverCapabilities);
+        this.serverInfo = serverInfo;
+        this.instructions = instructions;
     }
 
     public InitializeResponse initialize(InitializeRequest request) {
@@ -28,8 +37,8 @@ public class ProtocolLifecycle {
         return new InitializeResponse(
                 SUPPORTED_VERSION,
                 new Capabilities(clientCapabilities, serverCapabilities),
-                new ServerInfo("mcp-java", "MCP Java Reference", "0.1.0"),
-                null
+                serverInfo,
+                instructions
         );
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -29,6 +29,7 @@ import com.amannmalik.mcp.lifecycle.LifecycleCodec;
 import com.amannmalik.mcp.lifecycle.LifecycleState;
 import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
+import com.amannmalik.mcp.lifecycle.ServerInfo;
 import com.amannmalik.mcp.lifecycle.UnsupportedProtocolVersionException;
 import com.amannmalik.mcp.ping.PingCodec;
 import com.amannmalik.mcp.ping.PingRequest;
@@ -142,9 +143,14 @@ public final class McpServer implements AutoCloseable {
     private final Map<RequestId, CompletableFuture<JsonRpcMessage>> pending = new ConcurrentHashMap<>();
 
     public McpServer(Transport transport) {
+        this(transport, null);
+    }
+
+    public McpServer(Transport transport, String instructions) {
         this(createDefaultResources(), createDefaultTools(), createDefaultPrompts(), createDefaultCompletions(),
                 createDefaultPrivacyBoundary("default"),
                 new Principal("default", Set.of()),
+                instructions,
                 transport);
     }
 
@@ -156,6 +162,7 @@ public final class McpServer implements AutoCloseable {
         this(resources, tools, prompts, completions,
                 createDefaultPrivacyBoundary("default"),
                 new Principal("default", Set.of()),
+                null,
                 transport);
     }
 
@@ -165,6 +172,7 @@ public final class McpServer implements AutoCloseable {
               CompletionProvider completions,
               ResourceAccessController resourceAccess,
               Principal principal,
+              String instructions,
               Transport transport) {
         this.transport = transport;
         EnumSet<ServerCapability> caps = EnumSet.noneOf(ServerCapability.class);
@@ -173,7 +181,7 @@ public final class McpServer implements AutoCloseable {
         if (prompts != null) caps.add(ServerCapability.PROMPTS);
         if (completions != null) caps.add(ServerCapability.COMPLETIONS);
         caps.add(ServerCapability.LOGGING);
-        this.lifecycle = new ProtocolLifecycle(caps);
+        this.lifecycle = new ProtocolLifecycle(caps, new ServerInfo("mcp-java", "MCP Java Reference", "0.1.0"), instructions);
         this.resources = resources;
         this.tools = tools;
         this.prompts = prompts;


### PR DESCRIPTION
## Summary
- allow setting instructions for a server
- plumb instructions from CLI and config
- pass instructions through the protocol handshake

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895c8e906883248831892e71fac9d1