### PR TITLE
Fix CancelledNotification sanitization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/CancelledNotification.java
+++ b/src/main/java/com/amannmalik/mcp/util/CancelledNotification.java
@@ -1,11 +1,13 @@
 package com.amannmalik.mcp.util;
 
 import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.validation.InputSanitizer;
 
 public record CancelledNotification(RequestId requestId, String reason) {
     public CancelledNotification {
         if (requestId == null) {
             throw new IllegalArgumentException("requestId is required");
         }
+        reason = InputSanitizer.cleanNullable(reason);
     }
 }


### PR DESCRIPTION
## Summary
- sanitize the optional reason string in `CancelledNotification`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e22637c88324ae9f41b52abdd625