### PR TITLE
Fix resource update wiring

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -637,7 +637,7 @@ public final class McpServer implements AutoCloseable {
         try {
             ResourceSubscription sub = resources.subscribe(uri, update -> {
                 try {
-                    ResourceUpdatedNotification n = new ResourceUpdatedNotification(update.uri());
+                    ResourceUpdatedNotification n = new ResourceUpdatedNotification(update.uri(), update.title());
                     send(new JsonRpcNotification(
                             "notifications/resources/updated",
                             ResourcesCodec.toJsonObject(n)));

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -60,7 +60,12 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     public void notifyUpdate(String uri) {
-        ResourceUpdate update = new ResourceUpdate(uri);
+        String title = resources.stream()
+                .filter(r -> r.uri().equals(uri))
+                .map(Resource::title)
+                .findFirst()
+                .orElse(null);
+        ResourceUpdate update = new ResourceUpdate(uri, title);
         listeners.getOrDefault(uri, List.of()).forEach(l -> l.updated(update));
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdate.java
@@ -1,9 +1,11 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.UriValidator;
 
-public record ResourceUpdate(String uri) {
+public record ResourceUpdate(String uri, String title) {
     public ResourceUpdate {
         uri = UriValidator.requireAbsolute(uri);
+        title = title == null ? null : InputSanitizer.requireClean(title);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdatedNotification.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceUpdatedNotification.java
@@ -1,9 +1,11 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.UriValidator;
 
-public record ResourceUpdatedNotification(String uri) {
+public record ResourceUpdatedNotification(String uri, String title) {
     public ResourceUpdatedNotification {
         uri = UriValidator.requireAbsolute(uri);
+        title = title == null ? null : InputSanitizer.requireClean(title);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -71,6 +71,7 @@ public final class ResourcesCodec {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("uri", block.uri());
         if (block.mimeType() != null) b.add("mimeType", block.mimeType());
+        if (block.annotations() != null) b.add("annotations", toJsonObject(block.annotations()));
         if (block._meta() != null) b.add("_meta", block._meta());
         switch (block) {
             case ResourceBlock.Text t -> b.add("text", t.text());
@@ -85,10 +86,7 @@ public final class ResourcesCodec {
         if (uri == null) throw new IllegalArgumentException("uri required");
         String mime = obj.getString("mimeType", null);
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
-
-        if (obj.containsKey("annotations")) {
-            throw new IllegalArgumentException("annotations not allowed");
-        }
+        Annotations ann = obj.containsKey("annotations") ? toAnnotations(obj.getJsonObject("annotations")) : null;
 
         boolean hasText = obj.containsKey("text");
         boolean hasBlob = obj.containsKey("blob");
@@ -97,17 +95,17 @@ public final class ResourcesCodec {
         }
 
         for (String key : obj.keySet()) {
-            if (!Set.of("uri", "mimeType", "_meta", "text", "blob").contains(key)) {
+            if (!Set.of("uri", "mimeType", "_meta", "annotations", "text", "blob").contains(key)) {
                 throw new IllegalArgumentException("unexpected field: " + key);
             }
         }
 
         if (hasText) {
-            return new ResourceBlock.Text(uri, mime, obj.getString("text"), null, meta);
+            return new ResourceBlock.Text(uri, mime, obj.getString("text"), ann, meta);
         }
 
         byte[] data = Base64.getDecoder().decode(obj.getString("blob"));
-        return new ResourceBlock.Binary(uri, mime, data, null, meta);
+        return new ResourceBlock.Binary(uri, mime, data, ann, meta);
     }
 
     public static JsonObject toJsonObject(Annotations ann) {
@@ -156,9 +154,10 @@ public final class ResourcesCodec {
 
     public static JsonObject toJsonObject(ResourceUpdatedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
-        return Json.createObjectBuilder()
-                .add("uri", n.uri())
-                .build();
+        JsonObjectBuilder b = Json.createObjectBuilder()
+                .add("uri", n.uri());
+        if (n.title() != null) b.add("title", n.title());
+        return b.build();
     }
 
     public static JsonObject toJsonObject(SubscribeRequest req) {
@@ -220,10 +219,12 @@ public final class ResourcesCodec {
         if (obj == null || !obj.containsKey("uri")) {
             throw new IllegalArgumentException("uri required");
         }
-        if (obj.size() != 1) {
-            throw new IllegalArgumentException("unexpected fields");
+        for (String key : obj.keySet()) {
+            if (!Set.of("uri", "title").contains(key)) {
+                throw new IllegalArgumentException("unexpected field: " + key);
+            }
         }
-        return new ResourceUpdatedNotification(obj.getString("uri"));
+        return new ResourceUpdatedNotification(obj.getString("uri"), obj.getString("title", null));
     }
 
 


### PR DESCRIPTION
## Summary
- track resource titles in update events
- include annotations when encoding resource blocks
- wire resource update notifications to send titles

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889a0c141608324b01c2d45964cdf09