### PR TITLE
Allow flexible model hints

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/ModelHint.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/ModelHint.java
@@ -1,7 +1,4 @@
 package com.amannmalik.mcp.client.sampling;
 
 public record ModelHint(String name) {
-    public ModelHint {
-        if (name == null) throw new IllegalArgumentException("name is required");
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
@@ -127,7 +127,11 @@ public final class SamplingCodec {
         JsonObjectBuilder b = Json.createObjectBuilder();
         if (!prefs.hints().isEmpty()) {
             JsonArrayBuilder arr = Json.createArrayBuilder();
-            for (ModelHint h : prefs.hints()) arr.add(Json.createObjectBuilder().add("name", h.name()).build());
+            for (ModelHint h : prefs.hints()) {
+                JsonObjectBuilder hb = Json.createObjectBuilder();
+                if (h.name() != null) hb.add("name", h.name());
+                arr.add(hb.build());
+            }
             b.add("hints", arr.build());
         }
         if (prefs.costPriority() != null) b.add("costPriority", prefs.costPriority());
@@ -139,7 +143,11 @@ public final class SamplingCodec {
     static ModelPreferences toModelPreferences(JsonObject obj) {
         List<ModelHint> hints = obj.containsKey("hints")
                 ? obj.getJsonArray("hints").stream()
-                .map(v -> new ModelHint(v.asJsonObject().getString("name")))
+                .map(v -> {
+                    JsonObject h = v.asJsonObject();
+                    String name = h.getString("name", null);
+                    return new ModelHint(name);
+                })
                 .toList()
                 : List.of();
         Double cost = obj.containsKey("costPriority") ? obj.getJsonNumber("costPriority").doubleValue() : null;


### PR DESCRIPTION
## Summary
- relax ModelHint so name is optional
- handle absent model hint names in SamplingCodec

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895bf4dbf883249390ea8b063a887b