### PR TITLE
Optimize enum lookups

### DIFF
--- a/src/main/java/com/amannmalik/mcp/NotificationMethod.java
+++ b/src/main/java/com/amannmalik/mcp/NotificationMethod.java
@@ -1,6 +1,9 @@
 package com.amannmalik.mcp;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * JSON-RPC notification method names used by the protocol.
@@ -16,10 +19,16 @@ public enum NotificationMethod {
     MESSAGE("notifications/message"),
     ROOTS_LIST_CHANGED("notifications/roots/list_changed");
 
+    private static final Map<String, NotificationMethod> BY_METHOD;
     private final String method;
 
     NotificationMethod(String method) {
         this.method = method;
+    }
+
+    static {
+        BY_METHOD = Arrays.stream(values())
+                .collect(Collectors.toUnmodifiableMap(m -> m.method, m -> m));
     }
 
     /**
@@ -33,12 +42,8 @@ public enum NotificationMethod {
      * Parses a method string into a notification method.
      */
     public static Optional<NotificationMethod> from(String method) {
-        for (NotificationMethod m : values()) {
-            if (m.method.equals(method)) {
-                return Optional.of(m);
-            }
-        }
-        return Optional.empty();
+        if (method == null) return Optional.empty();
+        return Optional.ofNullable(BY_METHOD.get(method));
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcErrorCode.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcErrorCode.java
@@ -1,5 +1,9 @@
 package com.amannmalik.mcp.jsonrpc;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public enum JsonRpcErrorCode {
     PARSE_ERROR(-32700),
     INVALID_REQUEST(-32600),
@@ -7,10 +11,16 @@ public enum JsonRpcErrorCode {
     INVALID_PARAMS(-32602),
     INTERNAL_ERROR(-32603);
 
+    private static final Map<Integer, JsonRpcErrorCode> BY_CODE;
     private final int code;
 
     JsonRpcErrorCode(int code) {
         this.code = code;
+    }
+
+    static {
+        BY_CODE = Arrays.stream(values())
+                .collect(Collectors.toUnmodifiableMap(e -> e.code, e -> e));
     }
 
     public int code() {
@@ -18,9 +28,8 @@ public enum JsonRpcErrorCode {
     }
 
     public static JsonRpcErrorCode fromCode(int code) {
-        for (var c : values()) {
-            if (c.code == code) return c;
-        }
-        throw new IllegalArgumentException("Unknown error code: " + code);
+        JsonRpcErrorCode e = BY_CODE.get(code);
+        if (e == null) throw new IllegalArgumentException("Unknown error code: " + code);
+        return e;
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingLevel.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingLevel.java
@@ -1,5 +1,9 @@
 package com.amannmalik.mcp.server.logging;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public enum LoggingLevel {
     DEBUG,
     INFO,
@@ -10,12 +14,17 @@ public enum LoggingLevel {
     ALERT,
     EMERGENCY;
 
+    private static final Map<String, LoggingLevel> BY_NAME;
+
+    static {
+        BY_NAME = Arrays.stream(values())
+                .collect(Collectors.toUnmodifiableMap(l -> l.name().toLowerCase(), l -> l));
+    }
+
     public static LoggingLevel fromString(String raw) {
         if (raw == null) throw new IllegalArgumentException("level required");
-        try {
-            return valueOf(raw.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("invalid level", e);
-        }
+        LoggingLevel level = BY_NAME.get(raw.toLowerCase());
+        if (level == null) throw new IllegalArgumentException("invalid level");
+        return level;
     }
 }


### PR DESCRIPTION
## Summary
- cache `NotificationMethod` lookup by JSON-RPC method string
- cache `LoggingLevel` lookup by name
- cache `JsonRpcErrorCode` lookup by numeric code

## Testing
- `gradle test`
- `bash verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889df34a9308324afc300709fbf500b