### PR TITLE
Fix leftover session checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -357,6 +357,10 @@ public final class StreamableHttpTransport implements Transport {
             String session = sessionId.get();
             String last = lastSessionId.get();
             String header = req.getHeader("Mcp-Session-Id");
+            if (header != null && !isVisibleAscii(header)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
             String version = req.getHeader(PROTOCOL_HEADER);
             if (session == null) {
                 if (header != null && header.equals(last)) {
@@ -435,6 +439,10 @@ public final class StreamableHttpTransport implements Transport {
             }
             String session = sessionId.get();
             String header = req.getHeader("Mcp-Session-Id");
+            if (header != null && !isVisibleAscii(header)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
             String version = req.getHeader(PROTOCOL_HEADER);
             if (session == null) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);


### PR DESCRIPTION
## Summary
- enforce visible ASCII check on HTTP GET/DELETE session headers

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895be38f188324afedfb4496c39c16