### PR TITLE
Implement OAuth resource metadata endpoint

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -41,6 +41,9 @@ public final class ServerCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"--resource-metadata"}, description = "Resource metadata URL")
     private String resourceMetadataUrl;
 
+    @CommandLine.Option(names = {"--auth-server"}, description = "Authorization server URL", split = ",")
+    private List<String> authServers;
+
     public ServerCommand() {
     }
 
@@ -62,7 +65,7 @@ public final class ServerCommand implements Callable<Integer> {
             TransportType type = httpPort == null ? TransportType.STDIO : TransportType.HTTP;
             int port = httpPort == null ? 0 : httpPort;
             if (stdio) type = TransportType.STDIO;
-            cfg = new ServerConfig(type, port, null, expectedAudience, resourceMetadataUrl);
+            cfg = new ServerConfig(type, port, null, expectedAudience, resourceMetadataUrl, authServers);
         }
 
         Transport t;
@@ -77,7 +80,8 @@ public final class ServerCommand implements Callable<Integer> {
                     authManager = new AuthorizationManager(List.of(authStrategy));
                 }
                 StreamableHttpTransport ht = new StreamableHttpTransport(
-                        cfg.port(), originValidator, authManager, cfg.resourceMetadataUrl());
+                        cfg.port(), originValidator, authManager,
+                        cfg.resourceMetadataUrl(), cfg.authorizationServers());
                 if (verbose) System.err.println("Listening on http://127.0.0.1:" + ht.port());
                 t = ht;
             }

--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -1,15 +1,21 @@
 package com.amannmalik.mcp.cli;
 
+import java.util.List;
+
 public record ServerConfig(
         TransportType transport,
         int port,
         String instructions,
         String expectedAudience,
-        String resourceMetadataUrl) implements CliConfig {
+        String resourceMetadataUrl,
+        List<String> authorizationServers) implements CliConfig {
     public ServerConfig {
         if (transport == null) throw new IllegalArgumentException("transport");
         if (transport == TransportType.HTTP && port <= 0) {
             throw new IllegalArgumentException("port required for HTTP");
         }
+        authorizationServers = authorizationServers == null || authorizationServers.isEmpty()
+                ? List.of()
+                : List.copyOf(authorizationServers);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -44,6 +44,8 @@ public final class StreamableHttpTransport implements Transport {
     private final OriginValidator originValidator;
     private final AuthorizationManager authManager;
     private final String resourceMetadataUrl;
+    private final String metadataPath;
+    private final java.util.List<String> authorizationServers;
     private static final String PROTOCOL_HEADER = "MCP-Protocol-Version";
     // Default to the previous protocol revision when no version header is
     // present, as recommended for backwards compatibility.
@@ -68,7 +70,11 @@ public final class StreamableHttpTransport implements Transport {
         resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 
-    public StreamableHttpTransport(int port, OriginValidator validator, AuthorizationManager auth, String resourceMetadataUrl) throws Exception {
+    public StreamableHttpTransport(int port,
+                                   OriginValidator validator,
+                                   AuthorizationManager auth,
+                                   String resourceMetadataUrl,
+                                   java.util.List<String> authorizationServers) throws Exception {
         server = new Server(new InetSocketAddress("127.0.0.1", port));
         ServletContextHandler ctx = new ServletContextHandler();
         ctx.addServlet(new ServletHolder(new McpServlet()), "/");
@@ -78,13 +84,22 @@ public final class StreamableHttpTransport implements Transport {
         this.originValidator = validator;
         this.authManager = auth;
         this.resourceMetadataUrl = resourceMetadataUrl;
+        if (resourceMetadataUrl != null) {
+            var uri = java.net.URI.create(resourceMetadataUrl);
+            this.metadataPath = uri.getPath();
+        } else {
+            this.metadataPath = null;
+        }
+        this.authorizationServers = authorizationServers == null || authorizationServers.isEmpty()
+                ? java.util.List.of()
+                : java.util.List.copyOf(authorizationServers);
         // Until initialization negotiates a version, assume the prior revision
         // as the default when no MCP-Protocol-Version header is present.
         this.protocolVersion = COMPATIBILITY_VERSION;
     }
 
     public StreamableHttpTransport(int port, OriginValidator validator, AuthorizationManager auth) throws Exception {
-        this(port, validator, auth, null);
+        this(port, validator, auth, null, java.util.List.of());
     }
 
     public int port() {
@@ -377,6 +392,18 @@ public final class StreamableHttpTransport implements Transport {
 
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            if (metadataPath != null && metadataPath.equals(req.getRequestURI())) {
+                var arr = jakarta.json.Json.createArrayBuilder();
+                for (String s : authorizationServers) arr.add(s);
+                var body = jakarta.json.Json.createObjectBuilder()
+                        .add("authorization_servers", arr.build())
+                        .build();
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.setContentType("application/json");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write(body.toString());
+                return;
+            }
             Principal principal = null;
             if (authManager != null) {
                 try {


### PR DESCRIPTION
## Summary
- extend ServerConfig to accept authorization server list
- load authorization server URLs from config/CLI
- include authorization server list when starting HTTP transport
- serve OAuth protected resource metadata at `.well-known/oauth-protected-resource`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889dbf80b608324bb599208a0e67f93