### PR TITLE
Refactor token string handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -613,7 +613,7 @@ public final class McpClient implements AutoCloseable {
     private void sendProgress(ProgressNotification note) throws IOException {
         if (!progressTracker.isActive(note.token())) return;
         try {
-            progressLimiter.requireAllowance(note.token().toString());
+            progressLimiter.requireAllowance(note.token().asString());
             progressTracker.update(note);
         } catch (IllegalArgumentException | IllegalStateException ignore) {
             return;

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -1,9 +1,29 @@
 package com.amannmalik.mcp.jsonrpc;
 
 public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId {
+    String asString();
+
     record StringId(String value) implements RequestId {
+        @Override
+        public String asString() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
     }
 
     record NumericId(long value) implements RequestId {
+        @Override
+        public String asString() {
+            return Long.toString(value);
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(value);
+        }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -535,7 +535,7 @@ public final class McpServer implements AutoCloseable {
     private void sendProgress(ProgressNotification note) throws IOException {
         if (!progressTracker.isActive(note.token())) return;
         try {
-            progressLimiter.requireAllowance(note.token().toString());
+            progressLimiter.requireAllowance(note.token().asString());
             progressTracker.update(note);
         } catch (IllegalArgumentException | IllegalStateException ignore) {
             return;

--- a/src/main/java/com/amannmalik/mcp/util/ProgressToken.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressToken.java
@@ -1,9 +1,29 @@
 package com.amannmalik.mcp.util;
 
 public sealed interface ProgressToken permits ProgressToken.StringToken, ProgressToken.NumericToken {
+    String asString();
+
     record StringToken(String value) implements ProgressToken {
+        @Override
+        public String asString() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
     }
 
     record NumericToken(long value) implements ProgressToken {
+        @Override
+        public String asString() {
+            return Long.toString(value);
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expose canonical string representation for `ProgressToken`
- expose canonical string representation for `RequestId`
- use the new canonical representation when rate limiting progress updates

## Testing
- `gradle check`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6889d6af650c8324b6a4fbf58ccd1367