### PR TITLE
Implement prompt/tool JSON decoding

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -111,7 +111,7 @@ public final class ResourcesCodec {
         return b.build();
     }
 
-    private static ResourceAnnotations toAnnotations(JsonObject obj) {
+    public static ResourceAnnotations toAnnotations(JsonObject obj) {
         Set<Audience> audience = EnumSet.noneOf(Audience.class);
         var audienceArr = obj.getJsonArray("audience");
         if (audienceArr != null) {


### PR DESCRIPTION
## Summary
- parse prompt-related JSON objects in `PromptCodec`
- expose `ResourcesCodec.toAnnotations` for reuse
- add parsing utilities for tools in `ToolCodec`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68896869d36083249cc19df37112cb45