### PR TITLE
Update notifications to match spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -598,7 +598,7 @@ public final class McpClient implements AutoCloseable {
             case "notifications/message" -> {
                 if (note.params() != null) {
                     try {
-                        loggingListener.onMessage(LoggingCodec.toLoggingNotification(note.params()));
+                        loggingListener.onMessage(LoggingCodec.toLoggingMessageNotification(note.params()));
                     } catch (IllegalArgumentException ignore) {
                     }
                 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -61,16 +61,16 @@ public final class PromptCodec {
         return builder.build();
     }
 
-    public static JsonObject toJsonObject(PromptsListChangedNotification n) {
+    public static JsonObject toJsonObject(PromptListChangedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
         return Json.createObjectBuilder().build();
     }
 
-    public static PromptsListChangedNotification toPromptsListChangedNotification(JsonObject obj) {
+    public static PromptListChangedNotification toPromptListChangedNotification(JsonObject obj) {
         if (obj != null && !obj.isEmpty()) {
             throw new IllegalArgumentException("unexpected fields");
         }
-        return new PromptsListChangedNotification();
+        return new PromptListChangedNotification();
     }
 
     static JsonObject toJsonObject(PromptContent content) {

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptListChangedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptListChangedNotification.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.prompts;
+
+public record PromptListChangedNotification() {
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptsListChangedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptsListChangedNotification.java
@@ -1,4 +1,0 @@
-package com.amannmalik.mcp.prompts;
-
-public record PromptsListChangedNotification() {
-}

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -56,7 +56,7 @@ import com.amannmalik.mcp.server.completion.CompletionProvider;
 import com.amannmalik.mcp.server.completion.InMemoryCompletionProvider;
 import com.amannmalik.mcp.server.logging.LoggingCodec;
 import com.amannmalik.mcp.server.logging.LoggingLevel;
-import com.amannmalik.mcp.server.logging.LoggingNotification;
+import com.amannmalik.mcp.server.logging.LoggingMessageNotification;
 import com.amannmalik.mcp.server.resources.Audience;
 import com.amannmalik.mcp.server.resources.InMemoryResourceProvider;
 import com.amannmalik.mcp.server.resources.Resource;
@@ -636,8 +636,7 @@ public final class McpServer implements AutoCloseable {
         try {
             ResourceSubscription sub = resources.subscribe(uri, update -> {
                 try {
-                    ResourceUpdatedNotification n = new ResourceUpdatedNotification(
-                            update.uri(), update.title());
+                    ResourceUpdatedNotification n = new ResourceUpdatedNotification(update.uri());
                     send(new JsonRpcNotification(
                             "notifications/resources/updated",
                             ResourcesCodec.toJsonObject(n)));
@@ -805,7 +804,7 @@ public final class McpServer implements AutoCloseable {
         }
     }
 
-    private void sendLog(LoggingNotification note) throws IOException {
+    private void sendLog(LoggingMessageNotification note) throws IOException {
         logLimiter.requireAllowance(note.logger() == null ? "" : note.logger());
         if (note.level().ordinal() < logLevel.ordinal()) return;
         requireServerCapability(ServerCapability.LOGGING);
@@ -814,7 +813,7 @@ public final class McpServer implements AutoCloseable {
     }
 
     private void sendLog(LoggingLevel level, String logger, JsonValue data) throws IOException {
-        sendLog(new LoggingNotification(level, logger, data));
+        sendLog(new LoggingMessageNotification(level, logger, data));
     }
 
     private JsonRpcMessage complete(JsonRpcRequest req) {

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
@@ -9,7 +9,7 @@ public final class LoggingCodec {
     private LoggingCodec() {
     }
 
-    public static JsonObject toJsonObject(LoggingNotification n) {
+    public static JsonObject toJsonObject(LoggingMessageNotification n) {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("level", n.level().name().toLowerCase())
                 .add("data", n.data());
@@ -17,7 +17,7 @@ public final class LoggingCodec {
         return b.build();
     }
 
-    public static LoggingNotification toLoggingNotification(JsonObject obj) {
+    public static LoggingMessageNotification toLoggingMessageNotification(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("object required");
 
         String rawLevel;
@@ -40,7 +40,7 @@ public final class LoggingCodec {
             }
         }
 
-        return new LoggingNotification(level, logger, data);
+        return new LoggingMessageNotification(level, logger, data);
     }
 
     public static JsonObject toJsonObject(SetLevelRequest req) {

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingListener.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingListener.java
@@ -2,5 +2,5 @@ package com.amannmalik.mcp.server.logging;
 
 @FunctionalInterface
 public interface LoggingListener {
-    void onMessage(LoggingNotification notification);
+    void onMessage(LoggingMessageNotification notification);
 }

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingMessageNotification.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingMessageNotification.java
@@ -2,8 +2,8 @@ package com.amannmalik.mcp.server.logging;
 
 import jakarta.json.JsonValue;
 
-public record LoggingNotification(LoggingLevel level, String logger, JsonValue data) {
-    public LoggingNotification {
+public record LoggingMessageNotification(LoggingLevel level, String logger, JsonValue data) {
+    public LoggingMessageNotification {
         if (level == null || data == null) {
             throw new IllegalArgumentException("level and data are required");
         }

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -59,8 +59,8 @@ public final class InMemoryResourceProvider implements ResourceProvider {
         return true;
     }
 
-    public void notifyUpdate(String uri, String title) {
-        ResourceUpdate update = new ResourceUpdate(uri, title);
+    public void notifyUpdate(String uri) {
+        ResourceUpdate update = new ResourceUpdate(uri);
         listeners.getOrDefault(uri, List.of()).forEach(l -> l.updated(update));
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdate.java
@@ -1,11 +1,9 @@
 package com.amannmalik.mcp.server.resources;
 
-import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.UriValidator;
 
-public record ResourceUpdate(String uri, String title) {
+public record ResourceUpdate(String uri) {
     public ResourceUpdate {
         uri = UriValidator.requireAbsolute(uri);
-        title = title == null ? null : InputSanitizer.requireClean(title);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdatedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdatedNotification.java
@@ -1,11 +1,9 @@
 package com.amannmalik.mcp.server.resources;
 
-import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.UriValidator;
 
-public record ResourceUpdatedNotification(String uri, String title) {
+public record ResourceUpdatedNotification(String uri) {
     public ResourceUpdatedNotification {
         uri = UriValidator.requireAbsolute(uri);
-        title = title == null ? null : InputSanitizer.requireClean(title);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -143,16 +143,12 @@ public final class ResourcesCodec {
     }
 
     public static JsonObject toJsonObject(ResourceUpdatedNotification n) {
-        JsonObjectBuilder b = Json.createObjectBuilder()
-                .add("uri", n.uri());
-        if (n.title() != null) b.add("title", n.title());
-        return b.build();
+        return Json.createObjectBuilder()
+                .add("uri", n.uri())
+                .build();
     }
 
     public static ResourceUpdatedNotification toResourceUpdatedNotification(JsonObject obj) {
-        return new ResourceUpdatedNotification(
-                obj.getString("uri"),
-                obj.getString("title", null)
-        );
+        return new ResourceUpdatedNotification(obj.getString("uri"));
     }
 }


### PR DESCRIPTION
## Summary
- conform ResourceUpdatedNotification to 2025-06-18 schema
- remove unused title field from ResourceUpdate and provider
- rename logging and prompt list notifications to spec names
- adapt codecs, listener interfaces and server logic

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68896874ca0c8324ba1ff20a632ab928