### PR TITLE
Implement 401 handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -5,6 +5,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 
+import com.amannmalik.mcp.transport.UnauthorizedException;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,6 +66,11 @@ public final class StreamableHttpClientTransport implements Transport {
 
         int status = response.statusCode();
         String ct = response.headers().firstValue("Content-Type").orElse("");
+        if (status == 401) {
+            String header = response.headers().firstValue("WWW-Authenticate").orElse(null);
+            response.body().close();
+            throw new UnauthorizedException(header);
+        }
         if (status == 202) {
             response.body().close();
             return;

--- a/src/main/java/com/amannmalik/mcp/transport/UnauthorizedException.java
+++ b/src/main/java/com/amannmalik/mcp/transport/UnauthorizedException.java
@@ -1,0 +1,23 @@
+package com.amannmalik.mcp.transport;
+
+import java.io.IOException;
+
+/**
+ * Thrown when the server responds with HTTP 401 Unauthorized.
+ * <p>
+ * The {@code wwwAuthenticate} header may be used by callers to
+ * initiate an authorization flow.
+ */
+public final class UnauthorizedException extends IOException {
+    private final String wwwAuthenticate;
+
+    public UnauthorizedException(String wwwAuthenticate) {
+        super("HTTP 401 Unauthorized");
+        this.wwwAuthenticate = wwwAuthenticate;
+    }
+
+    public String wwwAuthenticate() {
+        return wwwAuthenticate;
+    }
+}
+


### PR DESCRIPTION
## Summary
- raise UnauthorizedException when server returns 401
- expose www-authenticate header for auth flows

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889eaa345408324853d86bf10da8d15