### PR TITLE
Add sampling access check in client

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -66,6 +66,8 @@ public final class HostProcess implements AutoCloseable {
             throw new IllegalArgumentException("Client already registered: " + id);
         }
         try {
+            client.setPrincipal(principal);
+            client.setSamplingAccessPolicy(samplingAccess);
             client.configurePing(30000, 5000);
             client.connect();
         } catch (IOException e) {


### PR DESCRIPTION
## Summary
- enforce sampling access policy in `McpClient`
- configure client principals and sampling policy in `HostProcess`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688994ff361483248ace8bd17cbdeac2