### PR TITLE
Enforce protocol version header

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -259,6 +259,11 @@ public final class StreamableHttpTransport implements Transport {
             } else if (authManager != null && sessionPrincipal.get() != null && !sessionPrincipal.get().id().equals(principal.id())) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
+            } else if (session != null) {
+                if (version == null || !version.equals(protocolVersion)) {
+                    resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                    return;
+                }
             } else if (version != null && !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
@@ -424,7 +429,12 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
 
-            if (version != null && !version.equals(protocolVersion)) {
+            if (session != null) {
+                if (version == null || !version.equals(protocolVersion)) {
+                    resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                    return;
+                }
+            } else if (version != null && !version.equals(protocolVersion)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }


### PR DESCRIPTION
## Summary
- enforce `MCP-Protocol-Version` header for HTTP transport once a session is
  established

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68898b57f98c8324a8a561681b55cf17