### PR TITLE
Fix Accept header case checking

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -224,7 +224,12 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
             String accept = req.getHeader("Accept");
-            if (accept == null || !(accept.contains("application/json") && accept.contains("text/event-stream"))) {
+            if (accept == null) {
+                resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                return;
+            }
+            String acceptNorm = accept.toLowerCase(java.util.Locale.ROOT);
+            if (!(acceptNorm.contains("application/json") && acceptNorm.contains("text/event-stream"))) {
                 resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
                 return;
             }
@@ -404,7 +409,12 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
             String accept = req.getHeader("Accept");
-            if (accept == null || !accept.contains("text/event-stream")) {
+            if (accept == null) {
+                resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                return;
+            }
+            String acceptNorm = accept.toLowerCase(java.util.Locale.ROOT);
+            if (!acceptNorm.contains("text/event-stream")) {
                 resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
                 return;
             }


### PR DESCRIPTION
## Summary
- enforce case-insensitive checks for `Accept` headers in `StreamableHttpTransport`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889d4069cf0832498c3df7322ac5f31