### PR TITLE
Refactor JSON-RPC error creation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
@@ -6,6 +6,22 @@ public record JsonRpcError(RequestId id, ErrorDetail error) implements JsonRpcMe
     public record ErrorDetail(int code, String message, JsonValue data) {
     }
 
+    public static JsonRpcError of(RequestId id, JsonRpcErrorCode code, String message) {
+        return of(id, code, message, null);
+    }
+
+    public static JsonRpcError of(RequestId id, JsonRpcErrorCode code, String message, JsonValue data) {
+        return new JsonRpcError(id, new ErrorDetail(code.code(), message, data));
+    }
+
+    public static JsonRpcError of(RequestId id, int code, String message) {
+        return of(id, code, message, null);
+    }
+
+    public static JsonRpcError of(RequestId id, int code, String message, JsonValue data) {
+        return new JsonRpcError(id, new ErrorDetail(code, message, data));
+    }
+
     public JsonRpcError {
         if (id == null || error == null) {
             throw new IllegalArgumentException("id and error are required");

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -162,11 +162,10 @@ public final class StreamableHttpTransport implements Transport {
             requestStreams.forEach((id, client) -> {
                 try {
                     RequestId reqId = RequestId.parse(id);
-                    JsonRpcError err = new JsonRpcError(reqId,
-                            new JsonRpcError.ErrorDetail(
-                                    JsonRpcErrorCode.INTERNAL_ERROR.code(),
-                                    "Transport closed",
-                                    null));
+                    JsonRpcError err = JsonRpcError.of(
+                            reqId,
+                            JsonRpcErrorCode.INTERNAL_ERROR,
+                            "Transport closed");
                     client.send(JsonRpcCodec.toJsonObject(err));
                     client.close();
                 } catch (Exception ignore) {
@@ -177,11 +176,10 @@ public final class StreamableHttpTransport implements Transport {
 
             responseQueues.forEach((id, queue) -> {
                 RequestId reqId = RequestId.parse(id);
-                JsonRpcError err = new JsonRpcError(reqId,
-                        new JsonRpcError.ErrorDetail(
-                                JsonRpcErrorCode.INTERNAL_ERROR.code(),
-                                "Transport closed",
-                                null));
+                JsonRpcError err = JsonRpcError.of(
+                        reqId,
+                        JsonRpcErrorCode.INTERNAL_ERROR,
+                        "Transport closed");
                 queue.offer(JsonRpcCodec.toJsonObject(err));
             });
             responseQueues.clear();


### PR DESCRIPTION
## Summary
- add factory helpers for `JsonRpcError`
- use helpers in `McpServer`, `McpClient`, and `StreamableHttpTransport`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889e7dc29f88324a6d726105ac00a1b