### PR TITLE
Fix tool name validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -664,6 +664,12 @@ public final class McpServer implements AutoCloseable {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INVALID_PARAMS.code(), "name required", null));
         }
+        try {
+            name = InputSanitizer.requireClean(name);
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        }
 
         JsonValue argsVal = params.get("arguments");
         JsonObject args = null;


### PR DESCRIPTION
## Summary
- sanitize tool names in `callTool`

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68896f0747208324a0bc3e67c4e3bc0e