### PR TITLE
Add CreateMessageRequest meta

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/CreateMessageRequest.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.client.sampling;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
 import java.util.List;
@@ -13,7 +14,8 @@ public record CreateMessageRequest(
         Double temperature,
         int maxTokens,
         List<String> stopSequences,
-        JsonObject metadata
+        JsonObject metadata,
+        JsonObject _meta
 ) {
     public enum IncludeContext {NONE, THIS_SERVER, ALL_SERVERS}
 
@@ -30,5 +32,6 @@ public record CreateMessageRequest(
         if (maxTokens <= 0) {
             throw new IllegalArgumentException("maxTokens must be > 0");
         }
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
@@ -38,6 +38,7 @@ public final class SamplingCodec {
             obj.add("stopSequences", arr.build());
         }
         if (req.metadata() != null) obj.add("metadata", req.metadata());
+        if (req._meta() != null) obj.add("_meta", req._meta());
         return obj.build();
     }
 
@@ -65,7 +66,8 @@ public final class SamplingCodec {
                 .stream().map(JsonString::getString).toList()
                 : List.of();
         JsonObject metadata = obj.getJsonObject("metadata");
-        return new CreateMessageRequest(messages, prefs, system, ctx, temp, max, stops, metadata);
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new CreateMessageRequest(messages, prefs, system, ctx, temp, max, stops, metadata, meta);
     }
 
     public static JsonObject toJsonObject(CreateMessageResponse resp) {


### PR DESCRIPTION
## Summary
- include `_meta` in `CreateMessageRequest`
- handle `_meta` field in `SamplingCodec`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e74a90f48324acb8d45b6e42dc11