### PR TITLE
Fix protocol version header in HTTP client

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -39,6 +39,7 @@ import com.amannmalik.mcp.ping.PingResponse;
 import com.amannmalik.mcp.prompts.PromptsListener;
 import com.amannmalik.mcp.security.RateLimiter;
 import com.amannmalik.mcp.security.SamplingAccessPolicy;
+import com.amannmalik.mcp.transport.StreamableHttpClientTransport;
 import com.amannmalik.mcp.server.logging.LoggingCodec;
 import com.amannmalik.mcp.server.logging.LoggingLevel;
 import com.amannmalik.mcp.server.logging.LoggingListener;
@@ -216,6 +217,9 @@ public final class McpClient implements AutoCloseable {
                 } catch (IOException ignore) {
                 }
                 throw new UnsupportedProtocolVersionException(ir.protocolVersion(), ProtocolLifecycle.SUPPORTED_VERSION);
+            }
+            if (transport instanceof StreamableHttpClientTransport http) {
+                http.setProtocolVersion(ir.protocolVersion());
             }
             serverCapabilities = ir.capabilities().server();
             instructions = ir.instructions();


### PR DESCRIPTION
## Summary
- track the negotiated protocol version in `StreamableHttpClientTransport`
- use that value for the `MCP-Protocol-Version` header
- update `McpClient` to set the negotiated version on HTTP transports

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889de6af6508324a9f4accd2f437578