### PR TITLE
Align elicitation types with 2025-06-18 spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -1,10 +1,10 @@
 package com.amannmalik.mcp.client;
 
 import com.amannmalik.mcp.client.elicitation.ElicitationAction;
-import com.amannmalik.mcp.client.elicitation.ElicitationCodec;
+import com.amannmalik.mcp.client.elicitation.ElicitCodec;
 import com.amannmalik.mcp.client.elicitation.ElicitationProvider;
-import com.amannmalik.mcp.client.elicitation.ElicitationRequest;
-import com.amannmalik.mcp.client.elicitation.ElicitationResponse;
+import com.amannmalik.mcp.client.elicitation.ElicitRequest;
+import com.amannmalik.mcp.client.elicitation.ElicitResult;
 import com.amannmalik.mcp.client.roots.RootsCodec;
 import com.amannmalik.mcp.client.roots.RootsProvider;
 import com.amannmalik.mcp.client.roots.RootsSubscription;
@@ -555,8 +555,8 @@ public final class McpClient implements AutoCloseable {
                     JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing params", null));
         }
         try {
-            ElicitationRequest er = ElicitationCodec.toRequest(params);
-            ElicitationResponse resp = elicitation.elicit(er);
+            ElicitRequest er = ElicitCodec.toRequest(params);
+            ElicitResult resp = elicitation.elicit(er);
             if (resp.action() == ElicitationAction.ACCEPT) {
                 try {
                     SchemaValidator.validate(er.requestedSchema(), resp.content());
@@ -565,7 +565,7 @@ public final class McpClient implements AutoCloseable {
                             JsonRpcErrorCode.INVALID_PARAMS.code(), ve.getMessage(), null));
                 }
             }
-            return new JsonRpcResponse(req.id(), ElicitationCodec.toJsonObject(resp));
+            return new JsonRpcResponse(req.id(), ElicitCodec.toJsonObject(resp));
         } catch (IllegalArgumentException e) {
             return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                     JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/BlockingElicitationProvider.java
@@ -5,18 +5,18 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 public final class BlockingElicitationProvider implements ElicitationProvider {
-    private final BlockingQueue<ElicitationResponse> responses = new LinkedBlockingQueue<>();
+    private final BlockingQueue<ElicitResult> responses = new LinkedBlockingQueue<>();
 
-    public void respond(ElicitationResponse response) {
+    public void respond(ElicitResult response) {
         if (response == null) throw new IllegalArgumentException("response is required");
         responses.offer(response);
     }
 
     @Override
-    public ElicitationResponse elicit(ElicitationRequest request, long timeoutMillis) throws InterruptedException {
-        ElicitationResponse resp = timeoutMillis <= 0
+    public ElicitResult elicit(ElicitRequest request, long timeoutMillis) throws InterruptedException {
+        ElicitResult resp = timeoutMillis <= 0
                 ? responses.take()
                 : responses.poll(timeoutMillis, TimeUnit.MILLISECONDS);
-        return resp != null ? resp : new ElicitationResponse(ElicitationAction.CANCEL, null, null);
+        return resp != null ? resp : new ElicitResult(ElicitationAction.CANCEL, null, null);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitCodec.java
@@ -4,11 +4,11 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
-public final class ElicitationCodec {
-    private ElicitationCodec() {
+public final class ElicitCodec {
+    private ElicitCodec() {
     }
 
-    public static JsonObject toJsonObject(ElicitationRequest req) {
+    public static JsonObject toJsonObject(ElicitRequest req) {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("message", req.message())
                 .add("requestedSchema", req.requestedSchema());
@@ -16,7 +16,7 @@ public final class ElicitationCodec {
         return b.build();
     }
 
-    public static ElicitationRequest toRequest(JsonObject obj) {
+    public static ElicitRequest toRequest(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("object required");
         if (!obj.containsKey("message")) throw new IllegalArgumentException("message required");
         if (!obj.containsKey("requestedSchema")) throw new IllegalArgumentException("requestedSchema required");
@@ -25,14 +25,14 @@ public final class ElicitationCodec {
             throw new IllegalArgumentException("requestedSchema must be object");
         }
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
-        return new ElicitationRequest(
+        return new ElicitRequest(
                 obj.getString("message"),
                 schemaVal.asJsonObject(),
                 meta
         );
     }
 
-    public static JsonObject toJsonObject(ElicitationResponse resp) {
+    public static JsonObject toJsonObject(ElicitResult resp) {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("action", resp.action().name().toLowerCase());
         if (resp.content() != null) b.add("content", resp.content());
@@ -40,7 +40,7 @@ public final class ElicitationCodec {
         return b.build();
     }
 
-    public static ElicitationResponse toResponse(JsonObject obj) {
+    public static ElicitResult toResult(JsonObject obj) {
         if (obj == null || !obj.containsKey("action")) {
             throw new IllegalArgumentException("action required");
         }
@@ -61,6 +61,6 @@ public final class ElicitationCodec {
             content = c.asJsonObject();
         }
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
-        return new ElicitationResponse(action, content, meta);
+        return new ElicitResult(action, content, meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitRequest.java
@@ -5,10 +5,10 @@ import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
-public record ElicitationRequest(String message,
-                                 JsonObject requestedSchema,
-                                 JsonObject _meta) {
-    public ElicitationRequest(String message, JsonObject requestedSchema, JsonObject _meta) {
+public record ElicitRequest(String message,
+                            JsonObject requestedSchema,
+                            JsonObject _meta) {
+    public ElicitRequest(String message, JsonObject requestedSchema, JsonObject _meta) {
         if (message == null || requestedSchema == null) {
             throw new IllegalArgumentException("message and requestedSchema are required");
         }

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitResult.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitResult.java
@@ -4,10 +4,10 @@ import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
-public record ElicitationResponse(ElicitationAction action,
-                                  JsonObject content,
-                                  JsonObject _meta) {
-    public ElicitationResponse {
+public record ElicitResult(ElicitationAction action,
+                           JsonObject content,
+                           JsonObject _meta) {
+    public ElicitResult {
         if (action == null) {
             throw new IllegalArgumentException("action is required");
         }

--- a/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/elicitation/ElicitationProvider.java
@@ -2,9 +2,9 @@ package com.amannmalik.mcp.client.elicitation;
 
 public interface ElicitationProvider {
 
-    ElicitationResponse elicit(ElicitationRequest request, long timeoutMillis) throws InterruptedException;
+    ElicitResult elicit(ElicitRequest request, long timeoutMillis) throws InterruptedException;
 
-    default ElicitationResponse elicit(ElicitationRequest request) throws InterruptedException {
+    default ElicitResult elicit(ElicitRequest request) throws InterruptedException {
         return elicit(request, 0);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -2,9 +2,9 @@ package com.amannmalik.mcp.server;
 
 import com.amannmalik.mcp.auth.Principal;
 import com.amannmalik.mcp.client.elicitation.ElicitationAction;
-import com.amannmalik.mcp.client.elicitation.ElicitationCodec;
-import com.amannmalik.mcp.client.elicitation.ElicitationRequest;
-import com.amannmalik.mcp.client.elicitation.ElicitationResponse;
+import com.amannmalik.mcp.client.elicitation.ElicitCodec;
+import com.amannmalik.mcp.client.elicitation.ElicitRequest;
+import com.amannmalik.mcp.client.elicitation.ElicitResult;
 import com.amannmalik.mcp.client.roots.ListRootsRequest;
 import com.amannmalik.mcp.client.roots.Root;
 import com.amannmalik.mcp.client.roots.RootsCodec;
@@ -880,11 +880,11 @@ public final class McpServer implements AutoCloseable {
         rootsListeners.forEach(RootsListener::listChanged);
     }
 
-    public ElicitationResponse elicit(ElicitationRequest req) throws IOException {
+    public ElicitResult elicit(ElicitRequest req) throws IOException {
         requireClientCapability(ClientCapability.ELICITATION);
-        JsonRpcMessage msg = sendRequest("elicitation/create", ElicitationCodec.toJsonObject(req));
+        JsonRpcMessage msg = sendRequest("elicitation/create", ElicitCodec.toJsonObject(req));
         if (msg instanceof JsonRpcResponse resp) {
-            ElicitationResponse er = ElicitationCodec.toResponse(resp.result());
+            ElicitResult er = ElicitCodec.toResult(resp.result());
             if (er.action() == ElicitationAction.ACCEPT) {
                 SchemaValidator.validate(req.requestedSchema(), er.content());
             }

--- a/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceTest.java
@@ -3,7 +3,7 @@ package com.amannmalik.mcp;
 import com.amannmalik.mcp.client.McpClient;
 import com.amannmalik.mcp.client.elicitation.BlockingElicitationProvider;
 import com.amannmalik.mcp.client.elicitation.ElicitationAction;
-import com.amannmalik.mcp.client.elicitation.ElicitationResponse;
+import com.amannmalik.mcp.client.elicitation.ElicitResult;
 import com.amannmalik.mcp.client.roots.InMemoryRootsProvider;
 import com.amannmalik.mcp.client.roots.Root;
 import com.amannmalik.mcp.client.sampling.CreateMessageResponse;
@@ -104,7 +104,7 @@ class McpConformanceTest {
             );
 
             BlockingElicitationProvider elicitation = new BlockingElicitationProvider();
-            elicitation.respond(new ElicitationResponse(ElicitationAction.CANCEL, null, null));
+            elicitation.respond(new ElicitResult(ElicitationAction.CANCEL, null, null));
             SamplingProvider sampling = SamplingProviderFactory.createMock(new CreateMessageResponse(
                     Role.ASSISTANT,
                     new MessageContent.Text("ok", null, null),


### PR DESCRIPTION
## Summary
- rename `ElicitationRequest`/`ElicitationResponse` to `ElicitRequest`/`ElicitResult`
- rename `ElicitationCodec` to `ElicitCodec`
- update usages across server, client and tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68898ebb7b588324a8760c8eecc05a4b