### PR TITLE
Implement sampling consent controls

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -10,6 +10,7 @@ import com.amannmalik.mcp.security.HostProcess;
 import com.amannmalik.mcp.security.PrivacyBoundaryEnforcer;
 import com.amannmalik.mcp.security.SecurityPolicy;
 import com.amannmalik.mcp.security.ToolAccessController;
+import com.amannmalik.mcp.security.SamplingAccessController;
 import com.amannmalik.mcp.transport.StdioTransport;
 import picocli.CommandLine;
 
@@ -70,10 +71,11 @@ public final class HostCommand implements Callable<Integer> {
         ConsentManager consents = new ConsentManager();
         ToolAccessController tools = new ToolAccessController();
         PrivacyBoundaryEnforcer privacyBoundary = new PrivacyBoundaryEnforcer();
+        SamplingAccessController sampling = new SamplingAccessController();
         SecurityPolicy policy = c -> true;
         Principal principal = new Principal("user", Set.of());
 
-        try (HostProcess host = new HostProcess(policy, consents, tools, privacyBoundary, principal)) {
+        try (HostProcess host = new HostProcess(policy, consents, tools, privacyBoundary, sampling, principal)) {
             for (var entry : cfg.clients().entrySet()) {
                 host.grantConsent(entry.getKey());
                 var pb = new ProcessBuilder(entry.getValue().split(" "));
@@ -146,6 +148,14 @@ public final class HostCommand implements Callable<Integer> {
                             host.revokeTool(parts[1]);
                             System.out.println("Revoked tool: " + parts[1]);
                         }
+                    }
+                    case "allow-sampling" -> {
+                        host.allowSampling();
+                        System.out.println("Sampling allowed");
+                    }
+                    case "revoke-sampling" -> {
+                        host.revokeSampling();
+                        System.out.println("Sampling revoked");
                     }
                     case "list-tools" -> {
                         if (parts.length < 2) {
@@ -230,6 +240,8 @@ public final class HostCommand implements Callable<Integer> {
                   revoke-consent <scope>            - Revoke consent for scope
                   allow-tool <tool>                 - Allow tool access
                   revoke-tool <tool>                - Revoke tool access
+                  allow-sampling                   - Allow sampling requests
+                  revoke-sampling                  - Revoke sampling requests
                   allow-audience <audience>         - Allow audience access
                   revoke-audience <audience>        - Revoke audience access
                   list-tools <client-id> [cursor]  - List tools from client

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -24,6 +24,7 @@ public final class HostProcess implements AutoCloseable {
     private final Principal principal;
     private final ToolAccessController toolAccess;
     private final PrivacyBoundaryEnforcer privacyBoundary;
+    private final SamplingAccessController samplingAccess;
 
     private static ServerCapability capabilityForMethod(String method) {
         if (method.startsWith("tools/")) return ServerCapability.TOOLS;
@@ -44,11 +45,13 @@ public final class HostProcess implements AutoCloseable {
                        ConsentManager consents,
                        ToolAccessController toolAccess,
                        PrivacyBoundaryEnforcer privacyBoundary,
+                       SamplingAccessController samplingAccess,
                        Principal principal) {
         this.policy = policy;
         this.consents = consents;
         this.toolAccess = toolAccess;
         this.privacyBoundary = privacyBoundary;
+        this.samplingAccess = samplingAccess;
         this.principal = principal;
     }
 
@@ -90,6 +93,14 @@ public final class HostProcess implements AutoCloseable {
 
     public void revokeTool(String tool) {
         toolAccess.revoke(principal.id(), tool);
+    }
+
+    public void allowSampling() {
+        samplingAccess.allow(principal.id());
+    }
+
+    public void revokeSampling() {
+        samplingAccess.revoke(principal.id());
     }
 
     public void allowAudience(Role audience) {

--- a/src/main/java/com/amannmalik/mcp/security/SamplingAccessController.java
+++ b/src/main/java/com/amannmalik/mcp/security/SamplingAccessController.java
@@ -1,0 +1,29 @@
+package com.amannmalik.mcp.security;
+
+import com.amannmalik.mcp.auth.Principal;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class SamplingAccessController implements SamplingAccessPolicy {
+    private final Set<String> allowed = ConcurrentHashMap.newKeySet();
+
+    public void allow(String principalId) {
+        if (principalId == null || principalId.isBlank()) throw new IllegalArgumentException("principalId required");
+        allowed.add(principalId);
+    }
+
+    public void revoke(String principalId) {
+        if (principalId == null || principalId.isBlank()) throw new IllegalArgumentException("principalId required");
+        allowed.remove(principalId);
+    }
+
+    @Override
+    public void requireAllowed(Principal principal) {
+        if (principal == null) throw new IllegalArgumentException("principal required");
+        if (!allowed.contains(principal.id())) {
+            throw new SecurityException("Sampling not authorized");
+        }
+    }
+}
+

--- a/src/main/java/com/amannmalik/mcp/security/SamplingAccessPolicy.java
+++ b/src/main/java/com/amannmalik/mcp/security/SamplingAccessPolicy.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.security;
+
+import com.amannmalik.mcp.auth.Principal;
+
+@FunctionalInterface
+public interface SamplingAccessPolicy {
+    void requireAllowed(Principal principal);
+
+    SamplingAccessPolicy PERMISSIVE = p -> {
+    };
+}
+


### PR DESCRIPTION
## Summary
- enforce sampling access with new security policy classes
- require sampling approval in `McpServer`
- expose sampling permissions in `HostProcess` and `HostCommand`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68898d24d2e88324b95a6ec27e033e07