### PR TITLE
Add result aliases

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.prompts;
+
+import java.util.List;
+
+/** Result for a {@code prompts/list} request. */
+public record ListPromptsResult(List<Prompt> prompts, String nextCursor) {
+    public ListPromptsResult {
+        prompts = prompts == null ? List.of() : List.copyOf(prompts);
+    }
+
+    @Override
+    public List<Prompt> prompts() {
+        return List.copyOf(prompts);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -64,6 +64,10 @@ public final class PromptCodec {
         return builder.build();
     }
 
+    public static JsonObject toJsonObject(ListPromptsResult page) {
+        return toJsonObject(new PromptPage(page.prompts(), page.nextCursor()));
+    }
+
     public static JsonObject toJsonObject(PromptListChangedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
         return Json.createObjectBuilder().build();
@@ -175,6 +179,11 @@ public final class PromptCodec {
         }
         String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
         return new PromptPage(prompts, cursor);
+    }
+
+    public static ListPromptsResult toListPromptsResult(JsonObject obj) {
+        PromptPage page = toPromptPage(obj);
+        return new ListPromptsResult(page.prompts(), page.nextCursor());
     }
 
     private static PromptArgument toPromptArgument(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesResult.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.server.resources;
+
+import java.util.List;
+
+/** Result for a {@code resources/templates/list} request. */
+public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, String nextCursor) {
+    public ListResourceTemplatesResult {
+        resourceTemplates = resourceTemplates == null ? List.of() : List.copyOf(resourceTemplates);
+    }
+
+    public List<ResourceTemplate> resourceTemplates() {
+        return List.copyOf(resourceTemplates);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesResult.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.server.resources;
+
+import java.util.List;
+
+/** Result for a {@code resources/list} request. */
+public record ListResourcesResult(List<Resource> resources, String nextCursor) {
+    public ListResourcesResult {
+        resources = resources == null ? List.of() : List.copyOf(resources);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -4,6 +4,9 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import com.amannmalik.mcp.util.PaginatedResult;
+import com.amannmalik.mcp.util.PaginationCodec;
 
 
 import java.time.Instant;
@@ -138,6 +141,46 @@ public final class ResourcesCodec {
             }
         }
         return new ResourceAnnotations(audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience), priority, lastModified);
+    }
+
+    public static JsonObject toJsonObject(ListResourcesResult page) {
+        var arr = Json.createArrayBuilder();
+        page.resources().forEach(r -> arr.add(toJsonObject(r)));
+        var b = Json.createObjectBuilder().add("resources", arr.build());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(b::add);
+        return b.build();
+    }
+
+    public static ListResourcesResult toListResourcesResult(JsonObject obj) {
+        var resourcesArr = obj.getJsonArray("resources");
+        if (resourcesArr == null) throw new IllegalArgumentException("resources required");
+        java.util.List<Resource> list = new java.util.ArrayList<>();
+        for (JsonValue v : resourcesArr) {
+            if (v.getValueType() != JsonValue.ValueType.OBJECT) throw new IllegalArgumentException("resource must be object");
+            list.add(toResource(v.asJsonObject()));
+        }
+        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
+        return new ListResourcesResult(list, cursor);
+    }
+
+    public static JsonObject toJsonObject(ListResourceTemplatesResult page) {
+        var arr = Json.createArrayBuilder();
+        page.resourceTemplates().forEach(t -> arr.add(toJsonObject(t)));
+        var b = Json.createObjectBuilder().add("resourceTemplates", arr.build());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(b::add);
+        return b.build();
+    }
+
+    public static ListResourceTemplatesResult toListResourceTemplatesResult(JsonObject obj) {
+        var arr = obj.getJsonArray("resourceTemplates");
+        if (arr == null) throw new IllegalArgumentException("resourceTemplates required");
+        java.util.List<ResourceTemplate> list = new java.util.ArrayList<>();
+        for (JsonValue v : arr) {
+            if (v.getValueType() != JsonValue.ValueType.OBJECT) throw new IllegalArgumentException("resourceTemplate must be object");
+            list.add(toResourceTemplate(v.asJsonObject()));
+        }
+        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
+        return new ListResourceTemplatesResult(list, cursor);
     }
 
     public static JsonObject toJsonObject(ResourceListChangedNotification n) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ListToolsResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ListToolsResult.java
@@ -1,0 +1,15 @@
+package com.amannmalik.mcp.server.tools;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Result for a {@code tools/list} request. */
+public record ListToolsResult(List<Tool> tools, String nextCursor) {
+    public ListToolsResult {
+        tools = tools == null || tools.isEmpty() ? List.of() : List.copyOf(tools);
+    }
+
+    public List<Tool> tools() {
+        return Collections.unmodifiableList(tools);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -36,6 +36,10 @@ public final class ToolCodec {
         return builder.build();
     }
 
+    public static JsonObject toJsonObject(ListToolsResult page) {
+        return toJsonObject(new ToolPage(page.tools(), page.nextCursor()));
+    }
+
     public static JsonObject toJsonObject(ToolResult result) {
         JsonObjectBuilder builder = Json.createObjectBuilder()
                 .add("content", result.content());
@@ -96,6 +100,11 @@ public final class ToolCodec {
         }
         String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
         return new ToolPage(tools, cursor);
+    }
+
+    public static ListToolsResult toListToolsResult(JsonObject obj) {
+        ToolPage page = toToolPage(obj);
+        return new ListToolsResult(page.tools(), page.nextCursor());
     }
 
     public static ToolResult toToolResult(JsonObject obj) {


### PR DESCRIPTION
## Summary
- add alias result types for prompts, tools, and resources
- expose helpers in codecs for new result records

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688971b695388324843b70a7f62cb587