### PR TITLE
Implement missing MCP request types

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
@@ -1,0 +1,17 @@
+package com.amannmalik.mcp.prompts;
+
+import com.amannmalik.mcp.validation.InputSanitizer;
+
+import java.util.Map;
+
+public record GetPromptRequest(String name, Map<String, String> arguments) {
+    public GetPromptRequest {
+        name = InputSanitizer.requireClean(name);
+        arguments = arguments == null || arguments.isEmpty() ? Map.of() : Map.copyOf(arguments);
+    }
+
+    @Override
+    public Map<String, String> arguments() {
+        return Map.copyOf(arguments);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.prompts;
+
+public record ListPromptsRequest(String cursor) {
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -240,23 +240,6 @@ public final class ResourcesCodec {
         return new ListResourcesRequest(PaginationCodec.toPaginatedRequest(obj).cursor());
     }
 
-    public static JsonObject toJsonObject(ListResourcesResult result) {
-        var arr = Json.createArrayBuilder();
-        result.resources().forEach(r -> arr.add(toJsonObject(r)));
-        JsonObjectBuilder b = Json.createObjectBuilder().add("resources", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor())).forEach(b::add);
-        return b.build();
-    }
-
-    public static ListResourcesResult toListResourcesResult(JsonObject obj) {
-        var arr = obj.getJsonArray("resources");
-        if (arr == null) throw new IllegalArgumentException("resources required");
-        java.util.List<Resource> list = new java.util.ArrayList<>();
-        arr.forEach(v -> list.add(toResource(v.asJsonObject())));
-        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
-        return new ListResourcesResult(list, cursor);
-    }
-
     public static JsonObject toJsonObject(ListResourceTemplatesRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
         return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
@@ -266,27 +249,7 @@ public final class ResourcesCodec {
         return new ListResourceTemplatesRequest(PaginationCodec.toPaginatedRequest(obj).cursor());
     }
 
-    public static JsonObject toJsonObject(ListResourceTemplatesResult result) {
-        var arr = Json.createArrayBuilder();
-        result.resourceTemplates().forEach(t -> arr.add(toJsonObject(t)));
-        JsonObjectBuilder b = Json.createObjectBuilder().add("resourceTemplates", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor())).forEach(b::add);
-        return b.build();
-    }
 
-    public static ListResourceTemplatesResult toListResourceTemplatesResult(JsonObject obj) {
-        var arr = obj.getJsonArray("resourceTemplates");
-        if (arr == null) throw new IllegalArgumentException("resourceTemplates required");
-        java.util.List<ResourceTemplate> list = new java.util.ArrayList<>();
-        arr.forEach(v -> list.add(toResourceTemplate(v.asJsonObject())));
-        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
-        return new ListResourceTemplatesResult(list, cursor);
-    }
-
-    public static JsonObject toJsonObject(ReadResourceRequest req) {
-        if (req == null) throw new IllegalArgumentException("request required");
-        return Json.createObjectBuilder().add("uri", req.uri()).build();
-    }
 
     public static ReadResourceRequest toReadResourceRequest(JsonObject obj) {
         if (obj == null || !obj.containsKey("uri")) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/CallToolRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/CallToolRequest.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp.server.tools;
+
+import com.amannmalik.mcp.validation.InputSanitizer;
+import jakarta.json.JsonObject;
+
+public record CallToolRequest(String name, JsonObject arguments) {
+    public CallToolRequest {
+        name = InputSanitizer.requireClean(name);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ListToolsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ListToolsRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.server.tools;
+
+public record ListToolsRequest(String cursor) {
+}


### PR DESCRIPTION
## Summary
- introduce request records for prompts and tools
- update PromptCodec and ToolCodec with helpers
- parse new request types in McpServer
- prune duplicate code in ResourcesCodec

## Testing
- `bash verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68897843bd188324b6995f1f0a5b403c