### PR TITLE
Align initialization version response

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -26,11 +26,6 @@ public class ProtocolLifecycle {
         clientCapabilities = requested.isEmpty()
                 ? EnumSet.noneOf(ClientCapability.class)
                 : EnumSet.copyOf(requested);
-        if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
-            throw new UnsupportedProtocolVersionException(
-                    request.protocolVersion(), SUPPORTED_VERSION);
-        }
-
         return new InitializeResponse(
                 SUPPORTED_VERSION,
                 new Capabilities(clientCapabilities, serverCapabilities, Map.of(), Map.of()),

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -31,7 +31,6 @@ import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.lifecycle.ServerFeatures;
 import com.amannmalik.mcp.lifecycle.ServerInfo;
-import com.amannmalik.mcp.lifecycle.UnsupportedProtocolVersionException;
 import com.amannmalik.mcp.ping.PingCodec;
 import com.amannmalik.mcp.ping.PingRequest;
 import com.amannmalik.mcp.prompts.GetPromptRequest;
@@ -402,19 +401,7 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage initialize(JsonRpcRequest req) {
         InitializeRequest init = LifecycleCodec.toInitializeRequest(req.params());
-        InitializeResponse baseResp;
-        try {
-            baseResp = lifecycle.initialize(init);
-        } catch (UnsupportedProtocolVersionException e) {
-            var data = Json.createObjectBuilder()
-                    .add("supported", Json.createArrayBuilder().add(e.supported()))
-                    .add("requested", e.requested())
-                    .build();
-            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
-                    JsonRpcErrorCode.INVALID_PARAMS.code(),
-                    "Unsupported protocol version",
-                    data));
-        }
+        InitializeResponse baseResp = lifecycle.initialize(init);
         InitializeResponse resp = new InitializeResponse(
                 baseResp.protocolVersion(),
                 baseResp.capabilities(),


### PR DESCRIPTION
## Summary
- honor spec guidance that servers always respond with supported version
- simplify initialization handling in `McpServer`

## Testing
- `gradle check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688999998c0483249eb2cdeb4b742d40