### PR TITLE
Refactor progress token parsing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -54,8 +54,6 @@ import com.amannmalik.mcp.util.ProgressListener;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ProgressTracker;
-import com.amannmalik.mcp.validation.InputSanitizer;
-import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.SchemaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -624,18 +622,7 @@ public final class McpClient implements AutoCloseable {
     }
 
     private ProgressToken parseProgressToken(JsonObject params) {
-        if (params == null || !params.containsKey("_meta")) return null;
-        JsonObject meta = params.getJsonObject("_meta");
-        MetaValidator.requireValid(meta);
-        if (!meta.containsKey("progressToken")) return null;
-        var val = meta.get("progressToken");
-        return switch (val.getValueType()) {
-            case STRING -> new ProgressToken.StringToken(
-                    InputSanitizer.requireClean(meta.getString("progressToken"))
-            );
-            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
-            default -> throw new IllegalArgumentException("progressToken must be a string or number");
-        };
+        return ProgressCodec.fromMeta(params);
     }
 
     public void setProgressListener(ProgressListener listener) {

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -100,7 +100,6 @@ import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ProgressTracker;
 import com.amannmalik.mcp.validation.InputSanitizer;
-import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.SchemaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -463,16 +462,7 @@ public final class McpServer implements AutoCloseable {
     }
 
     private ProgressToken parseProgressToken(JsonObject params) {
-        if (params == null || !params.containsKey("_meta")) return null;
-        JsonObject meta = params.getJsonObject("_meta");
-        MetaValidator.requireValid(meta);
-        if (!meta.containsKey("progressToken")) return null;
-        var val = meta.get("progressToken");
-        return switch (val.getValueType()) {
-            case STRING -> new ProgressToken.StringToken(InputSanitizer.requireClean(meta.getString("progressToken")));
-            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
-            default -> throw new IllegalArgumentException("progressToken must be a string or number");
-        };
+        return ProgressCodec.fromMeta(params);
     }
 
     private boolean allowed(Annotations ann) {

--- a/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.util;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
@@ -37,6 +38,21 @@ public final class ProgressCodec {
             case STRING -> new ProgressToken.StringToken(InputSanitizer.requireClean(((JsonString) value).getString()));
             case NUMBER -> new ProgressToken.NumericToken(((JsonNumber) value).longValue());
             default -> throw new IllegalArgumentException("Invalid token type");
+        };
+    }
+
+    public static ProgressToken fromMeta(JsonObject params) {
+        if (params == null || !params.containsKey("_meta")) return null;
+        JsonObject meta = params.getJsonObject("_meta");
+        MetaValidator.requireValid(meta);
+        if (!meta.containsKey("progressToken")) return null;
+        var val = meta.get("progressToken");
+        return switch (val.getValueType()) {
+            case STRING -> new ProgressToken.StringToken(
+                    InputSanitizer.requireClean(meta.getString("progressToken"))
+            );
+            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
+            default -> throw new IllegalArgumentException("progressToken must be a string or number");
         };
     }
 }


### PR DESCRIPTION
## Summary
- centralize parsing of progressToken metadata
- reuse new helper in client and server

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889d157710483248e8fde9a691ba0ba