### PR TITLE
Add meta to elicitation responses

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProvider.java
@@ -17,6 +17,6 @@ public final class BlockingElicitationProvider implements ElicitationProvider {
         ElicitationResponse resp = timeoutMillis <= 0
                 ? responses.take()
                 : responses.poll(timeoutMillis, TimeUnit.MILLISECONDS);
-        return resp != null ? resp : new ElicitationResponse(ElicitationAction.CANCEL, null);
+        return resp != null ? resp : new ElicitationResponse(ElicitationAction.CANCEL, null, null);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationCodec.java
@@ -36,6 +36,7 @@ public final class ElicitationCodec {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("action", resp.action().name().toLowerCase());
         if (resp.content() != null) b.add("content", resp.content());
+        if (resp._meta() != null) b.add("_meta", resp._meta());
         return b.build();
     }
 
@@ -59,6 +60,7 @@ public final class ElicitationCodec {
             }
             content = c.asJsonObject();
         }
-        return new ElicitationResponse(action, content);
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new ElicitationResponse(action, content, meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationResponse.java
@@ -1,9 +1,12 @@
 package com.amannmalik.mcp.client.elicitation;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
-public record ElicitationResponse(ElicitationAction action, JsonObject content) {
+public record ElicitationResponse(ElicitationAction action,
+                                  JsonObject content,
+                                  JsonObject _meta) {
     public ElicitationResponse {
         if (action == null) {
             throw new IllegalArgumentException("action is required");
@@ -23,5 +26,6 @@ public record ElicitationResponse(ElicitationAction action, JsonObject content) 
                 }
             }
         }
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -102,7 +102,7 @@ class McpConformanceTest {
             );
 
             BlockingElicitationProvider elicitation = new BlockingElicitationProvider();
-            elicitation.respond(new ElicitationResponse(ElicitationAction.CANCEL, null));
+            elicitation.respond(new ElicitationResponse(ElicitationAction.CANCEL, null, null));
             SamplingProvider sampling = SamplingProviderFactory.createMock(new CreateMessageResponse(
                     Role.ASSISTANT,
                     new MessageContent.Text("ok", null, null),


### PR DESCRIPTION
## Summary
- carry `_meta` field through `ElicitationResponse`
- support `_meta` in `ElicitationCodec`
- update test expectation

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68898b57f98c8324a8a561681b55cf17