### PR TITLE
Expand MCP conformance scenarios

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -336,6 +336,37 @@ public final class McpConformanceSteps {
         lastMessage = client.request("resources/list", params);
     }
 
+    @When("the client lists resources with cursor {string}")
+    public void listResourcesWithCursor(String cursor) throws Exception {
+        JsonObject params = Json.createObjectBuilder()
+                .add("cursor", cursor)
+                .build();
+        lastMessage = client.request("resources/list", params);
+    }
+
+    @When("the client lists prompts with cursor {string}")
+    public void listPromptsWithCursor(String cursor) throws Exception {
+        JsonObject params = Json.createObjectBuilder()
+                .add("cursor", cursor)
+                .build();
+        lastMessage = client.request("prompts/list", params);
+    }
+
+    @When("the client lists tools with cursor {string}")
+    public void listToolsWithCursor(String cursor) throws Exception {
+        JsonObject params = Json.createObjectBuilder()
+                .add("cursor", cursor)
+                .build();
+        lastMessage = client.request("tools/list", params);
+    }
+
+    @When("the client gets prompt {string} without arguments")
+    public void getPromptWithoutArgs(String name) throws Exception {
+        lastMessage = client.request("prompts/get", Json.createObjectBuilder()
+                .add("name", name)
+                .build());
+    }
+
     @Then("a log message with level {string} is received")
     public void verifyLogMessage(String level) throws Exception {
         long end = System.currentTimeMillis() + 500;

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -58,3 +58,40 @@ Feature: MCP protocol conformance
     Given a running MCP server and connected client
     When the client requests an invalid completion
     Then an error with code -32602 is returned
+
+  Scenario: Unknown method
+    Given a running MCP server and connected client
+    When the client calls an unknown method
+    Then an error with code -32601 is returned
+
+  Scenario: Pagination with invalid cursors
+    Given a running MCP server and connected client
+    When the client lists resources with cursor "bad"
+    Then an error with code -32602 is returned
+    When the client lists prompts with cursor "bad"
+    Then an error with code -32602 is returned
+    When the client lists tools with cursor "bad"
+    Then an error with code -32602 is returned
+
+  Scenario: Prompt missing arguments
+    Given a running MCP server and connected client
+    When the client gets prompt "test_prompt" without arguments
+    Then an error with code -32602 is returned
+
+  Scenario: Tool rate limiting
+    Given a running MCP server and connected client
+    When the client calls "test_tool"
+    When the client calls "test_tool"
+    When the client calls "test_tool"
+    When the client calls "test_tool"
+    When the client calls "test_tool"
+    When the client calls "test_tool"
+    Then an error with code -32001 is returned
+
+  Scenario: Logging on unknown method
+    Given a running MCP server and connected client
+    When the client sets the log level to "debug"
+    Then the call succeeds
+    When the client calls an unknown method
+    Then an error with code -32601 is returned
+


### PR DESCRIPTION
## Summary
- add tests for bad cursors, rate limits, and missing arguments
- add logging and unknown method checks
- support new cucumber steps

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889b8571624832499e25c7db48763ea