### PR TITLE
Simplify cursor sanitization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -512,9 +512,6 @@ public final class McpServer implements AutoCloseable {
         return invalidParams(req, e.getMessage());
     }
 
-    private static String sanitizeCursor(String cursor) {
-        return cursor == null ? null : InputSanitizer.requireClean(cursor);
-    }
 
     private void cancelled(JsonRpcNotification note) {
         CancelledNotification cn = CancellationCodec.toCancelledNotification(note.params());
@@ -549,7 +546,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = lr.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(cursor);
+                cursor = InputSanitizer.cleanNullable(cursor);
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }
@@ -610,7 +607,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = request.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(cursor);
+                cursor = InputSanitizer.cleanNullable(cursor);
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }
@@ -706,7 +703,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = ltr.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(cursor);
+                cursor = InputSanitizer.cleanNullable(cursor);
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }
@@ -770,7 +767,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = lpr.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(cursor);
+                cursor = InputSanitizer.cleanNullable(cursor);
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }


### PR DESCRIPTION
## Summary
- removed custom `sanitizeCursor` helper
- rely on `InputSanitizer.cleanNullable` for cursor validation

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889eb130d8c83249c49233f7d7d8a69