### PR TITLE
Implement typed list request classes

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.prompts;
+
+public record ListPromptsRequest(String cursor) {
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -62,6 +62,13 @@ public final class PromptCodec {
         return builder.build();
     }
 
+    public static JsonObject toJsonObject(ListPromptsRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (req.cursor() != null) b.add("cursor", req.cursor());
+        return b.build();
+    }
+
     public static JsonObject toJsonObject(ListPromptsResult page) {
         return toJsonObject(new PromptPage(page.prompts(), page.nextCursor()));
     }
@@ -182,6 +189,11 @@ public final class PromptCodec {
     public static ListPromptsResult toListPromptsResult(JsonObject obj) {
         PromptPage page = toPromptPage(obj);
         return new ListPromptsResult(page.prompts(), page.nextCursor());
+    }
+
+    public static ListPromptsRequest toListPromptsRequest(JsonObject obj) {
+        String cursor = obj == null ? null : obj.getString("cursor", null);
+        return new ListPromptsRequest(cursor);
     }
 
     private static PromptArgument toPromptArgument(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -46,6 +46,7 @@ import com.amannmalik.mcp.prompts.PromptProvider;
 import com.amannmalik.mcp.prompts.PromptTemplate;
 import com.amannmalik.mcp.prompts.PromptsSubscription;
 import com.amannmalik.mcp.prompts.Role;
+import com.amannmalik.mcp.prompts.ListPromptsRequest;
 import com.amannmalik.mcp.security.PrivacyBoundaryEnforcer;
 import com.amannmalik.mcp.security.RateLimiter;
 import com.amannmalik.mcp.security.ResourceAccessController;
@@ -65,6 +66,7 @@ import com.amannmalik.mcp.server.resources.ResourceBlock;
 import com.amannmalik.mcp.server.resources.ResourceList;
 import com.amannmalik.mcp.server.resources.ResourceListSubscription;
 import com.amannmalik.mcp.server.resources.ListResourcesResult;
+import com.amannmalik.mcp.server.resources.ListResourcesRequest;
 import com.amannmalik.mcp.server.resources.ListResourceTemplatesRequest;
 import com.amannmalik.mcp.server.resources.ListResourceTemplatesResult;
 import com.amannmalik.mcp.server.resources.ResourceProvider;
@@ -83,6 +85,7 @@ import com.amannmalik.mcp.server.tools.ToolListSubscription;
 import com.amannmalik.mcp.server.tools.ToolPage;
 import com.amannmalik.mcp.server.tools.ToolProvider;
 import com.amannmalik.mcp.server.tools.ToolResult;
+import com.amannmalik.mcp.server.tools.ListToolsRequest;
 import com.amannmalik.mcp.transport.Transport;
 import com.amannmalik.mcp.util.CancellationCodec;
 import com.amannmalik.mcp.util.CancellationTracker;
@@ -507,7 +510,8 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage listResources(JsonRpcRequest req) {
         requireServerCapability(ServerCapability.RESOURCES);
-        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
+        ListResourcesRequest lr = ResourcesCodec.toListResourcesRequest(req.params());
+        String cursor = lr.cursor();
         if (cursor != null) {
             try {
                 cursor = InputSanitizer.requireClean(cursor);
@@ -671,7 +675,8 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage listTools(JsonRpcRequest req) {
         requireServerCapability(ServerCapability.TOOLS);
-        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
+        ListToolsRequest ltr = ToolCodec.toListToolsRequest(req.params());
+        String cursor = ltr.cursor();
         if (cursor != null) {
             try {
                 cursor = InputSanitizer.requireClean(cursor);
@@ -723,7 +728,8 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage listPrompts(JsonRpcRequest req) {
         requireServerCapability(ServerCapability.PROMPTS);
-        String cursor = PaginationCodec.toPaginatedRequest(req.params()).cursor();
+        ListPromptsRequest lpr = PromptCodec.toListPromptsRequest(req.params());
+        String cursor = lpr.cursor();
         if (cursor != null) {
             try {
                 cursor = InputSanitizer.requireClean(cursor);

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.server.resources;
+
+public record ListResourcesRequest(String cursor) {
+}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -244,6 +244,18 @@ public final class ResourcesCodec {
         return new ListResourcesResult(resources, obj.getString("nextCursor", null));
     }
 
+    public static JsonObject toJsonObject(ListResourcesRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (req.cursor() != null) b.add("cursor", req.cursor());
+        return b.build();
+    }
+
+    public static ListResourcesRequest toListResourcesRequest(JsonObject obj) {
+        String cursor = obj == null ? null : obj.getString("cursor", null);
+        return new ListResourcesRequest(cursor);
+    }
+
     public static JsonObject toJsonObject(ListResourceTemplatesRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
         JsonObjectBuilder b = Json.createObjectBuilder();

--- a/src/main/java/com/amannmalik/mcp/server/tools/ListToolsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ListToolsRequest.java
@@ -1,0 +1,4 @@
+package com.amannmalik.mcp.server.tools;
+
+public record ListToolsRequest(String cursor) {
+}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -33,6 +33,13 @@ public final class ToolCodec {
         return builder.build();
     }
 
+    public static JsonObject toJsonObject(ListToolsRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (req.cursor() != null) b.add("cursor", req.cursor());
+        return b.build();
+    }
+
     public static JsonObject toJsonObject(ListToolsResult page) {
         return toJsonObject(new ToolPage(page.tools(), page.nextCursor()));
     }
@@ -102,6 +109,11 @@ public final class ToolCodec {
     public static ListToolsResult toListToolsResult(JsonObject obj) {
         ToolPage page = toToolPage(obj);
         return new ListToolsResult(page.tools(), page.nextCursor());
+    }
+
+    public static ListToolsRequest toListToolsRequest(JsonObject obj) {
+        String cursor = obj == null ? null : obj.getString("cursor", null);
+        return new ListToolsRequest(cursor);
     }
 
     public static ToolResult toToolResult(JsonObject obj) {


### PR DESCRIPTION
## Summary
- add `ListResourcesRequest`, `ListToolsRequest`, and `ListPromptsRequest`
- update codecs to encode/decode typed list requests
- use typed list requests in `McpServer`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68898b57f98c8324a8a561681b55cf17