### PR TITLE
Implement basic token validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
@@ -1,0 +1,57 @@
+package com.amannmalik.mcp.auth;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import java.io.StringReader;
+import java.util.Base64;
+import java.util.Set;
+
+public final class JwtTokenValidator implements TokenValidator {
+    private final String expectedAudience;
+
+    public JwtTokenValidator(String expectedAudience) {
+        if (expectedAudience == null || expectedAudience.isBlank()) {
+            throw new IllegalArgumentException("expectedAudience required");
+        }
+        this.expectedAudience = expectedAudience;
+    }
+
+    @Override
+    public Principal validate(String token) throws AuthorizationException {
+        if (token == null || token.isBlank()) {
+            throw new AuthorizationException("token required");
+        }
+        String[] parts = token.split("\\.");
+        if (parts.length < 2) {
+            throw new AuthorizationException("invalid token format");
+        }
+        String payloadJson;
+        try {
+            payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+        } catch (IllegalArgumentException e) {
+            throw new AuthorizationException("invalid token encoding");
+        }
+        JsonObject payload;
+        try (JsonReader reader = Json.createReader(new StringReader(payloadJson))) {
+            payload = reader.readObject();
+        } catch (Exception e) {
+            throw new AuthorizationException("invalid token payload");
+        }
+        String aud = payload.getString("aud", null);
+        if (!expectedAudience.equals(aud)) {
+            throw new AuthorizationException("audience mismatch");
+        }
+        String sub = payload.getString("sub", null);
+        if (sub == null || sub.isBlank()) {
+            throw new AuthorizationException("subject required");
+        }
+        Set<String> scopes = Set.of();
+        var scopeStr = payload.getString("scope", null);
+        if (scopeStr != null && !scopeStr.isBlank()) {
+            scopes = Set.of(scopeStr.split(" "));
+        }
+        return new Principal(sub, scopes);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/auth/TokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/TokenValidator.java
@@ -2,5 +2,5 @@ package com.amannmalik.mcp.auth;
 
 @FunctionalInterface
 public interface TokenValidator {
-    Principal validate(String token);
+    Principal validate(String token) throws AuthorizationException;
 }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -5,6 +5,9 @@ import com.amannmalik.mcp.jsonrpc.JsonRpcError;
 import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
 import com.amannmalik.mcp.jsonrpc.RequestId;
 import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
+import com.amannmalik.mcp.auth.AuthorizationException;
+import com.amannmalik.mcp.auth.AuthorizationManager;
+import com.amannmalik.mcp.auth.Principal;
 import com.amannmalik.mcp.security.OriginValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -40,6 +43,7 @@ public final class StreamableHttpTransport implements Transport {
     private final Server server;
     private final int port;
     private final OriginValidator originValidator;
+    private final AuthorizationManager authManager;
     private static final String PROTOCOL_HEADER = "MCP-Protocol-Version";
     // Default to the previous protocol revision when no version header is
     // present, as recommended for backwards compatibility.
@@ -50,12 +54,13 @@ public final class StreamableHttpTransport implements Transport {
     private final AtomicReference<String> sessionId = new AtomicReference<>();
     private final AtomicReference<String> lastSessionId = new AtomicReference<>();
     private final AtomicReference<String> sessionOwner = new AtomicReference<>();
+    private final AtomicReference<Principal> sessionPrincipal = new AtomicReference<>();
     private static final SecureRandom RANDOM = new SecureRandom();
     private volatile String protocolVersion;
     private final ConcurrentHashMap<String, BlockingQueue<JsonObject>> responseQueues = new ConcurrentHashMap<>();
     private final AtomicLong nextEventId = new AtomicLong(1);
 
-    public StreamableHttpTransport(int port, OriginValidator validator) throws Exception {
+    public StreamableHttpTransport(int port, OriginValidator validator, AuthorizationManager auth) throws Exception {
         server = new Server(new InetSocketAddress("127.0.0.1", port));
         ServletContextHandler ctx = new ServletContextHandler();
         ctx.addServlet(new ServletHolder(new McpServlet()), "/");
@@ -63,13 +68,18 @@ public final class StreamableHttpTransport implements Transport {
         server.start();
         this.port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
         this.originValidator = validator;
+        this.authManager = auth;
         // Until initialization negotiates a version, assume the prior revision
         // as the default when no MCP-Protocol-Version header is present.
         this.protocolVersion = DEFAULT_VERSION;
     }
 
+    public StreamableHttpTransport(int port, OriginValidator validator) throws Exception {
+        this(port, validator, null);
+    }
+
     public StreamableHttpTransport(int port) throws Exception {
-        this(port, new OriginValidator(Set.of("http://localhost", "http://127.0.0.1")));
+        this(port, new OriginValidator(Set.of("http://localhost", "http://127.0.0.1")), null);
     }
 
     public int port() {
@@ -174,6 +184,7 @@ public final class StreamableHttpTransport implements Transport {
             sessionId.set(null);
             lastSessionId.set(null);
             sessionOwner.set(null);
+            sessionPrincipal.set(null);
             protocolVersion = ProtocolLifecycle.SUPPORTED_VERSION;
         } catch (Exception e) {
             throw new IOException(e);
@@ -183,6 +194,15 @@ public final class StreamableHttpTransport implements Transport {
     private class McpServlet extends HttpServlet {
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            Principal principal = null;
+            if (authManager != null) {
+                try {
+                    principal = authManager.authorize(req.getHeader("Authorization"));
+                } catch (AuthorizationException e) {
+                    resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
+            }
             if (!originValidator.isValid(req.getHeader("Origin"))) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
@@ -213,6 +233,7 @@ public final class StreamableHttpTransport implements Transport {
                 session = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
                 sessionId.set(session);
                 sessionOwner.set(req.getRemoteAddr());
+                sessionPrincipal.set(principal);
                 lastSessionId.set(null);
                 resp.setHeader("Mcp-Session-Id", session);
             } else if (session == null) {
@@ -227,6 +248,9 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             } else if (!session.equals(header) || !req.getRemoteAddr().equals(sessionOwner.get())) {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            } else if (authManager != null && sessionPrincipal.get() != null && !sessionPrincipal.get().id().equals(principal.id())) {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             } else if (version == null || !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
@@ -345,6 +369,15 @@ public final class StreamableHttpTransport implements Transport {
 
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            Principal principal = null;
+            if (authManager != null) {
+                try {
+                    principal = authManager.authorize(req.getHeader("Authorization"));
+                } catch (AuthorizationException e) {
+                    resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
+            }
             if (!originValidator.isValid(req.getHeader("Origin"))) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
@@ -372,6 +405,11 @@ public final class StreamableHttpTransport implements Transport {
             }
             if (!session.equals(header) || !req.getRemoteAddr().equals(sessionOwner.get())) {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+
+            if (authManager != null && sessionPrincipal.get() != null && !sessionPrincipal.get().id().equals(principal.id())) {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             }
 
@@ -429,6 +467,15 @@ public final class StreamableHttpTransport implements Transport {
 
         @Override
         protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            Principal principal = null;
+            if (authManager != null) {
+                try {
+                    principal = authManager.authorize(req.getHeader("Authorization"));
+                } catch (AuthorizationException e) {
+                    resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
+            }
             if (!originValidator.isValid(req.getHeader("Origin"))) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
@@ -448,6 +495,10 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
+            if (authManager != null && sessionPrincipal.get() != null && !sessionPrincipal.get().id().equals(principal.id())) {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
             if (version == null || !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
@@ -455,6 +506,7 @@ public final class StreamableHttpTransport implements Transport {
             lastSessionId.set(session);
             sessionId.set(null);
             sessionOwner.set(null);
+            sessionPrincipal.set(null);
             protocolVersion = ProtocolLifecycle.SUPPORTED_VERSION;
             nextEventId.set(1);
             sseClients.forEach(SseClient::close);


### PR DESCRIPTION
## Summary
- provide `JwtTokenValidator` for verifying bearer tokens
- make `TokenValidator` throw `AuthorizationException`
- enforce bearer auth in `StreamableHttpTransport`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68895be38f188324afedfb4496c39c16