### PR TITLE
Support _meta in tool results

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -896,7 +896,7 @@ public final class McpServer implements AutoCloseable {
                                         .add("type", "text")
                                         .add("text", "ok")
                                         .build())
-                                .build(), null, false)));
+                                .build(), null, false, null)));
     }
 
     private static PromptProvider createDefaultPrompts() {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -43,6 +43,7 @@ public final class ToolCodec {
         if (result.structuredContent() != null) {
             builder.add("structuredContent", result.structuredContent());
         }
+        if (result._meta() != null) builder.add("_meta", result._meta());
         return builder.build();
     }
 
@@ -103,7 +104,8 @@ public final class ToolCodec {
         if (content == null) throw new IllegalArgumentException("content required");
         JsonObject structured = obj.getJsonObject("structuredContent");
         boolean isError = obj.getBoolean("isError", false);
-        return new ToolResult(content, structured, isError);
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new ToolResult(content, structured, isError, meta);
     }
 
     private static ToolAnnotations toToolAnnotations(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -6,6 +6,7 @@ import com.amannmalik.mcp.server.resources.ResourceAnnotations;
 import com.amannmalik.mcp.server.resources.ResourceBlock;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
@@ -22,9 +23,11 @@ import java.util.Set;
 
 public record ToolResult(JsonArray content,
                          JsonObject structuredContent,
-                         boolean isError) {
+                         boolean isError,
+                         JsonObject _meta) {
     public ToolResult {
         content = sanitize(content == null ? JsonValue.EMPTY_JSON_ARRAY : content);
+        MetaValidator.requireValid(_meta);
     }
 
     private static JsonArray sanitize(JsonArray arr) {


### PR DESCRIPTION
## Summary
- add `_meta` property to `ToolResult`
- include `_meta` in `ToolCodec`
- adjust default tool result creation

## Testing
- `gradle test`
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_68896f0747208324a0bc3e67c4e3bc0e