### PR TITLE
Add tool lookup API

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -746,7 +746,7 @@ public final class McpServer implements AutoCloseable {
             ToolResult result = tools.call(callRequest.name(), callRequest.arguments());
             return new JsonRpcResponse(req.id(), ToolCodec.toJsonObject(result));
         } catch (IllegalArgumentException e) {
-            Optional<Tool> tool = findTool(callRequest.name());
+            Optional<Tool> tool = tools == null ? Optional.empty() : tools.find(callRequest.name());
             if (tool.isPresent() && lifecycle.negotiatedClientCapabilities().contains(ClientCapability.ELICITATION)) {
                 try {
                     ElicitRequest er = new ElicitRequest(
@@ -963,14 +963,6 @@ public final class McpServer implements AutoCloseable {
         throw new IOException(((JsonRpcError) msg).error().message());
     }
 
-    private Optional<Tool> findTool(String name) {
-        if (tools == null) return Optional.empty();
-        Pagination.Page<Tool> page = tools.list(null);
-        for (Tool t : page.items()) {
-            if (t.name().equals(name)) return Optional.of(t);
-        }
-        return Optional.empty();
-    }
 
     public CreateMessageResponse createMessage(CreateMessageRequest req) throws IOException {
         requireClientCapability(ClientCapability.SAMPLING);

--- a/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/InMemoryToolProvider.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
+import java.util.Optional;
 
 public final class InMemoryToolProvider implements ToolProvider {
     private final List<Tool> tools;
@@ -27,6 +28,15 @@ public final class InMemoryToolProvider implements ToolProvider {
     @Override
     public Pagination.Page<Tool> list(String cursor) {
         return Pagination.page(tools, cursor, 100);
+    }
+
+    @Override
+    public Optional<Tool> find(String name) {
+        if (name == null) throw new IllegalArgumentException("name required");
+        for (Tool t : tools) {
+            if (t.name().equals(name)) return Optional.of(t);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolProvider.java
@@ -2,11 +2,27 @@ package com.amannmalik.mcp.server.tools;
 
 import com.amannmalik.mcp.util.Pagination;
 import jakarta.json.JsonObject;
+import java.util.Optional;
 
 public interface ToolProvider {
     Pagination.Page<Tool> list(String cursor);
 
     ToolResult call(String name, JsonObject arguments);
+
+    default Optional<Tool> find(String name) {
+        if (name == null) throw new IllegalArgumentException("name required");
+        String cursor = null;
+        do {
+            Pagination.Page<Tool> page = list(cursor);
+            for (Tool t : page.items()) {
+                if (t.name().equals(name)) {
+                    return Optional.of(t);
+                }
+            }
+            cursor = page.nextCursor();
+        } while (cursor != null);
+        return Optional.empty();
+    }
 
     default ToolListSubscription subscribeList(ToolListListener listener) {
         return () -> {


### PR DESCRIPTION
## Summary
- add `ToolProvider.find` with default implementation
- override lookup in `InMemoryToolProvider`
- use new lookup in `McpServer`

## Testing
- `gradle test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6889e545c7708324994df20068d10368