### PR TITLE
Refactor pagination and completion constants

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -30,7 +30,7 @@ public final class InMemoryPromptProvider implements PromptProvider {
             all.add(t.prompt());
         }
         all.sort(Comparator.comparing(Prompt::name));
-        return Pagination.page(all, cursor, 100);
+        return Pagination.page(all, cursor, Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
@@ -7,6 +7,8 @@ import jakarta.json.JsonObject;
 import java.util.List;
 
 public record CompleteResult(Completion completion, JsonObject _meta) {
+    public static final int MAX_VALUES = 100;
+
     public CompleteResult {
         if (completion == null) throw new IllegalArgumentException("completion required");
         MetaValidator.requireValid(_meta);
@@ -21,8 +23,8 @@ public record CompleteResult(Completion completion, JsonObject _meta) {
             this.values = copy;
             this.total = total;
             this.hasMore = hasMore;
-            if (this.values.size() > 100) {
-                throw new IllegalArgumentException("values must not exceed 100 items");
+            if (this.values.size() > MAX_VALUES) {
+                throw new IllegalArgumentException("values must not exceed " + MAX_VALUES + " items");
             }
             if (this.total != null) {
                 if (this.total < 0) throw new IllegalArgumentException("total must be non-negative");

--- a/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.completion;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.server.completion.CompleteResult;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -63,7 +64,7 @@ public final class InMemoryCompletionProvider implements CompletionProvider {
                 .thenComparing(String::compareTo);
         List<String> sorted = unique.stream()
                 .sorted(cmp)
-                .limit(100)
+                .limit(CompleteResult.MAX_VALUES)
                 .toList();
         int total = unique.size();
         boolean hasMore = total > sorted.size();

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -23,7 +23,7 @@ public final class InMemoryResourceProvider implements ResourceProvider {
 
     @Override
     public Pagination.Page<Resource> list(String cursor) {
-        return Pagination.page(resources, cursor, 100);
+        return Pagination.page(resources, cursor, Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @Override
@@ -33,7 +33,7 @@ public final class InMemoryResourceProvider implements ResourceProvider {
 
     @Override
     public Pagination.Page<ResourceTemplate> listTemplates(String cursor) {
-        return Pagination.page(templates, cursor, 100);
+        return Pagination.page(templates, cursor, Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -26,7 +26,7 @@ public final class InMemoryToolProvider implements ToolProvider {
 
     @Override
     public Pagination.Page<Tool> list(String cursor) {
-        return Pagination.page(tools, cursor, 100);
+        return Pagination.page(tools, cursor, Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/util/Pagination.java
+++ b/src/main/java/com/amannmalik/mcp/util/Pagination.java
@@ -15,7 +15,7 @@ public final class Pagination {
         int end = Math.min(items.size(), start + size);
         List<T> slice = items.subList(start, end);
         String next = end < items.size() ? encode(end) : null;
-        return new Page<>(List.copyOf(slice), next);
+        return new Page<>(slice, next);
     }
 
     private static String encode(int index) {


### PR DESCRIPTION
## Summary
- avoid double copying lists in `Pagination.page`
- centralize completion result limit in `CompleteResult`
- use the new limit in `InMemoryCompletionProvider`
- use `Pagination.DEFAULT_PAGE_SIZE` in in-memory providers

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e545c7708324994df20068d10368