### PR TITLE
Add sampling handler

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -178,6 +178,14 @@ public final class HostCommand implements Callable<Integer> {
                             System.out.println(host.callTool(parts[1], parts[2], args));
                         }
                     }
+                    case "create-message" -> {
+                        if (parts.length < 3) {
+                            System.out.println("Usage: create-message <client-id> <json-params>");
+                        } else {
+                            var params = jakarta.json.Json.createReader(new java.io.StringReader(parts[2])).readObject();
+                            System.out.println(host.createMessage(parts[1], params));
+                        }
+                    }
                     case "allow-audience" -> {
                         if (parts.length != 2) {
                             System.out.println("Usage: allow-audience <audience>");
@@ -249,6 +257,7 @@ public final class HostCommand implements Callable<Integer> {
                   revoke-audience <audience>        - Revoke audience access
                   list-tools <client-id> [cursor]  - List tools from client
                   call-tool <client-id> <tool> [args] - Call tool (args as JSON)
+                  create-message <client-id> <params> - Request sampling
                   request <client-id> <method> [params] - Send request to client
                   notify <client-id> <method> [params]  - Send notification to client
                   quit                              - Exit interactive mode

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -153,6 +153,17 @@ public final class HostProcess implements AutoCloseable {
         throw new IOException("Unexpected response");
     }
 
+    public JsonObject createMessage(String clientId, JsonObject params) throws IOException {
+        McpClient client = clients.get(clientId);
+        if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
+        if (!client.connected()) throw new IllegalStateException("Client not connected: " + clientId);
+        samplingAccess.requireAllowed(principal);
+        JsonRpcMessage resp = client.request("sampling/createMessage", params);
+        if (resp instanceof JsonRpcResponse r) return r.result();
+        if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
+        throw new IOException("Unexpected response");
+    }
+
     public JsonRpcMessage request(String id, String method, JsonObject params) throws IOException {
         McpClient client = clients.get(id);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + id);

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -263,6 +263,8 @@ public final class McpServer implements AutoCloseable {
         if (completions != null) {
             registerRequestHandler("completion/complete", this::complete);
         }
+
+        registerRequestHandler("sampling/createMessage", this::handleCreateMessage);
     }
 
     private ProtocolLifecycle lifecycle() {
@@ -905,6 +907,25 @@ public final class McpServer implements AutoCloseable {
             return SamplingCodec.toCreateMessageResponse(resp.result());
         }
         throw new IOException(((JsonRpcError) msg).error().message());
+    }
+
+    private JsonRpcMessage handleCreateMessage(JsonRpcRequest req) {
+        JsonObject params = req.params();
+        if (params == null) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), "Missing params", null));
+        }
+        try {
+            CreateMessageRequest cmr = SamplingCodec.toCreateMessageRequest(params);
+            CreateMessageResponse resp = createMessage(cmr);
+            return new JsonRpcResponse(req.id(), SamplingCodec.toJsonObject(resp));
+        } catch (IllegalArgumentException e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
+        } catch (Exception e) {
+            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
+                    JsonRpcErrorCode.INTERNAL_ERROR.code(), e.getMessage(), null));
+        }
     }
 
     private static ResourceProvider createDefaultResources() {


### PR DESCRIPTION
## Summary
- allow HostProcess to call sampling/createMessage
- support new CLI command `create-message`
- expose sampling handler in McpServer

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68899a9886ac8324ae40563ac5318820