### PR TITLE
Fix duplicate resource codec methods

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -231,57 +231,6 @@ public final class ResourcesCodec {
         return new UnsubscribeRequest(obj.getString("uri"));
     }
 
-    public static JsonObject toJsonObject(ListResourcesRequest req) {
-        if (req == null) throw new IllegalArgumentException("request required");
-        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
-    }
-
-    public static ListResourcesRequest toListResourcesRequest(JsonObject obj) {
-        return new ListResourcesRequest(PaginationCodec.toPaginatedRequest(obj).cursor());
-    }
-
-    public static JsonObject toJsonObject(ListResourcesResult result) {
-        var arr = Json.createArrayBuilder();
-        result.resources().forEach(r -> arr.add(toJsonObject(r)));
-        JsonObjectBuilder b = Json.createObjectBuilder().add("resources", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor())).forEach(b::add);
-        return b.build();
-    }
-
-    public static ListResourcesResult toListResourcesResult(JsonObject obj) {
-        var arr = obj.getJsonArray("resources");
-        if (arr == null) throw new IllegalArgumentException("resources required");
-        java.util.List<Resource> list = new java.util.ArrayList<>();
-        arr.forEach(v -> list.add(toResource(v.asJsonObject())));
-        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
-        return new ListResourcesResult(list, cursor);
-    }
-
-    public static JsonObject toJsonObject(ListResourceTemplatesRequest req) {
-        if (req == null) throw new IllegalArgumentException("request required");
-        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
-    }
-
-    public static ListResourceTemplatesRequest toListResourceTemplatesRequest(JsonObject obj) {
-        return new ListResourceTemplatesRequest(PaginationCodec.toPaginatedRequest(obj).cursor());
-    }
-
-    public static JsonObject toJsonObject(ListResourceTemplatesResult result) {
-        var arr = Json.createArrayBuilder();
-        result.resourceTemplates().forEach(t -> arr.add(toJsonObject(t)));
-        JsonObjectBuilder b = Json.createObjectBuilder().add("resourceTemplates", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor())).forEach(b::add);
-        return b.build();
-    }
-
-    public static ListResourceTemplatesResult toListResourceTemplatesResult(JsonObject obj) {
-        var arr = obj.getJsonArray("resourceTemplates");
-        if (arr == null) throw new IllegalArgumentException("resourceTemplates required");
-        java.util.List<ResourceTemplate> list = new java.util.ArrayList<>();
-        arr.forEach(v -> list.add(toResourceTemplate(v.asJsonObject())));
-        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
-        return new ListResourceTemplatesResult(list, cursor);
-    }
 
     public static JsonObject toJsonObject(ReadResourceRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");


### PR DESCRIPTION
## Summary
- clean up duplicate codec definitions for resource lists

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68897843bd188324b6995f1f0a5b403c