### PR TITLE
Fix resource provider capability default

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -15,7 +15,7 @@ public interface ResourceProvider extends AutoCloseable {
     }
 
     default boolean supportsSubscribe() {
-        return true;
+        return false;
     }
 
     default boolean supportsListChanged() {


### PR DESCRIPTION
## Summary
- correct capability default by disabling resource subscription unless explicitly supported

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688967c146f88324a7b733b647ec17ec