### PR TITLE
Fix reserved meta prefix validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -34,9 +34,6 @@ public final class MetaValidator {
                 if (!LABEL.matcher(label).matches()) {
                     throw new IllegalArgumentException("Invalid _meta prefix: " + key);
                 }
-                if (i < labels.length - 1 && ("mcp".equals(label) || "modelcontextprotocol".equals(label))) {
-                    throw new IllegalArgumentException("Reserved _meta prefix: " + prefix + "/");
-                }
             }
         }
 


### PR DESCRIPTION
## Summary
- relax `_meta` validation to allow spec-reserved prefixes

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e22637c88324ae9f41b52abdd625