### PR TITLE
Implement _meta support for result objects

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageResponse.java
@@ -2,15 +2,20 @@ package com.amannmalik.mcp.client.sampling;
 
 import com.amannmalik.mcp.prompts.Role;
 
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
 public record CreateMessageResponse(
         Role role,
         MessageContent content,
         String model,
-        String stopReason
+        String stopReason,
+        JsonObject _meta
 ) {
     public CreateMessageResponse {
         if (role == null || content == null || model == null) {
             throw new IllegalArgumentException("role, content, and model are required");
         }
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
@@ -73,6 +73,7 @@ public final class SamplingCodec {
                 .add("content", toJsonObject(resp.content()))
                 .add("model", resp.model());
         if (resp.stopReason() != null) obj.add("stopReason", resp.stopReason());
+        if (resp._meta() != null) obj.add("_meta", resp._meta());
         return obj.build();
     }
 
@@ -82,7 +83,8 @@ public final class SamplingCodec {
         if (!obj.containsKey("model")) throw new IllegalArgumentException("model required");
         String model = obj.getString("model");
         String stop = obj.getString("stopReason", null);
-        return new CreateMessageResponse(role, content, model, stop);
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new CreateMessageResponse(role, content, model, stop, meta);
     }
 
     static JsonObject toJsonObject(SamplingMessage msg) {

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -896,7 +896,7 @@ public final class McpServer implements AutoCloseable {
                                         .add("type", "text")
                                         .add("text", "ok")
                                         .build())
-                                .build(), null, false)));
+                                .build(), null, false, null)));
     }
 
     private static PromptProvider createDefaultPrompts() {

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
@@ -3,9 +3,13 @@ package com.amannmalik.mcp.server.completion;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import java.util.List;
 
-public record CompleteResult(Completion completion) {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record CompleteResult(Completion completion, JsonObject _meta) {
     public CompleteResult {
         if (completion == null) throw new IllegalArgumentException("completion required");
+        MetaValidator.requireValid(_meta);
     }
 
     public record Completion(List<String> values, Integer total, Boolean hasMore) {

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
@@ -66,7 +66,9 @@ public final class CompletionCodec {
         JsonObjectBuilder comp = Json.createObjectBuilder().add("values", arr.build());
         if (result.completion().total() != null) comp.add("total", result.completion().total());
         if (result.completion().hasMore() != null) comp.add("hasMore", result.completion().hasMore());
-        return Json.createObjectBuilder().add("completion", comp.build()).build();
+        JsonObjectBuilder obj = Json.createObjectBuilder().add("completion", comp.build());
+        if (result._meta() != null) obj.add("_meta", result._meta());
+        return obj.build();
     }
 
     public static CompleteResult toCompleteResult(JsonObject obj) {
@@ -76,7 +78,8 @@ public final class CompletionCodec {
                 .toList();
         Integer total = comp.containsKey("total") ? comp.getInt("total") : null;
         Boolean hasMore = comp.containsKey("hasMore") ? comp.getBoolean("hasMore") : null;
-        return new CompleteResult(new CompleteResult.Completion(values, total, hasMore));
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new CompleteResult(new CompleteResult.Completion(values, total, hasMore), meta);
     }
 
     static JsonObject toJsonObject(CompleteRequest.Ref ref) {

--- a/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
@@ -67,7 +67,7 @@ public final class InMemoryCompletionProvider implements CompletionProvider {
                 .toList();
         int total = unique.size();
         boolean hasMore = total > sorted.size();
-        return new CompleteResult(new CompleteResult.Completion(sorted, total, hasMore));
+        return new CompleteResult(new CompleteResult.Completion(sorted, total, hasMore), null);
     }
 
     private static int similarity(String a, String b) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -43,6 +43,7 @@ public final class ToolCodec {
         if (result.structuredContent() != null) {
             builder.add("structuredContent", result.structuredContent());
         }
+        if (result._meta() != null) builder.add("_meta", result._meta());
         return builder.build();
     }
 
@@ -103,7 +104,8 @@ public final class ToolCodec {
         if (content == null) throw new IllegalArgumentException("content required");
         JsonObject structured = obj.getJsonObject("structuredContent");
         boolean isError = obj.getBoolean("isError", false);
-        return new ToolResult(content, structured, isError);
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new ToolResult(content, structured, isError, meta);
     }
 
     private static ToolAnnotations toToolAnnotations(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -6,6 +6,7 @@ import com.amannmalik.mcp.server.resources.ResourceAnnotations;
 import com.amannmalik.mcp.server.resources.ResourceBlock;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
@@ -22,9 +23,11 @@ import java.util.Set;
 
 public record ToolResult(JsonArray content,
                          JsonObject structuredContent,
-                         boolean isError) {
+                         boolean isError,
+                         JsonObject _meta) {
     public ToolResult {
         content = sanitize(content == null ? JsonValue.EMPTY_JSON_ARRAY : content);
+        MetaValidator.requireValid(_meta);
     }
 
     private static JsonArray sanitize(JsonArray arr) {

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -106,7 +106,8 @@ class McpConformanceTest {
                     Role.ASSISTANT,
                     new MessageContent.Text("ok", null, null),
                     "mock-model",
-                    "endTurn"
+                    "endTurn",
+                    null
             );
             McpClient client = new McpClient(
                     new ClientInfo("test-client", "Test Client", "1.0"),


### PR DESCRIPTION
## Summary
- support optional `_meta` for CreateMessageResponse
- support optional `_meta` for CompleteResult
- support optional `_meta` for ToolResult
- update related codecs and providers
- adjust tests for new constructors

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68896eaa32a48324a016ecbc26f0af84