### PR TITLE
Add _meta to elicitation requests

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationCodec.java
@@ -9,10 +9,11 @@ public final class ElicitationCodec {
     }
 
     public static JsonObject toJsonObject(ElicitationRequest req) {
-        return Json.createObjectBuilder()
+        JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("message", req.message())
-                .add("requestedSchema", req.requestedSchema())
-                .build();
+                .add("requestedSchema", req.requestedSchema());
+        if (req._meta() != null) b.add("_meta", req._meta());
+        return b.build();
     }
 
     public static ElicitationRequest toRequest(JsonObject obj) {
@@ -23,9 +24,11 @@ public final class ElicitationCodec {
         if (schemaVal == null || schemaVal.getValueType() != jakarta.json.JsonValue.ValueType.OBJECT) {
             throw new IllegalArgumentException("requestedSchema must be object");
         }
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
         return new ElicitationRequest(
                 obj.getString("message"),
-                schemaVal.asJsonObject()
+                schemaVal.asJsonObject(),
+                meta
         );
     }
 

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationRequest.java
@@ -2,15 +2,20 @@ package com.amannmalik.mcp.client.elicitation;
 
 import com.amannmalik.mcp.validation.ElicitationSchemaValidator;
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
-public record ElicitationRequest(String message, JsonObject requestedSchema) {
-    public ElicitationRequest(String message, JsonObject requestedSchema) {
+public record ElicitationRequest(String message,
+                                 JsonObject requestedSchema,
+                                 JsonObject _meta) {
+    public ElicitationRequest(String message, JsonObject requestedSchema, JsonObject _meta) {
         if (message == null || requestedSchema == null) {
             throw new IllegalArgumentException("message and requestedSchema are required");
         }
         this.message = InputSanitizer.requireClean(message);
         ElicitationSchemaValidator.requireValid(requestedSchema);
         this.requestedSchema = requestedSchema;
+        MetaValidator.requireValid(_meta);
+        this._meta = _meta;
     }
 }


### PR DESCRIPTION
## Summary
- support the `_meta` field in `ElicitationRequest`
- encode/decode `_meta` in `ElicitationCodec`

## Testing
- `./verify.sh`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6889757ba7cc832482fd47cb659de9d7