### PR TITLE
Centralize pagination encoding

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
+import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.PaginationCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
@@ -64,9 +65,7 @@ public final class PromptCodec {
 
     public static JsonObject toJsonObject(ListPromptsRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        JsonObjectBuilder b = Json.createObjectBuilder();
-        if (req.cursor() != null) b.add("cursor", req.cursor());
-        return b.build();
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
     }
 
     public static JsonObject toJsonObject(ListPromptsResult page) {
@@ -204,7 +203,7 @@ public final class PromptCodec {
     }
 
     public static ListPromptsRequest toListPromptsRequest(JsonObject obj) {
-        String cursor = obj == null ? null : obj.getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
         return new ListPromptsRequest(cursor);
     }
 

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -7,6 +7,8 @@ import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
 import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.prompts.Role;
+import com.amannmalik.mcp.util.PaginatedRequest;
+import com.amannmalik.mcp.util.PaginationCodec;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 
@@ -129,9 +131,7 @@ public final class HostProcess implements AutoCloseable {
         McpClient client = clients.get(clientId);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, java.util.Optional.of(ServerCapability.TOOLS));
-        JsonObject params = cursor == null
-                ? Json.createObjectBuilder().build()
-                : Json.createObjectBuilder().add("cursor", cursor).build();
+        JsonObject params = PaginationCodec.toJsonObject(new PaginatedRequest(cursor));
         JsonRpcMessage resp = client.request("tools/list", params);
         if (resp instanceof JsonRpcResponse r) return r.result();
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -2,6 +2,9 @@ package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.annotations.Annotations;
 import com.amannmalik.mcp.prompts.Role;
+import com.amannmalik.mcp.util.PaginatedRequest;
+import com.amannmalik.mcp.util.PaginatedResult;
+import com.amannmalik.mcp.util.PaginationCodec;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -232,7 +235,8 @@ public final class ResourcesCodec {
         var arr = Json.createArrayBuilder();
         result.resources().forEach(r -> arr.add(toJsonObject(r)));
         JsonObjectBuilder b = Json.createObjectBuilder().add("resources", arr.build());
-        if (result.nextCursor() != null) b.add("nextCursor", result.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor()))
+                .forEach(b::add);
         return b.build();
     }
 
@@ -242,30 +246,28 @@ public final class ResourcesCodec {
         if (arr == null) throw new IllegalArgumentException("resources required");
         java.util.List<Resource> resources = new java.util.ArrayList<>();
         arr.forEach(v -> resources.add(toResource(v.asJsonObject())));
-        return new ListResourcesResult(resources, obj.getString("nextCursor", null));
+        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
+        return new ListResourcesResult(resources, cursor);
     }
 
     public static JsonObject toJsonObject(ListResourcesRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        JsonObjectBuilder b = Json.createObjectBuilder();
-        if (req.cursor() != null) b.add("cursor", req.cursor());
-        return b.build();
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
     }
 
     public static ListResourcesRequest toListResourcesRequest(JsonObject obj) {
-        String cursor = obj == null ? null : obj.getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
         return new ListResourcesRequest(cursor);
     }
 
     public static JsonObject toJsonObject(ListResourceTemplatesRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        JsonObjectBuilder b = Json.createObjectBuilder();
-        if (req.cursor() != null) b.add("cursor", req.cursor());
-        return b.build();
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
     }
 
     public static ListResourceTemplatesRequest toListResourceTemplatesRequest(JsonObject obj) {
-        return new ListResourceTemplatesRequest(obj.getString("cursor", null));
+        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
+        return new ListResourceTemplatesRequest(cursor);
     }
 
     public static JsonObject toJsonObject(ListResourceTemplatesResult result) {
@@ -273,7 +275,8 @@ public final class ResourcesCodec {
         var arr = Json.createArrayBuilder();
         result.resourceTemplates().forEach(t -> arr.add(toJsonObject(t)));
         JsonObjectBuilder b = Json.createObjectBuilder().add("resourceTemplates", arr.build());
-        if (result.nextCursor() != null) b.add("nextCursor", result.nextCursor());
+        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor()))
+                .forEach(b::add);
         return b.build();
     }
 
@@ -283,6 +286,7 @@ public final class ResourcesCodec {
         if (arr == null) throw new IllegalArgumentException("resourceTemplates required");
         java.util.List<ResourceTemplate> templates = new java.util.ArrayList<>();
         arr.forEach(v -> templates.add(toResourceTemplate(v.asJsonObject())));
-        return new ListResourceTemplatesResult(templates, obj.getString("nextCursor", null));
+        String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
+        return new ListResourceTemplatesResult(templates, cursor);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.tools;
 
+import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.PaginationCodec;
 import jakarta.json.Json;
@@ -35,9 +36,7 @@ public final class ToolCodec {
 
     public static JsonObject toJsonObject(ListToolsRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        JsonObjectBuilder b = Json.createObjectBuilder();
-        if (req.cursor() != null) b.add("cursor", req.cursor());
-        return b.build();
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
     }
 
     public static JsonObject toJsonObject(ListToolsResult page) {
@@ -112,7 +111,7 @@ public final class ToolCodec {
     }
 
     public static ListToolsRequest toListToolsRequest(JsonObject obj) {
-        String cursor = obj == null ? null : obj.getString("cursor", null);
+        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
         return new ListToolsRequest(cursor);
     }
 


### PR DESCRIPTION
## Summary
- route pagination cursor handling through `PaginationCodec`
- wire codecs for prompts, resources, and tools to use the shared helpers
- update `HostProcess` to build paginated requests with `PaginationCodec`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889a07fb25c83249f35aa9a1c9059bb