### PR TITLE
Fix HTTP version negotiation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -265,7 +265,7 @@ public final class StreamableHttpTransport implements Transport {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             } else if (session != null) {
-                if (version == null || !version.equals(protocolVersion)) {
+                if (!initializing && (version == null || !version.equals(protocolVersion))) {
                     resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                     return;
                 }


### PR DESCRIPTION
## Summary
- handle MCP version header correctly during initialization

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889dee33a508324874b7ff40181cc93