### PR TITLE
Add default page size constant

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/Pagination.java
+++ b/src/main/java/com/amannmalik/mcp/util/Pagination.java
@@ -7,6 +7,8 @@ public final class Pagination {
     private Pagination() {
     }
 
+    public static final int DEFAULT_PAGE_SIZE = 100;
+
     public static <T> Page<T> page(List<T> items, String cursor, int size) {
         int start = decode(cursor);
         if (start < 0 || start > items.size()) throw new IllegalArgumentException("Invalid cursor");


### PR DESCRIPTION
## Summary
- expose a `Pagination.DEFAULT_PAGE_SIZE` constant for caller convenience

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889dc8ed31c8324995f9a4c0044f338