### PR TITLE
Refactor annotations codec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/annotations/AnnotationsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/annotations/AnnotationsCodec.java
@@ -1,0 +1,50 @@
+package com.amannmalik.mcp.annotations;
+
+import com.amannmalik.mcp.prompts.Role;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.EnumSet;
+import java.util.Set;
+
+public final class AnnotationsCodec {
+    private AnnotationsCodec() {
+    }
+
+    public static JsonObject toJsonObject(Annotations ann) {
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (!ann.audience().isEmpty()) {
+            JsonArrayBuilder arr = Json.createArrayBuilder();
+            ann.audience().forEach(r -> arr.add(r.name().toLowerCase()));
+            b.add("audience", arr);
+        }
+        if (ann.priority() != null) b.add("priority", ann.priority());
+        if (ann.lastModified() != null) b.add("lastModified", ann.lastModified().toString());
+        return b.build();
+    }
+
+    public static Annotations toAnnotations(JsonObject obj) {
+        if (obj == null) return null;
+        Set<Role> audience = EnumSet.noneOf(Role.class);
+        var arr = obj.getJsonArray("audience");
+        if (arr != null) {
+            arr.getValuesAs(JsonString.class)
+                    .forEach(js -> audience.add(Role.valueOf(js.getString().toUpperCase())));
+        }
+        Double priority = obj.containsKey("priority") ? obj.getJsonNumber("priority").doubleValue() : null;
+        Instant lastModified = null;
+        if (obj.containsKey("lastModified")) {
+            try {
+                lastModified = Instant.parse(obj.getString("lastModified"));
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException("Invalid lastModified", e);
+            }
+        }
+        return new Annotations(audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience), priority, lastModified);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
+import com.amannmalik.mcp.annotations.AnnotationsCodec;
 import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.Pagination;
@@ -89,7 +90,7 @@ public final class PromptCodec {
     static JsonObject toJsonObject(PromptContent content) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("type", content.type());
         if (content.annotations() != null) {
-            b.add("annotations", ResourcesCodec.toJsonObject(content.annotations()));
+            b.add("annotations", AnnotationsCodec.toJsonObject(content.annotations()));
         }
         switch (content) {
             case PromptContent.Text t -> {
@@ -110,7 +111,7 @@ public final class PromptCodec {
                 if (content._meta() != null) b.add("_meta", content._meta());
                 b.add("resource", ResourcesCodec.toJsonObject(r.resource()));
                 if (r.annotations() != null) {
-                    b.add("annotations", ResourcesCodec.toJsonObject(r.annotations()));
+                    b.add("annotations", AnnotationsCodec.toJsonObject(r.annotations()));
                 }
             }
             case PromptContent.ResourceLink l -> {
@@ -231,7 +232,7 @@ public final class PromptCodec {
     private static PromptContent toPromptContent(JsonObject obj) {
         String type = obj.getString("type", null);
         if (type == null) throw new IllegalArgumentException("type required");
-        var ann = obj.containsKey("annotations") ? ResourcesCodec.toAnnotations(obj.getJsonObject("annotations")) : null;
+        var ann = obj.containsKey("annotations") ? AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations")) : null;
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
         return switch (type) {
             case "text" -> new PromptContent.Text(obj.getString("text"), ann, meta);


### PR DESCRIPTION
## Summary
- centralize annotations JSON logic in new `AnnotationsCodec`
- use `AnnotationsCodec` across sampling, prompts, resources, and tool result classes

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e545c7708324994df20068d10368