### PR TITLE
Refactor list change handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/InMemoryRootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/InMemoryRootsProvider.java
@@ -2,10 +2,11 @@ package com.amannmalik.mcp.client.roots;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import com.amannmalik.mcp.util.ListChangeSupport;
 
 public final class InMemoryRootsProvider implements RootsProvider {
     private final List<Root> roots = new CopyOnWriteArrayList<>();
-    private final List<RootsListener> listeners = new CopyOnWriteArrayList<>();
+    private final ListChangeSupport<RootsListener> listChangeSupport = new ListChangeSupport<>();
 
     public InMemoryRootsProvider(List<Root> initial) {
         if (initial != null) roots.addAll(initial);
@@ -18,8 +19,8 @@ public final class InMemoryRootsProvider implements RootsProvider {
 
     @Override
     public RootsSubscription subscribe(RootsListener listener) {
-        listeners.add(listener);
-        return () -> listeners.remove(listener);
+        var sub = listChangeSupport.subscribe(listener);
+        return sub::close;
     }
 
     @Override
@@ -38,6 +39,6 @@ public final class InMemoryRootsProvider implements RootsProvider {
     }
 
     private void notifyListeners() {
-        listeners.forEach(RootsListener::listChanged);
+        listChangeSupport.notifyListeners();
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsListener.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsListener.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.client.roots;
 
+import com.amannmalik.mcp.util.ListChangeListener;
+
 @FunctionalInterface
-public interface RootsListener {
-    void listChanged();
+public interface RootsListener extends ListChangeListener {
 }

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsSubscription.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.client.roots;
 
-public interface RootsSubscription extends AutoCloseable {
-    @Override
-    void close();
+import com.amannmalik.mcp.util.ListChangeSubscription;
+
+public interface RootsSubscription extends ListChangeSubscription {
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -1,17 +1,17 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.util.Pagination;
+import com.amannmalik.mcp.util.ListChangeSupport;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class InMemoryPromptProvider implements PromptProvider {
     private final Map<String, PromptTemplate> templates = new ConcurrentHashMap<>();
-    private final List<PromptsListener> listeners = new CopyOnWriteArrayList<>();
+    private final ListChangeSupport<PromptsListener> listChangeSupport = new ListChangeSupport<>();
 
     public void add(PromptTemplate template) {
         templates.put(template.prompt().name(), template);
@@ -43,8 +43,8 @@ public final class InMemoryPromptProvider implements PromptProvider {
 
     @Override
     public PromptsSubscription subscribe(PromptsListener listener) {
-        listeners.add(listener);
-        return () -> listeners.remove(listener);
+        var sub = listChangeSupport.subscribe(listener);
+        return sub::close;
     }
 
     @Override
@@ -53,6 +53,6 @@ public final class InMemoryPromptProvider implements PromptProvider {
     }
 
     private void notifyListeners() {
-        listeners.forEach(PromptsListener::listChanged);
+        listChangeSupport.notifyListeners();
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptsListener.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptsListener.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
+import com.amannmalik.mcp.util.ListChangeListener;
+
 @FunctionalInterface
-public interface PromptsListener {
-    void listChanged();
+public interface PromptsListener extends ListChangeListener {
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptsSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptsSubscription.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.prompts;
 
-public interface PromptsSubscription extends AutoCloseable {
-    @Override
-    void close();
+import com.amannmalik.mcp.util.ListChangeSubscription;
+
+public interface PromptsSubscription extends ListChangeSubscription {
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceListListener.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceListListener.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.util.ListChangeListener;
+
 @FunctionalInterface
-public interface ResourceListListener {
-    void listChanged();
+public interface ResourceListListener extends ListChangeListener {
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceListSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceListSubscription.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.server.resources;
 
-public interface ResourceListSubscription extends AutoCloseable {
-    @Override
-    void close();
+import com.amannmalik.mcp.util.ListChangeSubscription;
+
+public interface ResourceListSubscription extends ListChangeSubscription {
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.tools;
 
 import com.amannmalik.mcp.util.Pagination;
+import com.amannmalik.mcp.util.ListChangeSupport;
 import com.amannmalik.mcp.validation.SchemaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -14,7 +15,7 @@ import java.util.function.Function;
 public final class InMemoryToolProvider implements ToolProvider {
     private final List<Tool> tools;
     private final Map<String, Function<JsonObject, ToolResult>> handlers;
-    private final List<ToolListListener> listeners = new CopyOnWriteArrayList<>();
+    private final ListChangeSupport<ToolListListener> listChangeSupport = new ListChangeSupport<>();
 
     public InMemoryToolProvider(List<Tool> tools, Map<String, Function<JsonObject, ToolResult>> handlers) {
         this.tools = tools == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(tools);
@@ -49,8 +50,8 @@ public final class InMemoryToolProvider implements ToolProvider {
 
     @Override
     public ToolListSubscription subscribeList(ToolListListener listener) {
-        listeners.add(listener);
-        return () -> listeners.remove(listener);
+        var sub = listChangeSupport.subscribe(listener);
+        return sub::close;
     }
 
     @Override
@@ -75,6 +76,6 @@ public final class InMemoryToolProvider implements ToolProvider {
     }
 
     private void notifyListeners() {
-        listeners.forEach(ToolListListener::listChanged);
+        listChangeSupport.notifyListeners();
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolListListener.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolListListener.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.tools;
 
+import com.amannmalik.mcp.util.ListChangeListener;
+
 @FunctionalInterface
-public interface ToolListListener {
-    void listChanged();
+public interface ToolListListener extends ListChangeListener {
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolListSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolListSubscription.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.server.tools;
 
-public interface ToolListSubscription extends AutoCloseable {
-    @Override
-    void close();
+import com.amannmalik.mcp.util.ListChangeSubscription;
+
+public interface ToolListSubscription extends ListChangeSubscription {
 }

--- a/src/main/java/com/amannmalik/mcp/util/ListChangeListener.java
+++ b/src/main/java/com/amannmalik/mcp/util/ListChangeListener.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.util;
+
+@FunctionalInterface
+public interface ListChangeListener {
+    void listChanged();
+}

--- a/src/main/java/com/amannmalik/mcp/util/ListChangeSubscription.java
+++ b/src/main/java/com/amannmalik/mcp/util/ListChangeSubscription.java
@@ -1,0 +1,6 @@
+package com.amannmalik.mcp.util;
+
+public interface ListChangeSubscription extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/src/main/java/com/amannmalik/mcp/util/ListChangeSupport.java
+++ b/src/main/java/com/amannmalik/mcp/util/ListChangeSupport.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.util;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public final class ListChangeSupport<L extends ListChangeListener> {
+    private final List<L> listeners = new CopyOnWriteArrayList<>();
+
+    public ListChangeSubscription subscribe(L listener) {
+        listeners.add(listener);
+        return () -> listeners.remove(listener);
+    }
+
+    public void notifyListeners() {
+        for (L l : listeners) {
+            l.listChanged();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ListChangeSupport` helper with `ListChangeListener` and `ListChangeSubscription`
- wire prompt, tool, resource and root providers to use the helper
- keep feature-specific listener and subscription interfaces but extend the common versions

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889d157710483248e8fde9a691ba0ba