### PR TITLE
Conform resource content format to spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -924,7 +924,7 @@ public final class McpServer implements AutoCloseable {
 
     private static ResourceProvider createDefaultResources() {
         Resource r = new Resource("test://example", "example", null, null, "text/plain", 5L, null, null);
-        ResourceBlock.Text block = new ResourceBlock.Text("test://example", "example", null, "text/plain", "hello", null, null);
+        ResourceBlock.Text block = new ResourceBlock.Text("test://example", "text/plain", "hello", null, null);
         ResourceTemplate t = new ResourceTemplate("test://template", "example_template", null, null, "text/plain", null, null);
         return new InMemoryResourceProvider(List.of(r), Map.of(r.uri(), block), List.of(t));
     }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceBlock.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceBlock.java
@@ -8,32 +8,24 @@ import jakarta.json.JsonObject;
 public sealed interface ResourceBlock permits ResourceBlock.Text, ResourceBlock.Binary {
     String uri();
 
-    String name();
-
-    String title();
-
     String mimeType();
 
     ResourceAnnotations annotations();
 
     JsonObject _meta();
 
-    record Text(String uri, String name, String title, String mimeType, String text, ResourceAnnotations annotations, JsonObject _meta) implements ResourceBlock {
+    record Text(String uri, String mimeType, String text, ResourceAnnotations annotations, JsonObject _meta) implements ResourceBlock {
         public Text {
             uri = UriValidator.requireAbsolute(uri);
-            name = InputSanitizer.requireClean(name);
-            title = title == null ? null : InputSanitizer.requireClean(title);
             mimeType = mimeType == null ? null : InputSanitizer.requireClean(mimeType);
             text = InputSanitizer.requireClean(text);
             MetaValidator.requireValid(_meta);
         }
     }
 
-    record Binary(String uri, String name, String title, String mimeType, byte[] blob, ResourceAnnotations annotations, JsonObject _meta) implements ResourceBlock {
+    record Binary(String uri, String mimeType, byte[] blob, ResourceAnnotations annotations, JsonObject _meta) implements ResourceBlock {
         public Binary {
             uri = UriValidator.requireAbsolute(uri);
-            name = InputSanitizer.requireClean(name);
-            title = title == null ? null : InputSanitizer.requireClean(title);
             mimeType = mimeType == null ? null : InputSanitizer.requireClean(mimeType);
             if (blob == null) {
                 throw new IllegalArgumentException("blob is required");

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -67,11 +67,8 @@ public final class ResourcesCodec {
 
     public static JsonObject toJsonObject(ResourceBlock block) {
         JsonObjectBuilder b = Json.createObjectBuilder()
-                .add("uri", block.uri())
-                .add("name", block.name());
-        if (block.title() != null) b.add("title", block.title());
+                .add("uri", block.uri());
         if (block.mimeType() != null) b.add("mimeType", block.mimeType());
-        if (block.annotations() != null) b.add("annotations", toJsonObject(block.annotations()));
         if (block._meta() != null) b.add("_meta", block._meta());
         switch (block) {
             case ResourceBlock.Text t -> b.add("text", t.text());
@@ -82,8 +79,6 @@ public final class ResourcesCodec {
 
     public static ResourceBlock toResourceBlock(JsonObject obj) {
         String uri = obj.getString("uri");
-        String name = obj.getString("name");
-        String title = obj.getString("title", null);
         String mime = obj.getString("mimeType", null);
         ResourceAnnotations ann = obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null;
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
@@ -93,10 +88,10 @@ public final class ResourcesCodec {
             throw new IllegalArgumentException("exactly one of text or blob must be present");
         }
         if (hasText) {
-            return new ResourceBlock.Text(uri, name, title, mime, obj.getString("text"), ann, meta);
+            return new ResourceBlock.Text(uri, mime, obj.getString("text"), ann, meta);
         }
         byte[] data = Base64.getDecoder().decode(obj.getString("blob"));
-        return new ResourceBlock.Binary(uri, name, title, mime, data, ann, meta);
+        return new ResourceBlock.Binary(uri, mime, data, ann, meta);
     }
 
     public static JsonObject toJsonObject(ResourceAnnotations ann) {


### PR DESCRIPTION
## Summary
- stop including name/title when emitting `ResourceBlock` JSON
- adjust default resource block

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68896869d36083249cc19df37112cb45