### PR TITLE
Refactor RequestId handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -1,6 +1,18 @@
 package com.amannmalik.mcp.jsonrpc;
 
 public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId {
+    static RequestId parse(String raw) {
+        if (raw == null) throw new IllegalArgumentException("raw required");
+        if (raw.startsWith("\"") && raw.endsWith("\"") && raw.length() > 1) {
+            return new StringId(raw.substring(1, raw.length() - 1));
+        }
+        try {
+            return new NumericId(Long.parseLong(raw));
+        } catch (NumberFormatException ignore) {
+            return new StringId(raw);
+        }
+    }
+
     record StringId(String value) implements RequestId {
     }
 

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -150,16 +150,7 @@ public final class StreamableHttpTransport implements Transport {
             lastGeneral.set(null);
             requestStreams.forEach((id, client) -> {
                 try {
-                    RequestId reqId;
-                    if (id.startsWith("\"") && id.endsWith("\"") && id.length() > 1) {
-                        reqId = new RequestId.StringId(id.substring(1, id.length() - 1));
-                    } else {
-                        try {
-                            reqId = new RequestId.NumericId(Long.parseLong(id));
-                        } catch (NumberFormatException e) {
-                            reqId = new RequestId.StringId(id);
-                        }
-                    }
+                    RequestId reqId = RequestId.parse(id);
                     JsonRpcError err = new JsonRpcError(reqId,
                             new JsonRpcError.ErrorDetail(
                                     JsonRpcErrorCode.INTERNAL_ERROR.code(),
@@ -174,16 +165,7 @@ public final class StreamableHttpTransport implements Transport {
             clientsByPrefix.clear();
 
             responseQueues.forEach((id, queue) -> {
-                RequestId reqId;
-                if (id.startsWith("\"") && id.endsWith("\"") && id.length() > 1) {
-                    reqId = new RequestId.StringId(id.substring(1, id.length() - 1));
-                } else {
-                    try {
-                        reqId = new RequestId.NumericId(Long.parseLong(id));
-                    } catch (NumberFormatException e) {
-                        reqId = new RequestId.StringId(id);
-                    }
-                }
+                RequestId reqId = RequestId.parse(id);
                 JsonRpcError err = new JsonRpcError(reqId,
                         new JsonRpcError.ErrorDetail(
                                 JsonRpcErrorCode.INTERNAL_ERROR.code(),


### PR DESCRIPTION
## Summary
- introduce `RequestId.parse` helper
- reuse it inside `StreamableHttpTransport`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889d6af650c8324b6a4fbf58ccd1367