### PR TITLE
Add protocol version header validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -235,6 +235,10 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
             String version = req.getHeader(PROTOCOL_HEADER);
+            if (version != null && !isVisibleAscii(version)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
             JsonObject obj;
             try (JsonReader reader = Json.createReader(req.getInputStream())) {
                 obj = reader.readObject();
@@ -419,6 +423,10 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
             String version = req.getHeader(PROTOCOL_HEADER);
+            if (version != null && !isVisibleAscii(version)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
             if (session == null) {
                 if (header != null && header.equals(last)) {
                     resp.sendError(HttpServletResponse.SC_NOT_FOUND);
@@ -547,6 +555,10 @@ public final class StreamableHttpTransport implements Transport {
                 return;
             }
             String version = req.getHeader(PROTOCOL_HEADER);
+            if (version != null && !isVisibleAscii(version)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
             if (session == null) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;


### PR DESCRIPTION
## Summary
- validate the `MCP-Protocol-Version` header for visible ASCII characters in `StreamableHttpTransport`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6889e74a90f48324acb8d45b6e42dc11