### PR TITLE
Add resource subscribe/unsubscribe handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -69,6 +69,8 @@ import com.amannmalik.mcp.server.resources.ResourceSubscription;
 import com.amannmalik.mcp.server.resources.ResourceTemplate;
 import com.amannmalik.mcp.server.resources.ResourceTemplatePage;
 import com.amannmalik.mcp.server.resources.ResourceUpdatedNotification;
+import com.amannmalik.mcp.server.resources.SubscribeRequest;
+import com.amannmalik.mcp.server.resources.UnsubscribeRequest;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.server.tools.InMemoryToolProvider;
 import com.amannmalik.mcp.server.tools.Tool;
@@ -612,18 +614,14 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage subscribeResource(JsonRpcRequest req) {
         requireServerCapability(ServerCapability.RESOURCES);
-        JsonObject params = req.params();
-        if (params == null || !params.containsKey("uri")) {
-            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
-                    JsonRpcErrorCode.INVALID_PARAMS.code(), "uri required", null));
-        }
-        String uri = params.getString("uri");
+        SubscribeRequest sr;
         try {
-            uri = UriValidator.requireAbsolute(uri);
+            sr = ResourcesCodec.toSubscribeRequest(req.params());
         } catch (IllegalArgumentException e) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
         }
+        String uri = sr.uri();
         ResourceBlock existing = resources.read(uri);
         if (existing == null) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
@@ -660,18 +658,14 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage unsubscribeResource(JsonRpcRequest req) {
         requireServerCapability(ServerCapability.RESOURCES);
-        JsonObject params = req.params();
-        if (params == null || !params.containsKey("uri")) {
-            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
-                    JsonRpcErrorCode.INVALID_PARAMS.code(), "uri required", null));
-        }
-        String uri = params.getString("uri");
+        UnsubscribeRequest ur;
         try {
-            uri = UriValidator.requireAbsolute(uri);
+            ur = ResourcesCodec.toUnsubscribeRequest(req.params());
         } catch (IllegalArgumentException e) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
         }
+        String uri = ur.uri();
         ResourceSubscription sub = resourceSubscriptions.remove(uri);
         if (sub != null) {
             try {

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -5,6 +5,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 
+
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Base64;
@@ -147,6 +148,34 @@ public final class ResourcesCodec {
                 .add("uri", n.uri());
         if (n.title() != null) b.add("title", n.title());
         return b.build();
+    }
+
+    public static JsonObject toJsonObject(SubscribeRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
+        return Json.createObjectBuilder()
+                .add("uri", req.uri())
+                .build();
+    }
+
+    public static SubscribeRequest toSubscribeRequest(JsonObject obj) {
+        if (obj == null || !obj.containsKey("uri")) {
+            throw new IllegalArgumentException("uri required");
+        }
+        return new SubscribeRequest(obj.getString("uri"));
+    }
+
+    public static JsonObject toJsonObject(UnsubscribeRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
+        return Json.createObjectBuilder()
+                .add("uri", req.uri())
+                .build();
+    }
+
+    public static UnsubscribeRequest toUnsubscribeRequest(JsonObject obj) {
+        if (obj == null || !obj.containsKey("uri")) {
+            throw new IllegalArgumentException("uri required");
+        }
+        return new UnsubscribeRequest(obj.getString("uri"));
     }
 
     public static ResourceUpdatedNotification toResourceUpdatedNotification(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/resources/SubscribeRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/SubscribeRequest.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.server.resources;
+
+import com.amannmalik.mcp.validation.UriValidator;
+
+public record SubscribeRequest(String uri) {
+    public SubscribeRequest {
+        uri = UriValidator.requireAbsolute(uri);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/UnsubscribeRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/UnsubscribeRequest.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.server.resources;
+
+import com.amannmalik.mcp.validation.UriValidator;
+
+public record UnsubscribeRequest(String uri) {
+    public UnsubscribeRequest {
+        uri = UriValidator.requireAbsolute(uri);
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -167,6 +167,16 @@ class McpConformanceTest {
                     .getJsonArray("contents").getJsonObject(0);
             assertEquals("hello", block.getString("text"));
 
+            m = client.request("resources/subscribe", Json.createObjectBuilder()
+                    .add("uri", "test://example")
+                    .build());
+            assertInstanceOf(JsonRpcResponse.class, m);
+
+            m = client.request("resources/unsubscribe", Json.createObjectBuilder()
+                    .add("uri", "test://example")
+                    .build());
+            assertInstanceOf(JsonRpcResponse.class, m);
+
             m = client.request("resources/templates/list", Json.createObjectBuilder().build());
             assertInstanceOf(JsonRpcResponse.class, m);
             var templates = ((JsonRpcResponse) m).result().getJsonArray("resourceTemplates");


### PR DESCRIPTION
## Summary
- implement `SubscribeRequest` and `UnsubscribeRequest`
- add codec helpers for resource subscription messages
- parse subscription requests in `McpServer`
- exercise the new endpoints in tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688968720ffc8324afb2aa74b9899b29