### PR TITLE
Refactor security permission utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/ConsentManager.java
+++ b/src/main/java/com/amannmalik/mcp/security/ConsentManager.java
@@ -17,8 +17,6 @@ public final class ConsentManager {
     public void requireConsent(Principal principal, String scope) {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (scope == null || scope.isBlank()) throw new IllegalArgumentException("scope required");
-        if (!consents.contains(principal.id(), scope)) {
-            throw new SecurityException("User consent required: " + scope);
-        }
+        consents.requirePermission(principal.id(), scope, "User consent required: " + scope);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/security/PrincipalPermissions.java
+++ b/src/main/java/com/amannmalik/mcp/security/PrincipalPermissions.java
@@ -28,6 +28,12 @@ final class PrincipalPermissions<T> {
         return set != null && set.contains(permission);
     }
 
+    void requirePermission(String principalId, T permission, String message) {
+        if (!contains(principalId, permission)) {
+            throw new SecurityException(message);
+        }
+    }
+
     private static void requirePrincipal(String id) {
         if (id == null || id.isBlank()) throw new IllegalArgumentException("principalId required");
     }

--- a/src/main/java/com/amannmalik/mcp/security/PrivacyBoundaryEnforcer.java
+++ b/src/main/java/com/amannmalik/mcp/security/PrivacyBoundaryEnforcer.java
@@ -22,9 +22,7 @@ public final class PrivacyBoundaryEnforcer implements ResourceAccessController {
         if (ann == null || ann.audience().isEmpty()) return;
 
         for (Role r : ann.audience()) {
-            if (!permissions.contains(principal.id(), r)) {
-                throw new SecurityException("Audience not permitted: " + ann.audience());
-            }
+            permissions.requirePermission(principal.id(), r, "Audience not permitted: " + ann.audience());
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/security/SamplingAccessController.java
+++ b/src/main/java/com/amannmalik/mcp/security/SamplingAccessController.java
@@ -19,9 +19,7 @@ public final class SamplingAccessController implements SamplingAccessPolicy {
     @Override
     public void requireAllowed(Principal principal) {
         if (principal == null) throw new IllegalArgumentException("principal required");
-        if (!permissions.contains(principal.id(), PERMISSION)) {
-            throw new SecurityException("Sampling not authorized");
-        }
+        permissions.requirePermission(principal.id(), PERMISSION, "Sampling not authorized");
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/security/ToolAccessController.java
+++ b/src/main/java/com/amannmalik/mcp/security/ToolAccessController.java
@@ -18,8 +18,6 @@ public final class ToolAccessController implements ToolAccessPolicy {
     public void requireAllowed(Principal principal, String tool) {
         if (principal == null) throw new IllegalArgumentException("principal required");
         if (tool == null || tool.isBlank()) throw new IllegalArgumentException("tool required");
-        if (!permissions.contains(principal.id(), tool)) {
-            throw new SecurityException("Tool not authorized: " + tool);
-        }
+        permissions.requirePermission(principal.id(), tool, "Tool not authorized: " + tool);
     }
 }


### PR DESCRIPTION
## Summary
- centralize permission enforcement logic with `requirePermission`
- apply shared method in `ConsentManager`, `ToolAccessController`, `SamplingAccessController`, and `PrivacyBoundaryEnforcer`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e307006c8324a7f6bf9337ac2581