### PR TITLE
Align numeric types with spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -607,7 +607,7 @@ public final class McpClient implements AutoCloseable {
         var val = meta.get("progressToken");
         return switch (val.getValueType()) {
             case STRING -> new ProgressToken.StringToken(meta.getString("progressToken"));
-            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").doubleValue());
+            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
             default -> throw new IllegalArgumentException("progressToken must be a string or number");
         };
     }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -92,7 +92,7 @@ public final class JsonRpcCodec {
             throw new IllegalArgumentException("id is required");
         }
         return switch (value.getValueType()) {
-            case NUMBER -> new RequestId.NumericId(((JsonNumber) value).doubleValue());
+            case NUMBER -> new RequestId.NumericId(((JsonNumber) value).longValue());
             case STRING -> new RequestId.StringId(((JsonString) value).getString());
             default -> throw new IllegalArgumentException("Invalid id type");
         };

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -4,6 +4,6 @@ public sealed interface RequestId permits RequestId.StringId, RequestId.NumericI
     record StringId(String value) implements RequestId {
     }
 
-    record NumericId(double value) implements RequestId {
+    record NumericId(long value) implements RequestId {
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -464,7 +464,7 @@ public final class McpServer implements AutoCloseable {
         var val = meta.get("progressToken");
         return switch (val.getValueType()) {
             case STRING -> new ProgressToken.StringToken(InputSanitizer.requireClean(meta.getString("progressToken")));
-            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").doubleValue());
+            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
             default -> throw new IllegalArgumentException("progressToken must be a string or number");
         };
     }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -159,7 +159,7 @@ public final class StreamableHttpTransport implements Transport {
                         reqId = new RequestId.StringId(id.substring(1, id.length() - 1));
                     } else {
                         try {
-                            reqId = new RequestId.NumericId(Double.parseDouble(id));
+                            reqId = new RequestId.NumericId(Long.parseLong(id));
                         } catch (NumberFormatException e) {
                             reqId = new RequestId.StringId(id);
                         }
@@ -183,7 +183,7 @@ public final class StreamableHttpTransport implements Transport {
                     reqId = new RequestId.StringId(id.substring(1, id.length() - 1));
                 } else {
                     try {
-                        reqId = new RequestId.NumericId(Double.parseDouble(id));
+                        reqId = new RequestId.NumericId(Long.parseLong(id));
                     } catch (NumberFormatException e) {
                         reqId = new RequestId.StringId(id);
                     }

--- a/src/main/java/com/amannmalik/mcp/util/CancellationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/CancellationCodec.java
@@ -35,7 +35,7 @@ public final class CancellationCodec {
         }
         return switch (v.getValueType()) {
             case STRING -> new RequestId.StringId(((JsonString) v).getString());
-            case NUMBER -> new RequestId.NumericId(((JsonNumber) v).doubleValue());
+            case NUMBER -> new RequestId.NumericId(((JsonNumber) v).longValue());
             default -> throw new IllegalArgumentException("Invalid requestId type");
         };
     }

--- a/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
@@ -35,7 +35,7 @@ public final class ProgressCodec {
     private static ProgressToken toToken(JsonValue value) {
         return switch (value.getValueType()) {
             case STRING -> new ProgressToken.StringToken(InputSanitizer.requireClean(((JsonString) value).getString()));
-            case NUMBER -> new ProgressToken.NumericToken(((JsonNumber) value).doubleValue());
+            case NUMBER -> new ProgressToken.NumericToken(((JsonNumber) value).longValue());
             default -> throw new IllegalArgumentException("Invalid token type");
         };
     }

--- a/src/main/java/com/amannmalik/mcp/util/ProgressToken.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressToken.java
@@ -4,6 +4,6 @@ public sealed interface ProgressToken permits ProgressToken.StringToken, Progres
     record StringToken(String value) implements ProgressToken {
     }
 
-    record NumericToken(double value) implements ProgressToken {
+    record NumericToken(long value) implements ProgressToken {
     }
 }


### PR DESCRIPTION
## Summary
- enforce integer-only progress tokens and request IDs
- parse numeric IDs safely in HTTP transport
- adjust conversion in codecs and server/client handlers

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688994ff361483248ace8bd17cbdeac2