### PR TITLE
Refactor pagination JSON helpers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -7,6 +7,7 @@ import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.PaginationJson;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -61,11 +62,7 @@ public final class PromptCodec {
     }
 
     public static JsonObject toJsonObject(Pagination.Page<Prompt> page) {
-        JsonArrayBuilder arr = Json.createArrayBuilder();
-        page.items().forEach(p -> arr.add(toJsonObject(p)));
-        JsonObjectBuilder builder = Json.createObjectBuilder().add("prompts", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
-        return builder.build();
+        return PaginationJson.toJson("prompts", page, PromptCodec::toJsonObject);
     }
 
     public static JsonObject toJsonObject(ListPromptsRequest req) {

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -5,7 +5,9 @@ import com.amannmalik.mcp.annotations.AnnotationsCodec;
 import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
 import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
+import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.PaginationJson;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -171,12 +173,10 @@ public final class ResourcesCodec {
 
     public static JsonObject toJsonObject(ListResourcesResult result) {
         if (result == null) throw new IllegalArgumentException("result required");
-        var arr = Json.createArrayBuilder();
-        result.resources().forEach(r -> arr.add(toJsonObject(r)));
-        JsonObjectBuilder b = Json.createObjectBuilder().add("resources", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor()))
-                .forEach(b::add);
-        return b.build();
+        return PaginationJson.toJson(
+                "resources",
+                new Pagination.Page<>(result.resources(), result.nextCursor()),
+                ResourcesCodec::toJsonObject);
     }
 
     public static JsonObject toJsonObject(ListResourcesRequest req) {
@@ -201,12 +201,10 @@ public final class ResourcesCodec {
 
     public static JsonObject toJsonObject(ListResourceTemplatesResult result) {
         if (result == null) throw new IllegalArgumentException("result required");
-        var arr = Json.createArrayBuilder();
-        result.resourceTemplates().forEach(t -> arr.add(toJsonObject(t)));
-        JsonObjectBuilder b = Json.createObjectBuilder().add("resourceTemplates", arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(result.nextCursor()))
-                .forEach(b::add);
-        return b.build();
+        return PaginationJson.toJson(
+                "resourceTemplates",
+                new Pagination.Page<>(result.resourceTemplates(), result.nextCursor()),
+                ResourcesCodec::toJsonObject);
     }
 
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -5,9 +5,9 @@ import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
+import com.amannmalik.mcp.util.PaginationJson;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
@@ -32,11 +32,7 @@ public final class ToolCodec {
     }
 
     public static JsonObject toJsonObject(Pagination.Page<Tool> page) {
-        JsonArrayBuilder arr = Json.createArrayBuilder();
-        page.items().forEach(t -> arr.add(toJsonObject(t)));
-        JsonObjectBuilder builder = Json.createObjectBuilder().add("tools", arr);
-        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor())).forEach(builder::add);
-        return builder.build();
+        return PaginationJson.toJson("tools", page, ToolCodec::toJsonObject);
     }
 
     public static JsonObject toJsonObject(ListToolsRequest req) {

--- a/src/main/java/com/amannmalik/mcp/util/PaginationJson.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginationJson.java
@@ -1,0 +1,25 @@
+package com.amannmalik.mcp.util;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+
+import java.util.function.Function;
+
+public final class PaginationJson {
+    private PaginationJson() {
+    }
+
+    public static <T> JsonObject toJson(String itemsField,
+                                        Pagination.Page<T> page,
+                                        Function<T, JsonValue> encoder) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        page.items().forEach(item -> arr.add(encoder.apply(item)));
+        JsonObjectBuilder b = Json.createObjectBuilder().add(itemsField, arr.build());
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor()))
+                .forEach(b::add);
+        return b.build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `PaginationJson` helper for encoding paginated JSON arrays
- refactor tool, prompt, and resource codecs to use new helper

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889efb705d08324904af03adb61b2f1