### PR TITLE
Implement resource metadata URL in server

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ConfigLoader.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ConfigLoader.java
@@ -43,7 +43,8 @@ public final class ConfigLoader {
                     parseTransport(transport),
                     obj.getInt("port", 0),
                     obj.containsKey("instructions") ? obj.getString("instructions") : null,
-                    obj.containsKey("expectedAudience") ? obj.getString("expectedAudience") : null);
+                    obj.containsKey("expectedAudience") ? obj.getString("expectedAudience") : null,
+                    obj.containsKey("resourceMetadataUrl") ? obj.getString("resourceMetadataUrl") : null);
             case "client" -> new ClientConfig(parseTransport(transport), obj.getString("command"));
             case "host" -> {
                 var cObj = obj.getJsonObject("clients");
@@ -67,7 +68,8 @@ public final class ConfigLoader {
                     parseTransport(transport),
                     portVal == null ? 0 : ((Number) portVal).intValue(),
                     map.get("instructions") == null ? null : map.get("instructions").toString(),
-                    map.get("expectedAudience") == null ? null : map.get("expectedAudience").toString());
+                    map.get("expectedAudience") == null ? null : map.get("expectedAudience").toString(),
+                    map.get("resourceMetadataUrl") == null ? null : map.get("resourceMetadataUrl").toString());
             case "client" -> new ClientConfig(parseTransport(transport), cmdVal.toString());
             case "host" -> {
                 if (!(clientsVal instanceof Map<?, ?> cMap) || cMap.isEmpty()) {

--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -38,6 +38,9 @@ public final class ServerCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"--audience"}, description = "Expected JWT audience for authorization")
     private String expectedAudience;
 
+    @CommandLine.Option(names = {"--resource-metadata"}, description = "Resource metadata URL")
+    private String resourceMetadataUrl;
+
     public ServerCommand() {
     }
 
@@ -59,7 +62,7 @@ public final class ServerCommand implements Callable<Integer> {
             TransportType type = httpPort == null ? TransportType.STDIO : TransportType.HTTP;
             int port = httpPort == null ? 0 : httpPort;
             if (stdio) type = TransportType.STDIO;
-            cfg = new ServerConfig(type, port, null, expectedAudience);
+            cfg = new ServerConfig(type, port, null, expectedAudience, resourceMetadataUrl);
         }
 
         Transport t;
@@ -73,7 +76,8 @@ public final class ServerCommand implements Callable<Integer> {
                     BearerTokenAuthorizationStrategy authStrategy = new BearerTokenAuthorizationStrategy(tokenValidator);
                     authManager = new AuthorizationManager(List.of(authStrategy));
                 }
-                StreamableHttpTransport ht = new StreamableHttpTransport(cfg.port(), originValidator, authManager);
+                StreamableHttpTransport ht = new StreamableHttpTransport(
+                        cfg.port(), originValidator, authManager, cfg.resourceMetadataUrl());
                 if (verbose) System.err.println("Listening on http://127.0.0.1:" + ht.port());
                 t = ht;
             }

--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -1,6 +1,11 @@
 package com.amannmalik.mcp.cli;
 
-public record ServerConfig(TransportType transport, int port, String instructions, String expectedAudience) implements CliConfig {
+public record ServerConfig(
+        TransportType transport,
+        int port,
+        String instructions,
+        String expectedAudience,
+        String resourceMetadataUrl) implements CliConfig {
     public ServerConfig {
         if (transport == null) throw new IllegalArgumentException("transport");
         if (transport == TransportType.HTTP && port <= 0) {


### PR DESCRIPTION
## Summary
- let ServerConfig keep a `resourceMetadataUrl`
- parse it in ConfigLoader
- expose `--resource-metadata` option in ServerCommand
- pass `resourceMetadataUrl` to StreamableHttpTransport

## Testing
- `gradle test`
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889d725e3ec8324b94eb6db6474c9be