### PR TITLE
Refactor security permission management

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/ConsentManager.java
+++ b/src/main/java/com/amannmalik/mcp/security/ConsentManager.java
@@ -2,28 +2,23 @@ package com.amannmalik.mcp.security;
 
 import com.amannmalik.mcp.auth.Principal;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+
 
 public final class ConsentManager {
-    private final Map<String, Set<String>> consents = new ConcurrentHashMap<>();
+    private final PrincipalPermissions<String> consents = new PrincipalPermissions<>();
 
     public void grant(String principalId, String scope) {
-        consents.computeIfAbsent(principalId, k -> ConcurrentHashMap.newKeySet())
-                .add(scope);
+        consents.grant(principalId, scope);
     }
 
     public void revoke(String principalId, String scope) {
-        var set = consents.get(principalId);
-        if (set != null) set.remove(scope);
+        consents.revoke(principalId, scope);
     }
 
     public void requireConsent(Principal principal, String scope) {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (scope == null || scope.isBlank()) throw new IllegalArgumentException("scope required");
-        var set = consents.get(principal.id());
-        if (set == null || !set.contains(scope)) {
+        if (!consents.contains(principal.id(), scope)) {
             throw new SecurityException("User consent required: " + scope);
         }
     }

--- a/src/main/java/com/amannmalik/mcp/security/PrincipalPermissions.java
+++ b/src/main/java/com/amannmalik/mcp/security/PrincipalPermissions.java
@@ -1,0 +1,38 @@
+package com.amannmalik.mcp.security;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe registry of permissions granted to principals.
+ */
+final class PrincipalPermissions<T> {
+    private final Map<String, Set<T>> map = new ConcurrentHashMap<>();
+
+    void grant(String principalId, T permission) {
+        requirePrincipal(principalId);
+        if (permission == null) throw new IllegalArgumentException("permission required");
+        map.computeIfAbsent(principalId, k -> ConcurrentHashMap.newKeySet())
+                .add(permission);
+    }
+
+    void revoke(String principalId, T permission) {
+        requirePrincipal(principalId);
+        if (permission == null) throw new IllegalArgumentException("permission required");
+        var set = map.get(principalId);
+        if (set != null) set.remove(permission);
+    }
+
+    boolean contains(String principalId, T permission) {
+        requirePrincipal(principalId);
+        if (permission == null) throw new IllegalArgumentException("permission required");
+        var set = map.get(principalId);
+        return set != null && set.contains(permission);
+    }
+
+    private static void requirePrincipal(String id) {
+        if (id == null || id.isBlank()) throw new IllegalArgumentException("principalId required");
+    }
+}
+

--- a/src/main/java/com/amannmalik/mcp/security/PrivacyBoundaryEnforcer.java
+++ b/src/main/java/com/amannmalik/mcp/security/PrivacyBoundaryEnforcer.java
@@ -4,22 +4,16 @@ import com.amannmalik.mcp.annotations.Annotations;
 import com.amannmalik.mcp.auth.Principal;
 import com.amannmalik.mcp.prompts.Role;
 
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public final class PrivacyBoundaryEnforcer implements ResourceAccessController {
-    private final Map<String, Set<Role>> permissions = new ConcurrentHashMap<>();
+    private final PrincipalPermissions<Role> permissions = new PrincipalPermissions<>();
 
     public void allow(String principalId, Role audience) {
-        permissions.computeIfAbsent(principalId, k -> EnumSet.noneOf(Role.class))
-                .add(audience);
+        permissions.grant(principalId, audience);
     }
 
     public void revoke(String principalId, Role audience) {
-        var set = permissions.get(principalId);
-        if (set != null) set.remove(audience);
+        permissions.revoke(principalId, audience);
     }
 
     @Override
@@ -27,9 +21,10 @@ public final class PrivacyBoundaryEnforcer implements ResourceAccessController {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (ann == null || ann.audience().isEmpty()) return;
 
-        var set = permissions.get(principal.id());
-        if (set == null || !set.containsAll(ann.audience())) {
-            throw new SecurityException("Audience not permitted: " + ann.audience());
+        for (Role r : ann.audience()) {
+            if (!permissions.contains(principal.id(), r)) {
+                throw new SecurityException("Audience not permitted: " + ann.audience());
+            }
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/security/ToolAccessController.java
+++ b/src/main/java/com/amannmalik/mcp/security/ToolAccessController.java
@@ -2,29 +2,23 @@ package com.amannmalik.mcp.security;
 
 import com.amannmalik.mcp.auth.Principal;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public final class ToolAccessController implements ToolAccessPolicy {
-    private final Map<String, Set<String>> permissions = new ConcurrentHashMap<>();
+    private final PrincipalPermissions<String> permissions = new PrincipalPermissions<>();
 
     public void allow(String principalId, String tool) {
-        permissions.computeIfAbsent(principalId, k -> ConcurrentHashMap.newKeySet())
-                .add(tool);
+        permissions.grant(principalId, tool);
     }
 
     public void revoke(String principalId, String tool) {
-        var set = permissions.get(principalId);
-        if (set != null) set.remove(tool);
+        permissions.revoke(principalId, tool);
     }
 
     @Override
     public void requireAllowed(Principal principal, String tool) {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (tool == null || tool.isBlank()) throw new IllegalArgumentException("tool required");
-        var set = permissions.get(principal.id());
-        if (set == null || !set.contains(tool)) {
+        if (!permissions.contains(principal.id(), tool)) {
             throw new SecurityException("Tool not authorized: " + tool);
         }
     }


### PR DESCRIPTION
## Summary
- centralize per-principal permission logic
- refactor consent, tool access and privacy boundary enforcement to use the new helper

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889d99026948324a33967fcfec8faf6