### PR TITLE
Fix Elicitation schema validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/ElicitationSchemaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/ElicitationSchemaValidator.java
@@ -61,6 +61,10 @@ public final class ElicitationSchemaValidator {
         if (prop.containsKey("maxLength") && prop.getInt("maxLength") < 0) {
             throw new IllegalArgumentException("maxLength must be >= 0 for " + name);
         }
+        if (prop.containsKey("minLength") && prop.containsKey("maxLength") &&
+                prop.getInt("maxLength") < prop.getInt("minLength")) {
+            throw new IllegalArgumentException("maxLength must be >= minLength for " + name);
+        }
         if (hasEnum) {
             JsonArray vals = prop.getJsonArray("enum");
             if (vals.isEmpty()) {


### PR DESCRIPTION
## Summary
- enforce `maxLength >= minLength` for elicitation schema validation

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889ee31f6188324b5ce71bdbf4687f7