### PR TITLE
Fix progress rate limit handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/ProgressUtil.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressUtil.java
@@ -26,7 +26,7 @@ public final class ProgressUtil {
         try {
             limiter.requireAllowance(note.token().asString());
             tracker.update(note);
-        } catch (IllegalArgumentException | IllegalStateException ignore) {
+        } catch (IllegalArgumentException | IllegalStateException | SecurityException ignore) {
             return;
         }
         sender.send(new JsonRpcNotification(


### PR DESCRIPTION
## Summary
- ignore rate limiter errors when sending progress notifications

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889eaa345408324853d86bf10da8d15