### PR TITLE
Refactor provider paging

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -24,14 +24,13 @@ public final class InMemoryPromptProvider implements PromptProvider {
     }
 
     @Override
-    public PromptPage list(String cursor) {
+    public Pagination.Page<Prompt> list(String cursor) {
         List<Prompt> all = new ArrayList<>();
         for (PromptTemplate t : templates.values()) {
             all.add(t.prompt());
         }
         all.sort(Comparator.comparing(Prompt::name));
-        Pagination.Page<Prompt> page = Pagination.page(all, cursor, 100);
-        return new PromptPage(page.items(), page.nextCursor());
+        return Pagination.page(all, cursor, 100);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.prompts;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
+import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.Json;
@@ -57,9 +58,9 @@ public final class PromptCodec {
         return obj.build();
     }
 
-    public static JsonObject toJsonObject(PromptPage page) {
+    public static JsonObject toJsonObject(Pagination.Page<Prompt> page) {
         JsonArrayBuilder arr = Json.createArrayBuilder();
-        page.prompts().forEach(p -> arr.add(toJsonObject(p)));
+        page.items().forEach(p -> arr.add(toJsonObject(p)));
         JsonObjectBuilder builder = Json.createObjectBuilder().add("prompts", arr.build());
         PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
         return builder.build();
@@ -71,7 +72,7 @@ public final class PromptCodec {
     }
 
     public static JsonObject toJsonObject(ListPromptsResult page) {
-        return toJsonObject(new PromptPage(page.prompts(), page.nextCursor()));
+        return toJsonObject(new Pagination.Page<>(page.prompts(), page.nextCursor()));
     }
 
     public static JsonObject toJsonObject(PromptListChangedNotification n) {
@@ -184,7 +185,7 @@ public final class PromptCodec {
         return new PromptInstance(description, msgs);
     }
 
-    public static PromptPage toPromptPage(JsonObject obj) {
+    public static Pagination.Page<Prompt> toPromptPage(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("object required");
         JsonArray arr = obj.getJsonArray("prompts");
         if (arr == null) throw new IllegalArgumentException("prompts required");
@@ -196,12 +197,12 @@ public final class PromptCodec {
             prompts.add(toPrompt(v.asJsonObject()));
         }
         String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
-        return new PromptPage(prompts, cursor);
+        return new Pagination.Page<>(prompts, cursor);
     }
 
     public static ListPromptsResult toListPromptsResult(JsonObject obj) {
-        PromptPage page = toPromptPage(obj);
-        return new ListPromptsResult(page.prompts(), page.nextCursor());
+        Pagination.Page<Prompt> page = toPromptPage(obj);
+        return new ListPromptsResult(page.items(), page.nextCursor());
     }
 
     public static ListPromptsRequest toListPromptsRequest(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptPage.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptPage.java
@@ -1,9 +1,0 @@
-package com.amannmalik.mcp.prompts;
-
-import java.util.List;
-
-public record PromptPage(List<Prompt> prompts, String nextCursor) {
-    public PromptPage {
-        prompts = prompts == null ? List.of() : List.copyOf(prompts);
-    }
-}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptProvider.java
@@ -1,9 +1,10 @@
 package com.amannmalik.mcp.prompts;
 
+import com.amannmalik.mcp.util.Pagination;
 import java.util.Map;
 
 public interface PromptProvider {
-    PromptPage list(String cursor);
+    Pagination.Page<Prompt> list(String cursor);
 
     PromptInstance get(String name, Map<String, String> arguments);
 

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -44,7 +44,6 @@ import com.amannmalik.mcp.prompts.PromptCodec;
 import com.amannmalik.mcp.prompts.PromptContent;
 import com.amannmalik.mcp.prompts.PromptInstance;
 import com.amannmalik.mcp.prompts.PromptMessageTemplate;
-import com.amannmalik.mcp.prompts.PromptPage;
 import com.amannmalik.mcp.prompts.PromptProvider;
 import com.amannmalik.mcp.prompts.PromptTemplate;
 import com.amannmalik.mcp.prompts.PromptsSubscription;
@@ -71,16 +70,15 @@ import com.amannmalik.mcp.server.resources.ReadResourceRequest;
 import com.amannmalik.mcp.server.resources.ReadResourceResult;
 import com.amannmalik.mcp.server.resources.Resource;
 import com.amannmalik.mcp.server.resources.ResourceBlock;
-import com.amannmalik.mcp.server.resources.ResourceList;
 import com.amannmalik.mcp.server.resources.ResourceListSubscription;
 import com.amannmalik.mcp.server.resources.ResourceProvider;
 import com.amannmalik.mcp.server.resources.ResourceSubscription;
 import com.amannmalik.mcp.server.resources.ResourceTemplate;
-import com.amannmalik.mcp.server.resources.ResourceTemplatePage;
 import com.amannmalik.mcp.server.resources.ResourceUpdatedNotification;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.server.resources.SubscribeRequest;
 import com.amannmalik.mcp.server.resources.UnsubscribeRequest;
+import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.server.tools.CallToolRequest;
 import com.amannmalik.mcp.server.tools.InMemoryToolProvider;
 import com.amannmalik.mcp.server.tools.ListToolsRequest;
@@ -88,7 +86,6 @@ import com.amannmalik.mcp.server.tools.Tool;
 import com.amannmalik.mcp.server.tools.ToolCodec;
 import com.amannmalik.mcp.server.tools.ToolListChangedNotification;
 import com.amannmalik.mcp.server.tools.ToolListSubscription;
-import com.amannmalik.mcp.server.tools.ToolPage;
 import com.amannmalik.mcp.server.tools.ToolProvider;
 import com.amannmalik.mcp.server.tools.ToolResult;
 import com.amannmalik.mcp.transport.Transport;
@@ -559,7 +556,7 @@ public final class McpServer implements AutoCloseable {
             }
         }
 
-        ResourceList list;
+        Pagination.Page<Resource> list;
         try {
             list = resources.list(cursor);
         } catch (IllegalArgumentException e) {
@@ -568,7 +565,7 @@ public final class McpServer implements AutoCloseable {
         }
 
         List<Resource> filteredResources = new ArrayList<>();
-        for (Resource r : list.resources()) {
+        for (Resource r : list.items()) {
             if (allowed(r.annotations()) && withinRoots(r.uri())) {
                 filteredResources.add(r);
             }
@@ -626,7 +623,7 @@ public final class McpServer implements AutoCloseable {
             }
         }
 
-        ResourceTemplatePage page;
+        Pagination.Page<ResourceTemplate> page;
         try {
             page = resources.listTemplates(cursor);
         } catch (IllegalArgumentException e) {
@@ -635,7 +632,7 @@ public final class McpServer implements AutoCloseable {
         }
 
         List<ResourceTemplate> filteredTemplates = new ArrayList<>();
-        for (ResourceTemplate t : page.resourceTemplates()) {
+        for (ResourceTemplate t : page.items()) {
             if (allowed(t.annotations())) {
                 filteredTemplates.add(t);
             }
@@ -729,7 +726,7 @@ public final class McpServer implements AutoCloseable {
                         JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
             }
         }
-        ToolPage page;
+        Pagination.Page<Tool> page;
         try {
             page = tools.list(cursor);
         } catch (IllegalArgumentException e) {
@@ -801,7 +798,7 @@ public final class McpServer implements AutoCloseable {
                         JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null));
             }
         }
-        PromptPage page;
+        Pagination.Page<Prompt> page;
         try {
             page = prompts.list(cursor);
         } catch (IllegalArgumentException e) {
@@ -986,8 +983,8 @@ public final class McpServer implements AutoCloseable {
 
     private Tool findTool(String name) {
         if (tools == null) return null;
-        ToolPage page = tools.list(null);
-        for (Tool t : page.tools()) {
+        Pagination.Page<Tool> page = tools.list(null);
+        for (Tool t : page.items()) {
             if (t.name().equals(name)) return t;
         }
         return null;

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -22,9 +22,8 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     @Override
-    public ResourceList list(String cursor) {
-        Pagination.Page<Resource> page = Pagination.page(resources, cursor, 100);
-        return new ResourceList(page.items(), page.nextCursor());
+    public Pagination.Page<Resource> list(String cursor) {
+        return Pagination.page(resources, cursor, 100);
     }
 
     @Override
@@ -33,9 +32,8 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     @Override
-    public ResourceTemplatePage listTemplates(String cursor) {
-        Pagination.Page<ResourceTemplate> page = Pagination.page(templates, cursor, 100);
-        return new ResourceTemplatePage(page.items(), page.nextCursor());
+    public Pagination.Page<ResourceTemplate> listTemplates(String cursor) {
+        return Pagination.page(templates, cursor, 100);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceList.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceList.java
@@ -1,9 +1,0 @@
-package com.amannmalik.mcp.server.resources;
-
-import java.util.List;
-
-public record ResourceList(List<Resource> resources, String nextCursor) {
-    public ResourceList {
-        resources = resources == null ? List.of() : List.copyOf(resources);
-    }
-}

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -1,11 +1,14 @@
+
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.util.Pagination;
+
 public interface ResourceProvider extends AutoCloseable {
-    ResourceList list(String cursor);
+    Pagination.Page<Resource> list(String cursor);
 
     ResourceBlock read(String uri);
 
-    ResourceTemplatePage listTemplates(String cursor);
+    Pagination.Page<ResourceTemplate> listTemplates(String cursor);
 
     ResourceSubscription subscribe(String uri, ResourceListener listener);
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplatePage.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplatePage.java
@@ -1,9 +1,0 @@
-package com.amannmalik.mcp.server.resources;
-
-import java.util.List;
-
-public record ResourceTemplatePage(List<ResourceTemplate> resourceTemplates, String nextCursor) {
-    public ResourceTemplatePage {
-        resourceTemplates = resourceTemplates == null ? List.of() : List.copyOf(resourceTemplates);
-    }
-}

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -23,9 +23,8 @@ public final class InMemoryToolProvider implements ToolProvider {
     }
 
     @Override
-    public ToolPage list(String cursor) {
-        Pagination.Page<Tool> page = Pagination.page(tools, cursor, 100);
-        return new ToolPage(page.items(), page.nextCursor());
+    public Pagination.Page<Tool> list(String cursor) {
+        return Pagination.page(tools, cursor, 100);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.server.tools;
 
 import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
+import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -29,9 +30,9 @@ public final class ToolCodec {
         return builder.build();
     }
 
-    public static JsonObject toJsonObject(ToolPage page) {
+    public static JsonObject toJsonObject(Pagination.Page<Tool> page) {
         JsonArrayBuilder arr = Json.createArrayBuilder();
-        page.tools().forEach(t -> arr.add(toJsonObject(t)));
+        page.items().forEach(t -> arr.add(toJsonObject(t)));
         JsonObjectBuilder builder = Json.createObjectBuilder().add("tools", arr);
         PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
         return builder.build();
@@ -43,7 +44,7 @@ public final class ToolCodec {
     }
 
     public static JsonObject toJsonObject(ListToolsResult page) {
-        return toJsonObject(new ToolPage(page.tools(), page.nextCursor()));
+        return toJsonObject(new Pagination.Page<>(page.tools(), page.nextCursor()));
     }
 
     public static JsonObject toJsonObject(ToolResult result) {
@@ -93,7 +94,7 @@ public final class ToolCodec {
         return new Tool(name, title, description, inputSchema, outputSchema, ann, meta);
     }
 
-    public static ToolPage toToolPage(JsonObject obj) {
+    public static Pagination.Page<Tool> toToolPage(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("object required");
         JsonArray arr = obj.getJsonArray("tools");
         if (arr == null) throw new IllegalArgumentException("tools required");
@@ -105,12 +106,12 @@ public final class ToolCodec {
             tools.add(toTool(v.asJsonObject()));
         }
         String cursor = PaginationCodec.toPaginatedResult(obj).nextCursor();
-        return new ToolPage(tools, cursor);
+        return new Pagination.Page<>(tools, cursor);
     }
 
     public static ListToolsResult toListToolsResult(JsonObject obj) {
-        ToolPage page = toToolPage(obj);
-        return new ListToolsResult(page.tools(), page.nextCursor());
+        Pagination.Page<Tool> page = toToolPage(obj);
+        return new ListToolsResult(page.items(), page.nextCursor());
     }
 
     public static ListToolsRequest toListToolsRequest(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolPage.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolPage.java
@@ -1,9 +1,0 @@
-package com.amannmalik.mcp.server.tools;
-
-import java.util.List;
-
-public record ToolPage(List<Tool> tools, String nextCursor) {
-    public ToolPage {
-        tools = tools == null || tools.isEmpty() ? List.of() : List.copyOf(tools);
-    }
-}

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
@@ -1,9 +1,10 @@
 package com.amannmalik.mcp.server.tools;
 
+import com.amannmalik.mcp.util.Pagination;
 import jakarta.json.JsonObject;
 
 public interface ToolProvider {
-    ToolPage list(String cursor);
+    Pagination.Page<Tool> list(String cursor);
 
     ToolResult call(String name, JsonObject arguments);
 


### PR DESCRIPTION
## Summary
- refactor provider interfaces to return `Pagination.Page<T>`
- update codecs and in-memory implementations
- remove now redundant `ToolPage`, `ResourceList`, `ResourceTemplatePage`, and `PromptPage`

## Testing
- `gradle testClasses`
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889d99026948324a33967fcfec8faf6