### PR TITLE
Refactor progress handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -55,6 +55,8 @@ import com.amannmalik.mcp.util.ProgressListener;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ProgressTracker;
+import com.amannmalik.mcp.util.ProgressUtil;
+import com.amannmalik.mcp.util.Timeouts;
 import com.amannmalik.mcp.validation.SchemaValidator;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -193,13 +195,13 @@ public final class McpClient implements AutoCloseable {
         });
         JsonRpcMessage msg;
         try {
-            msg = future.get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+            msg = future.get(Timeouts.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             try {
                 transport.close();
             } catch (IOException ignore) {
             }
-            throw new IOException("Initialization timed out after " + DEFAULT_TIMEOUT + " ms");
+            throw new IOException("Initialization timed out after " + Timeouts.DEFAULT_TIMEOUT_MS + " ms");
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
@@ -293,10 +295,9 @@ public final class McpClient implements AutoCloseable {
         return instructions == null ? "" : instructions;
     }
 
-    private static final long DEFAULT_TIMEOUT = 30_000L;
 
     public PingResponse ping() throws IOException {
-        return ping(DEFAULT_TIMEOUT);
+        return ping(Timeouts.DEFAULT_TIMEOUT_MS);
     }
 
     public PingResponse ping(long timeoutMillis) throws IOException {
@@ -352,13 +353,13 @@ public final class McpClient implements AutoCloseable {
     }
 
     public JsonRpcMessage request(String method, JsonObject params) throws IOException {
-        return request(method, params, DEFAULT_TIMEOUT);
+        return request(method, params, Timeouts.DEFAULT_TIMEOUT_MS);
     }
 
     public JsonRpcMessage request(String method, JsonObject params, long timeoutMillis) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
         RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
-        ProgressToken token = parseProgressToken(params);
+        ProgressToken token = ProgressUtil.tokenFromMeta(params);
         if (token != null) {
             progressTracker.register(token);
             progressTokens.put(reqId, token);
@@ -472,7 +473,7 @@ public final class McpClient implements AutoCloseable {
         cancellationTracker.register(req.id());
         ProgressToken token;
         try {
-            token = parseProgressToken(req.params());
+            token = ProgressUtil.tokenFromMeta(req.params());
             if (token != null) {
                 progressTracker.register(token);
                 progressTokens.put(req.id(), token);
@@ -612,18 +613,8 @@ public final class McpClient implements AutoCloseable {
     }
 
     private void sendProgress(ProgressNotification note) throws IOException {
-        if (!progressTracker.isActive(note.token())) return;
-        try {
-            progressLimiter.requireAllowance(note.token().asString());
-            progressTracker.update(note);
-        } catch (IllegalArgumentException | IllegalStateException ignore) {
-            return;
-        }
-        notify(NotificationMethod.PROGRESS.method(), ProgressCodec.toJsonObject(note));
-    }
-
-    private ProgressToken parseProgressToken(JsonObject params) {
-        return ProgressCodec.fromMeta(params);
+        ProgressUtil.sendProgress(note, progressTracker, progressLimiter,
+                n -> notify(n.method(), n.params()));
     }
 
     public void setProgressListener(ProgressListener listener) {

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -97,6 +97,8 @@ import com.amannmalik.mcp.util.ProgressCodec;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ProgressTracker;
+import com.amannmalik.mcp.util.ProgressUtil;
+import com.amannmalik.mcp.util.Timeouts;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.SchemaValidator;
 import jakarta.json.Json;
@@ -351,7 +353,7 @@ public final class McpServer implements AutoCloseable {
             }
 
             try {
-                token = parseProgressToken(req.params());
+                token = ProgressUtil.tokenFromMeta(req.params());
                 if (token != null) {
                     progressTracker.register(token);
                     progressTokens.put(req.id(), token);
@@ -461,9 +463,6 @@ public final class McpServer implements AutoCloseable {
         }
     }
 
-    private ProgressToken parseProgressToken(JsonObject params) {
-        return ProgressCodec.fromMeta(params);
-    }
 
     private boolean allowed(Annotations ann) {
         try {
@@ -531,17 +530,8 @@ public final class McpServer implements AutoCloseable {
     }
 
     private void sendProgress(ProgressNotification note) throws IOException {
-        if (!progressTracker.isActive(note.token())) return;
-        try {
-            progressLimiter.requireAllowance(note.token().asString());
-            progressTracker.update(note);
-        } catch (IllegalArgumentException | IllegalStateException ignore) {
-            return;
-
-        }
-        send(new JsonRpcNotification(
-                NotificationMethod.PROGRESS.method(),
-                ProgressCodec.toJsonObject(note)));
+        ProgressUtil.sendProgress(note, progressTracker, progressLimiter,
+                n -> send(n));
     }
 
     private JsonRpcMessage listResources(JsonRpcRequest req) {
@@ -889,10 +879,8 @@ public final class McpServer implements AutoCloseable {
         }
     }
 
-    private static final long DEFAULT_TIMEOUT = 30_000L;
-
     private JsonRpcMessage sendRequest(String method, JsonObject params) throws IOException {
-        return sendRequest(method, params, DEFAULT_TIMEOUT);
+        return sendRequest(method, params, Timeouts.DEFAULT_TIMEOUT_MS);
     }
 
     private JsonRpcMessage sendRequest(String method, JsonObject params, long timeoutMillis) throws IOException {

--- a/src/main/java/com/amannmalik/mcp/util/NotificationSender.java
+++ b/src/main/java/com/amannmalik/mcp/util/NotificationSender.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.util;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcNotification;
+import java.io.IOException;
+
+@FunctionalInterface
+public interface NotificationSender {
+    void send(JsonRpcNotification notification) throws IOException;
+}

--- a/src/main/java/com/amannmalik/mcp/util/ProgressUtil.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressUtil.java
@@ -1,0 +1,36 @@
+package com.amannmalik.mcp.util;
+
+import com.amannmalik.mcp.NotificationMethod;
+import com.amannmalik.mcp.jsonrpc.JsonRpcNotification;
+import com.amannmalik.mcp.security.RateLimiter;
+import jakarta.json.JsonObject;
+
+import java.io.IOException;
+
+public final class ProgressUtil {
+    private ProgressUtil() {
+    }
+
+    public static ProgressToken tokenFromMeta(JsonObject params) {
+        return ProgressCodec.fromMeta(params);
+    }
+
+    public static void sendProgress(
+            ProgressNotification note,
+            ProgressTracker tracker,
+            RateLimiter limiter,
+            NotificationSender sender
+    ) throws IOException {
+        if (!tracker.isActive(note.token())) return;
+        try {
+            limiter.requireAllowance(note.token().asString());
+            tracker.update(note);
+        } catch (IllegalArgumentException | IllegalStateException ignore) {
+            return;
+        }
+        sender.send(new JsonRpcNotification(
+                NotificationMethod.PROGRESS.method(),
+                ProgressCodec.toJsonObject(note)
+        ));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/util/Timeouts.java
+++ b/src/main/java/com/amannmalik/mcp/util/Timeouts.java
@@ -1,0 +1,8 @@
+package com.amannmalik.mcp.util;
+
+public final class Timeouts {
+    private Timeouts() {
+    }
+
+    public static final long DEFAULT_TIMEOUT_MS = 30_000L;
+}


### PR DESCRIPTION
## Summary
- extract `ProgressUtil` and `NotificationSender` for unified progress logic
- centralize request timeout constant in `Timeouts`
- use new utilities in both client and server

## Testing
- `gradle build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6889dc8ed31c8324995f9a4c0044f338