### PR TITLE
Align protocol version negotiation with spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -29,12 +29,13 @@ public class ProtocolLifecycle {
                 : EnumSet.copyOf(requested);
         clientFeatures = request.features() == null ? ClientFeatures.EMPTY : request.features();
 
-        if (!SUPPORTED_VERSION.equals(request.protocolVersion())) {
-            throw new UnsupportedProtocolVersionException(request.protocolVersion(), SUPPORTED_VERSION);
+        String negotiated = SUPPORTED_VERSION;
+        if (request.protocolVersion() != null && request.protocolVersion().equals(SUPPORTED_VERSION)) {
+            negotiated = request.protocolVersion();
         }
 
         return new InitializeResponse(
-                SUPPORTED_VERSION,
+                negotiated,
                 new Capabilities(clientCapabilities, serverCapabilities, Map.of(), Map.of()),
                 serverInfo,
                 instructions,

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -33,7 +33,6 @@ import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.lifecycle.ServerFeatures;
 import com.amannmalik.mcp.lifecycle.ServerInfo;
-import com.amannmalik.mcp.lifecycle.UnsupportedProtocolVersionException;
 import com.amannmalik.mcp.ping.PingCodec;
 import com.amannmalik.mcp.ping.PingRequest;
 import com.amannmalik.mcp.prompts.GetPromptRequest;
@@ -411,19 +410,7 @@ public final class McpServer implements AutoCloseable {
 
     private JsonRpcMessage initialize(JsonRpcRequest req) {
         InitializeRequest init = LifecycleCodec.toInitializeRequest(req.params());
-        InitializeResponse baseResp;
-        try {
-            baseResp = lifecycle.initialize(init);
-        } catch (UnsupportedProtocolVersionException e) {
-            var data = Json.createObjectBuilder()
-                    .add("supported", Json.createArrayBuilder().add(e.supported()))
-                    .add("requested", e.requested())
-                    .build();
-            return new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
-                    JsonRpcErrorCode.INVALID_PARAMS.code(),
-                    "Unsupported protocol version",
-                    data));
-        }
+        InitializeResponse baseResp = lifecycle.initialize(init);
         InitializeResponse resp = new InitializeResponse(
                 baseResp.protocolVersion(),
                 baseResp.capabilities(),


### PR DESCRIPTION
## Summary
- respond to mismatched protocol version without an error
- simplify server initialization logic

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e22637c88324ae9f41b52abdd625