### PR TITLE
Fix elicitation response validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.client.elicitation;
 
+import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.JsonObject;
 
 public record ElicitationResponse(ElicitationAction action, JsonObject content) {
@@ -9,6 +10,18 @@ public record ElicitationResponse(ElicitationAction action, JsonObject content) 
         }
         if (action == ElicitationAction.ACCEPT && content == null) {
             throw new IllegalArgumentException("content required for ACCEPT action");
+        }
+        if (content != null) {
+            for (var entry : content.entrySet()) {
+                InputSanitizer.requireClean(entry.getKey());
+                switch (entry.getValue().getValueType()) {
+                    case STRING -> InputSanitizer.requireClean(content.getString(entry.getKey()));
+                    case NUMBER, TRUE, FALSE -> {
+                    }
+                    default -> throw new IllegalArgumentException(
+                            "content values must be primitive");
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/amannmalik/mcp/client/ElicitationResponseTest.java
+++ b/src/test/java/com/amannmalik/mcp/client/ElicitationResponseTest.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.client;
+
+import com.amannmalik.mcp.client.elicitation.ElicitationAction;
+import com.amannmalik.mcp.client.elicitation.ElicitationResponse;
+import jakarta.json.Json;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ElicitationResponseTest {
+    @Test
+    void rejectNestedContent() {
+        var content = Json.createObjectBuilder()
+                .add("foo", Json.createObjectBuilder().add("bar", 1).build())
+                .build();
+        assertThrows(IllegalArgumentException.class,
+                () -> new ElicitationResponse(ElicitationAction.ACCEPT, content));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce primitive content in ElicitationResponse
- add regression test to cover invalid nested content

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68898098f2d48324848cc7d5247190ee