### PR TITLE
Refactor progress token handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -345,7 +345,7 @@ public final class McpServer implements AutoCloseable {
                     "Unknown method: " + req.method(), null)));
             return;
         }
-        ProgressToken token = null;
+        Optional<ProgressToken> token = Optional.empty();
         boolean cancellable = false;
         try {
             try {
@@ -358,14 +358,14 @@ public final class McpServer implements AutoCloseable {
 
             try {
                 token = ProgressUtil.tokenFromMeta(req.params());
-                if (token != null) {
-                    progressTracker.register(token);
-                    progressTokens.put(req.id(), token);
+                token.ifPresent(t -> {
+                    progressTracker.register(t);
+                    progressTokens.put(req.id(), t);
                     try {
-                        sendProgress(new ProgressNotification(token, 0.0, 1.0, null));
+                        sendProgress(new ProgressNotification(t, 0.0, 1.0, null));
                     } catch (IOException ignore) {
                     }
-                }
+                });
             } catch (IllegalArgumentException e) {
                 send(new JsonRpcError(req.id(), new JsonRpcError.ErrorDetail(
                         JsonRpcErrorCode.INVALID_PARAMS.code(), e.getMessage(), null)));
@@ -394,11 +394,13 @@ public final class McpServer implements AutoCloseable {
             if (!cancelled && resp != null) {
                 send(resp);
             }
-            if (!cancelled && token != null) {
-                try {
-                    sendProgress(new ProgressNotification(token, 1.0, 1.0, null));
-                } catch (IOException ignore) {
-                }
+            if (!cancelled) {
+                token.ifPresent(t -> {
+                    try {
+                        sendProgress(new ProgressNotification(t, 1.0, 1.0, null));
+                    } catch (IOException ignore) {
+                    }
+                });
             }
         } finally {
             cleanup(req.id());

--- a/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressCodec.java
@@ -8,6 +8,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
+import java.util.Optional;
 
 public final class ProgressCodec {
     private ProgressCodec() {
@@ -41,18 +42,19 @@ public final class ProgressCodec {
         };
     }
 
-    public static ProgressToken fromMeta(JsonObject params) {
-        if (params == null || !params.containsKey("_meta")) return null;
+    public static Optional<ProgressToken> fromMeta(JsonObject params) {
+        if (params == null || !params.containsKey("_meta")) return Optional.empty();
         JsonObject meta = params.getJsonObject("_meta");
         MetaValidator.requireValid(meta);
-        if (!meta.containsKey("progressToken")) return null;
+        if (!meta.containsKey("progressToken")) return Optional.empty();
         var val = meta.get("progressToken");
-        return switch (val.getValueType()) {
+        ProgressToken token = switch (val.getValueType()) {
             case STRING -> new ProgressToken.StringToken(
                     InputSanitizer.requireClean(meta.getString("progressToken"))
             );
             case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
             default -> throw new IllegalArgumentException("progressToken must be a string or number");
         };
+        return Optional.of(token);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/util/ProgressUtil.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressUtil.java
@@ -6,12 +6,13 @@ import com.amannmalik.mcp.security.RateLimiter;
 import jakarta.json.JsonObject;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public final class ProgressUtil {
     private ProgressUtil() {
     }
 
-    public static ProgressToken tokenFromMeta(JsonObject params) {
+    public static Optional<ProgressToken> tokenFromMeta(JsonObject params) {
         return ProgressCodec.fromMeta(params);
     }
 


### PR DESCRIPTION
## Summary
- use `Optional` for progress tokens
- propagate changes through ProgressUtil, server, and client

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e307006c8324a7f6bf9337ac2581