### PR TITLE
Apply schema-sanctioned input sanitization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
@@ -18,7 +18,14 @@ public record CreateMessageRequest(
 
     public CreateMessageRequest {
         messages = messages == null || messages.isEmpty() ? List.of() : List.copyOf(messages);
-        stopSequences = stopSequences == null || stopSequences.isEmpty() ? List.of() : List.copyOf(stopSequences);
+        systemPrompt = systemPrompt == null ? null : com.amannmalik.mcp.validation.InputSanitizer.requireClean(systemPrompt);
+        if (stopSequences == null || stopSequences.isEmpty()) {
+            stopSequences = List.of();
+        } else {
+            stopSequences = stopSequences.stream()
+                    .map(com.amannmalik.mcp.validation.InputSanitizer::requireClean)
+                    .toList();
+        }
         if (maxTokens <= 0) {
             throw new IllegalArgumentException("maxTokens must be > 0");
         }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
@@ -14,6 +14,7 @@ public sealed interface MessageContent permits MessageContent.Text, MessageConte
     record Text(String text, Annotations annotations, JsonObject _meta) implements MessageContent {
         public Text {
             if (text == null) throw new IllegalArgumentException("text is required");
+            text = com.amannmalik.mcp.validation.InputSanitizer.requireClean(text);
             MetaValidator.requireValid(_meta);
         }
 


### PR DESCRIPTION
## Summary
- sanitize message text inputs
- sanitize systemPrompt and stop sequences in sampling requests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688999998c0483249eb2cdeb4b742d40