### PR TITLE
Refactor empty list-change notifications

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -5,6 +5,7 @@ import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
+import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,13 +32,11 @@ public final class RootsCodec {
 
     public static JsonObject toJsonObject(RootsListChangedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
-        return JsonValue.EMPTY_JSON_OBJECT;
+        return EmptyJsonObjectCodec.toJsonObject();
     }
 
     public static RootsListChangedNotification toRootsListChangedNotification(JsonObject obj) {
-        if (obj != null && !obj.isEmpty()) {
-            throw new IllegalArgumentException("unexpected fields");
-        }
+        EmptyJsonObjectCodec.requireEmpty(obj);
         return new RootsListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -5,6 +5,7 @@ import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -77,13 +78,11 @@ public final class PromptCodec {
 
     public static JsonObject toJsonObject(PromptListChangedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
-        return JsonValue.EMPTY_JSON_OBJECT;
+        return EmptyJsonObjectCodec.toJsonObject();
     }
 
     public static PromptListChangedNotification toPromptListChangedNotification(JsonObject obj) {
-        if (obj != null && !obj.isEmpty()) {
-            throw new IllegalArgumentException("unexpected fields");
-        }
+        EmptyJsonObjectCodec.requireEmpty(obj);
         return new PromptListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -5,6 +5,7 @@ import com.amannmalik.mcp.prompts.Role;
 import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -148,13 +149,11 @@ public final class ResourcesCodec {
 
     public static JsonObject toJsonObject(ResourceListChangedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
-        return JsonValue.EMPTY_JSON_OBJECT;
+        return EmptyJsonObjectCodec.toJsonObject();
     }
 
     public static ResourceListChangedNotification toResourceListChangedNotification(JsonObject obj) {
-        if (obj != null && !obj.isEmpty()) {
-            throw new IllegalArgumentException("unexpected fields");
-        }
+        EmptyJsonObjectCodec.requireEmpty(obj);
         return new ResourceListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -4,6 +4,7 @@ import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
@@ -60,13 +61,11 @@ public final class ToolCodec {
 
     public static JsonObject toJsonObject(ToolListChangedNotification n) {
         if (n == null) throw new IllegalArgumentException("notification required");
-        return JsonValue.EMPTY_JSON_OBJECT;
+        return EmptyJsonObjectCodec.toJsonObject();
     }
 
     public static ToolListChangedNotification toToolListChangedNotification(JsonObject obj) {
-        if (obj != null && !obj.isEmpty()) {
-            throw new IllegalArgumentException("unexpected fields");
-        }
+        EmptyJsonObjectCodec.requireEmpty(obj);
         return new ToolListChangedNotification();
     }
 

--- a/src/main/java/com/amannmalik/mcp/util/EmptyJsonObjectCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/EmptyJsonObjectCodec.java
@@ -1,0 +1,30 @@
+package com.amannmalik.mcp.util;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+/**
+ * Utility for encoding and validating empty JSON objects.
+ */
+public final class EmptyJsonObjectCodec {
+    private EmptyJsonObjectCodec() {
+    }
+
+    /**
+     * Returns an empty JSON object instance.
+     */
+    public static JsonObject toJsonObject() {
+        return JsonValue.EMPTY_JSON_OBJECT;
+    }
+
+    /**
+     * Ensures the provided object is either {@code null} or empty.
+     *
+     * @throws IllegalArgumentException if the object contains any fields
+     */
+    public static void requireEmpty(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) {
+            throw new IllegalArgumentException("unexpected fields");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide `EmptyJsonObjectCodec` for encoding/validating empty JSON payloads
- refactor resources/tools/prompts/roots codecs to share logic

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889df34a9308324afc300709fbf500b