### PR TITLE
Add Streamable HTTP client transport

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -1,0 +1,140 @@
+package com.amannmalik.mcp.transport;
+
+import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public final class StreamableHttpClientTransport implements Transport {
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final URI endpoint;
+    private final BlockingQueue<JsonObject> incoming = new LinkedBlockingQueue<>();
+    private final Set<SseReader> streams = ConcurrentHashMap.newKeySet();
+    private volatile String sessionId;
+
+    public StreamableHttpClientTransport(URI endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public void send(JsonObject message) throws IOException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(endpoint)
+                .header("Accept", "application/json, text/event-stream")
+                .header("Content-Type", "application/json")
+                .header("MCP-Protocol-Version", ProtocolLifecycle.SUPPORTED_VERSION);
+        Optional.ofNullable(sessionId).ifPresent(id -> builder.header("Mcp-Session-Id", id));
+        HttpRequest request = builder.POST(HttpRequest.BodyPublishers.ofString(message.toString())).build();
+        HttpResponse<InputStream> response;
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+        sessionId = response.headers().firstValue("Mcp-Session-Id").orElse(sessionId);
+        int status = response.statusCode();
+        String ct = response.headers().firstValue("Content-Type").orElse("");
+        if (status == 202) {
+            response.body().close();
+            return;
+        }
+        if (ct.startsWith("application/json")) {
+            try (JsonReader reader = Json.createReader(response.body())) {
+                incoming.add(reader.readObject());
+            }
+            return;
+        }
+        if (ct.startsWith("text/event-stream")) {
+            SseReader reader = new SseReader(response.body());
+            streams.add(reader);
+            Thread t = new Thread(reader);
+            t.setDaemon(true);
+            t.start();
+            return;
+        }
+        response.body().close();
+        throw new IOException("Unexpected response: " + status + " " + ct);
+    }
+
+    @Override
+    public JsonObject receive() throws IOException {
+        try {
+            return incoming.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (sessionId != null) {
+            HttpRequest.Builder builder = HttpRequest.newBuilder(endpoint)
+                    .header("Mcp-Session-Id", sessionId)
+                    .header("MCP-Protocol-Version", ProtocolLifecycle.SUPPORTED_VERSION)
+                    .DELETE();
+            try {
+                client.send(builder.build(), HttpResponse.BodyHandlers.discarding());
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        streams.forEach(SseReader::close);
+        streams.clear();
+    }
+
+    private final class SseReader implements Runnable {
+        private final InputStream input;
+        private volatile boolean closed;
+
+        SseReader(InputStream input) {
+            this.input = input;
+        }
+
+        @Override
+        public void run() {
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+                String line;
+                StringBuilder data = new StringBuilder();
+                while (!closed && (line = br.readLine()) != null) {
+                    if (line.startsWith("data: ")) {
+                        data.append(line.substring(6));
+                    } else if (line.isEmpty()) {
+                        if (!data.isEmpty()) {
+                            try (JsonReader jr = Json.createReader(new StringReader(data.toString()))) {
+                                incoming.add(jr.readObject());
+                            } catch (Exception ignore) {
+                            }
+                            data.setLength(0);
+                        }
+                    }
+                }
+            } catch (IOException ignore) {
+            }
+        }
+
+        void close() {
+            closed = true;
+            try {
+                input.close();
+            } catch (IOException ignore) {
+            }
+        }
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/McpHttpConformanceFeatureTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpHttpConformanceFeatureTest.java
@@ -1,0 +1,10 @@
+package com.amannmalik.mcp;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class McpHttpConformanceFeatureTest {
+    static {
+        System.setProperty("mcp.test.transport", "http");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `StreamableHttpClientTransport` to talk to a server via Streamable HTTP
- support choosing transport in Cucumber steps
- run conformance tests using HTTP transport as well as stdio

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889d4580e588324a0b51e6331c4f517