### PR TITLE
Fix tool call types

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/tools/CallToolRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/CallToolRequest.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.validation.InputSanitizer;
+import jakarta.json.JsonObject;
+
+public record CallToolRequest(String name, JsonObject arguments) {
+    public CallToolRequest {
+        name = InputSanitizer.requireClean(name);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/CallToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/CallToolResult.java
@@ -21,11 +21,11 @@ import java.util.Base64;
 import java.util.EnumSet;
 import java.util.Set;
 
-public record ToolResult(JsonArray content,
-                         JsonObject structuredContent,
-                         boolean isError,
-                         JsonObject _meta) {
-    public ToolResult {
+public record CallToolResult(JsonArray content,
+                             JsonObject structuredContent,
+                             boolean isError,
+                             JsonObject _meta) {
+    public CallToolResult {
         content = sanitize(content == null ? JsonValue.EMPTY_JSON_ARRAY : content);
         MetaValidator.requireValid(_meta);
     }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -16,6 +16,20 @@ public final class ToolCodec {
     private ToolCodec() {
     }
 
+    public static JsonObject toJsonObject(CallToolRequest req) {
+        JsonObjectBuilder b = Json.createObjectBuilder().add("name", req.name());
+        if (req.arguments() != null) b.add("arguments", req.arguments());
+        return b.build();
+    }
+
+    public static CallToolRequest toCallToolRequest(JsonObject obj) {
+        if (obj == null) throw new IllegalArgumentException("object required");
+        String name = obj.getString("name", null);
+        if (name == null) throw new IllegalArgumentException("name required");
+        JsonObject args = obj.getJsonObject("arguments");
+        return new CallToolRequest(name, args);
+    }
+
     public static JsonObject toJsonObject(Tool tool) {
         JsonObjectBuilder builder = Json.createObjectBuilder()
                 .add("name", tool.name());
@@ -36,7 +50,7 @@ public final class ToolCodec {
         return builder.build();
     }
 
-    public static JsonObject toJsonObject(ToolResult result) {
+    public static JsonObject toJsonObject(CallToolResult result) {
         JsonObjectBuilder builder = Json.createObjectBuilder()
                 .add("content", result.content());
         if (result.isError()) builder.add("isError", true);
@@ -98,14 +112,14 @@ public final class ToolCodec {
         return new ToolPage(tools, cursor);
     }
 
-    public static ToolResult toToolResult(JsonObject obj) {
+    public static CallToolResult toCallToolResult(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("object required");
         JsonArray content = obj.getJsonArray("content");
         if (content == null) throw new IllegalArgumentException("content required");
         JsonObject structured = obj.getJsonObject("structuredContent");
         boolean isError = obj.getBoolean("isError", false);
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
-        return new ToolResult(content, structured, isError, meta);
+        return new CallToolResult(content, structured, isError, meta);
     }
 
     private static ToolAnnotations toToolAnnotations(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
@@ -5,7 +5,7 @@ import jakarta.json.JsonObject;
 public interface ToolProvider {
     ToolPage list(String cursor);
 
-    ToolResult call(String name, JsonObject arguments);
+    CallToolResult call(String name, JsonObject arguments);
 
     default ToolListSubscription subscribeList(ToolListListener listener) {
         return () -> {


### PR DESCRIPTION
## Summary
- add CallToolRequest and CallToolResult to implement tools/call types from spec
- update ToolProvider and server implementation to use them
- handle CallToolRequest parsing via ToolCodec

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889744609388324b0284058fe2df17e