### PR TITLE
Centralize request method names

### DIFF
--- a/src/main/java/com/amannmalik/mcp/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/RequestMethod.java
@@ -1,0 +1,46 @@
+package com.amannmalik.mcp;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public enum RequestMethod {
+    INITIALIZE("initialize"),
+    PING("ping"),
+    RESOURCES_LIST("resources/list"),
+    RESOURCES_TEMPLATES_LIST("resources/templates/list"),
+    RESOURCES_READ("resources/read"),
+    RESOURCES_SUBSCRIBE("resources/subscribe"),
+    RESOURCES_UNSUBSCRIBE("resources/unsubscribe"),
+    TOOLS_LIST("tools/list"),
+    TOOLS_CALL("tools/call"),
+    PROMPTS_LIST("prompts/list"),
+    PROMPTS_GET("prompts/get"),
+    LOGGING_SET_LEVEL("logging/setLevel"),
+    COMPLETION_COMPLETE("completion/complete"),
+    SAMPLING_CREATE_MESSAGE("sampling/createMessage"),
+    ROOTS_LIST("roots/list"),
+    ELICITATION_CREATE("elicitation/create");
+
+    private static final Map<String, RequestMethod> BY_METHOD;
+    private final String method;
+
+    static {
+        BY_METHOD = Arrays.stream(values())
+                .collect(Collectors.toUnmodifiableMap(m -> m.method, m -> m));
+    }
+
+    RequestMethod(String method) {
+        this.method = method;
+    }
+
+    public String method() {
+        return method;
+    }
+
+    public static Optional<RequestMethod> from(String method) {
+        if (method == null) return Optional.empty();
+        return Optional.ofNullable(BY_METHOD.get(method));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -10,6 +10,7 @@ import com.amannmalik.mcp.prompts.Role;
 import com.amannmalik.mcp.server.tools.ListToolsResult;
 import com.amannmalik.mcp.server.tools.ToolCodec;
 import com.amannmalik.mcp.server.tools.ToolResult;
+import com.amannmalik.mcp.RequestMethod;
 import com.amannmalik.mcp.util.PaginatedRequest;
 import com.amannmalik.mcp.util.PaginationCodec;
 import jakarta.json.Json;
@@ -137,7 +138,7 @@ public final class HostProcess implements AutoCloseable {
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, Optional.of(ServerCapability.TOOLS));
         JsonObject params = PaginationCodec.toJsonObject(new PaginatedRequest(cursor));
-        JsonRpcMessage resp = client.request("tools/list", params);
+        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_LIST.method(), params);
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toListToolsResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
@@ -153,7 +154,7 @@ public final class HostProcess implements AutoCloseable {
                 .add("name", name)
                 .add("arguments", args == null ? JsonValue.EMPTY_JSON_OBJECT : args)
                 .build();
-        JsonRpcMessage resp = client.request("tools/call", params);
+        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_CALL.method(), params);
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toToolResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
@@ -165,7 +166,7 @@ public final class HostProcess implements AutoCloseable {
         if (!client.connected()) throw new IllegalStateException("Client not connected: " + clientId);
         consents.requireConsent(principal, "sampling");
         samplingAccess.requireAllowed(principal);
-        JsonRpcMessage resp = client.request("sampling/createMessage", params);
+        JsonRpcMessage resp = client.request(RequestMethod.SAMPLING_CREATE_MESSAGE.method(), params);
         if (resp instanceof JsonRpcResponse r) return r.result();
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");


### PR DESCRIPTION
## Summary
- introduce `RequestMethod` enum for request names
- refactor `McpClient`, `McpServer`, and `HostProcess` to use new enum
- provide convenience overloads for `request()`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889efb705d08324904af03adb61b2f1