### PR TITLE
Refactor map sanitization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
@@ -2,19 +2,12 @@ package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public record GetPromptRequest(String name, Map<String, String> arguments) {
     public GetPromptRequest {
         if (name == null) throw new IllegalArgumentException("name required");
         name = InputSanitizer.requireClean(name);
-        if (arguments == null || arguments.isEmpty()) {
-            arguments = Map.of();
-        } else {
-            Map<String, String> copy = new HashMap<>();
-            arguments.forEach((k, v) -> copy.put(InputSanitizer.requireClean(k), InputSanitizer.requireClean(v)));
-            arguments = Map.copyOf(copy);
-        }
+        arguments = InputSanitizer.requireCleanMap(arguments);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
@@ -5,7 +5,6 @@ import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriTemplateValidator;
 import jakarta.json.JsonObject;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public record CompleteRequest(
@@ -31,15 +30,7 @@ public record CompleteRequest(
 
     public record Context(Map<String, String> arguments) {
         public Context(Map<String, String> arguments) {
-            if (arguments == null || arguments.isEmpty()) {
-                this.arguments = Map.of();
-            } else {
-                Map<String, String> copy = new HashMap<>();
-                arguments.forEach((k, v) -> {
-                    copy.put(InputSanitizer.requireClean(k), InputSanitizer.requireClean(v));
-                });
-                this.arguments = Map.copyOf(copy);
-            }
+            this.arguments = InputSanitizer.requireCleanMap(arguments);
         }
 
         @Override

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.completion;
 
+import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -55,7 +56,7 @@ public final class CompletionCodec {
                     args.put(k, ((JsonString) v).getString());
                 });
             }
-            ctx = new CompleteRequest.Context(args);
+            ctx = new CompleteRequest.Context(InputSanitizer.requireCleanMap(args));
         }
         return new CompleteRequest(ref, argument, ctx);
     }

--- a/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/InMemoryCompletionProvider.java
@@ -1,11 +1,9 @@
 package com.amannmalik.mcp.server.completion;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
-import com.amannmalik.mcp.server.completion.CompleteResult;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,14 +18,7 @@ public final class InMemoryCompletionProvider implements CompletionProvider {
                     Map<String, String> context,
                     List<String> values) {
         argumentName = InputSanitizer.requireClean(argumentName);
-        Map<String, String> ctx;
-        if (context == null || context.isEmpty()) {
-            ctx = Map.of();
-        } else {
-            Map<String, String> copy = new HashMap<>();
-            context.forEach((k, v) -> copy.put(InputSanitizer.requireClean(k), InputSanitizer.requireClean(v)));
-            ctx = Map.copyOf(copy);
-        }
+        Map<String, String> ctx = InputSanitizer.requireCleanMap(context);
         List<String> vals = values == null ? List.of() : values.stream()
                 .map(InputSanitizer::requireClean)
                 .toList();

--- a/src/main/java/com/amannmalik/mcp/validation/InputSanitizer.java
+++ b/src/main/java/com/amannmalik/mcp/validation/InputSanitizer.java
@@ -1,5 +1,8 @@
 package com.amannmalik.mcp.validation;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public final class InputSanitizer {
     private InputSanitizer() {
     }
@@ -17,5 +20,12 @@ public final class InputSanitizer {
 
     public static String cleanNullable(String value) {
         return value == null ? null : requireClean(value);
+    }
+
+    public static Map<String, String> requireCleanMap(Map<String, String> map) {
+        if (map == null || map.isEmpty()) return Map.of();
+        Map<String, String> copy = new HashMap<>();
+        map.forEach((k, v) -> copy.put(requireClean(k), requireClean(v)));
+        return Map.copyOf(copy);
     }
 }


### PR DESCRIPTION
## Summary
- introduce `InputSanitizer.requireCleanMap` for reusing map sanitation logic
- update GetPromptRequest, CompleteRequest.Context and completion utilities to use new helper
- simplify InMemoryCompletionProvider

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e7dc29f88324a6d726105ac00a1b