### PR TITLE
Use ToolCodec when requesting tool info

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -165,7 +165,8 @@ public final class HostCommand implements Callable<Integer> {
                             System.out.println("Usage: list-tools <client-id> [cursor]");
                         } else {
                             String cursor = parts.length > 2 ? parts[2] : null;
-                            System.out.println(host.listTools(parts[1], cursor));
+                            var page = host.listTools(parts[1], cursor);
+                            System.out.println(com.amannmalik.mcp.server.tools.ToolCodec.toJsonObject(page));
                         }
                     }
                     case "call-tool" -> {
@@ -175,7 +176,8 @@ public final class HostCommand implements Callable<Integer> {
                             var args = parts.length > 3 ?
                                     jakarta.json.Json.createReader(new java.io.StringReader(parts[3])).readObject() :
                                     null;
-                            System.out.println(host.callTool(parts[1], parts[2], args));
+                            var result = host.callTool(parts[1], parts[2], args);
+                            System.out.println(com.amannmalik.mcp.server.tools.ToolCodec.toJsonObject(result));
                         }
                     }
                     case "create-message" -> {

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -7,6 +7,9 @@ import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
 import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.prompts.Role;
+import com.amannmalik.mcp.server.tools.ListToolsResult;
+import com.amannmalik.mcp.server.tools.ToolCodec;
+import com.amannmalik.mcp.server.tools.ToolResult;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 
@@ -125,7 +128,7 @@ public final class HostProcess implements AutoCloseable {
                 .collect(Collectors.joining(System.lineSeparator()));
     }
 
-    public JsonObject listTools(String clientId, String cursor) throws IOException {
+    public ListToolsResult listTools(String clientId, String cursor) throws IOException {
         McpClient client = clients.get(clientId);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, java.util.Optional.of(ServerCapability.TOOLS));
@@ -133,12 +136,12 @@ public final class HostProcess implements AutoCloseable {
                 ? Json.createObjectBuilder().build()
                 : Json.createObjectBuilder().add("cursor", cursor).build();
         JsonRpcMessage resp = client.request("tools/list", params);
-        if (resp instanceof JsonRpcResponse r) return r.result();
+        if (resp instanceof JsonRpcResponse r) return ToolCodec.toListToolsResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
     }
 
-    public JsonObject callTool(String clientId, String name, JsonObject args) throws IOException {
+    public ToolResult callTool(String clientId, String name, JsonObject args) throws IOException {
         McpClient client = clients.get(clientId);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, java.util.Optional.of(ServerCapability.TOOLS));
@@ -148,7 +151,7 @@ public final class HostProcess implements AutoCloseable {
                 .add("arguments", args == null ? Json.createObjectBuilder().build() : args)
                 .build();
         JsonRpcMessage resp = client.request("tools/call", params);
-        if (resp instanceof JsonRpcResponse r) return r.result();
+        if (resp instanceof JsonRpcResponse r) return ToolCodec.toToolResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
     }


### PR DESCRIPTION
## Summary
- parse tool list and tool call responses with ToolCodec
- print typed results in HostCommand

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6889a02a08d48324aa26bde5946433a9