### PR TITLE
Fix resource ref validation for completions

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.completion;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.UriTemplateValidator;
 import java.util.Map;
 
 public record CompleteRequest(
@@ -62,6 +63,7 @@ public record CompleteRequest(
             public ResourceRef {
                 if (uri == null) throw new IllegalArgumentException("uri required");
                 uri = InputSanitizer.requireClean(uri);
+                uri = UriTemplateValidator.requireAbsoluteTemplate(uri);
             }
 
             @Override


### PR DESCRIPTION
## Summary
- validate `ref/resource` URIs in completion requests as absolute URI templates

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68895ccf251083248417ef0e3b67e57a