### PR TITLE
Fix prompt input sanitization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.prompts;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -101,7 +102,8 @@ public final class PromptCodec {
             if (v.getValueType() != JsonValue.ValueType.STRING) {
                 throw new IllegalArgumentException("argument values must be strings");
             }
-            args.put(k, ((JsonString) v).getString());
+            args.put(InputSanitizer.requireClean(k),
+                    InputSanitizer.requireClean(((JsonString) v).getString()));
         });
         return args;
     }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -85,6 +85,7 @@ import com.amannmalik.mcp.util.ProgressCodec;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ProgressTracker;
+import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.SchemaValidator;
 import com.amannmalik.mcp.validation.UriValidator;
@@ -746,7 +747,20 @@ public final class McpServer implements AutoCloseable {
                     JsonRpcErrorCode.INVALID_PARAMS.code(),
                     "name is required", null));
         }
-        Map<String, String> args = PromptCodec.toArguments(params.getJsonObject("arguments"));
+        try {
+            name = InputSanitizer.requireClean(name);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
+
+        Map<String, String> args;
+        try {
+            args = PromptCodec.toArguments(params.getJsonObject("arguments"));
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
         try {
             PromptInstance inst = prompts.get(name, args);
             JsonObject result = PromptCodec.toJsonObject(inst);


### PR DESCRIPTION
## Summary
- sanitize prompt argument names and values
- validate prompt names via InputSanitizer in `prompts/get`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895bb240ac8324b39e717dd96d9680