### PR TITLE
Fix resource update title retrieval

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -61,11 +61,13 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     public void notifyUpdate(String uri) {
-        String title = resources.stream()
-                .filter(r -> r.uri().equals(uri))
-                .map(Resource::title)
-                .findFirst()
-                .orElse(null);
+        String title = null;
+        for (Resource r : resources) {
+            if (r.uri().equals(uri)) {
+                title = r.title();
+                break;
+            }
+        }
         ResourceUpdate update = new ResourceUpdate(uri, title);
         listeners.getOrDefault(uri, List.of()).forEach(l -> l.updated(update));
     }


### PR DESCRIPTION
## Summary
- remove `.orElse(null)` usage in `InMemoryResourceProvider`
- iterate over resources to find matching title

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889dbf80b608324bb599208a0e67f93