### PR TITLE
Refactor protocol version constants

### DIFF
--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -7,6 +7,11 @@ import java.util.Set;
 
 public class ProtocolLifecycle {
     public static final String SUPPORTED_VERSION = "2025-06-18";
+    /**
+     * The most recent prior revision that implementations should fall back to
+     * when no protocol version is negotiated.
+     */
+    public static final String PREVIOUS_VERSION = "2025-03-26";
 
     private final Set<ServerCapability> serverCapabilities;
     private final ServerInfo serverInfo;

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -48,9 +48,10 @@ public final class StreamableHttpTransport implements Transport {
 
 
     private static final String PROTOCOL_HEADER = TransportHeaders.PROTOCOL_VERSION;
-    // Default to the previous protocol revision when no version header is
-    // present, as recommended for backwards compatibility.
-    private static final String COMPATIBILITY_VERSION = "2025-03-26";
+    // Default to the previous protocol revision when the version header is
+    // absent, as recommended for backwards compatibility.
+    private static final String COMPATIBILITY_VERSION =
+            com.amannmalik.mcp.lifecycle.ProtocolLifecycle.PREVIOUS_VERSION;
     private final BlockingQueue<JsonObject> incoming = new LinkedBlockingQueue<>();
     private final Set<SseClient> generalClients = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String, SseClient> requestStreams = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Summary
- expose `PREVIOUS_VERSION` in `ProtocolLifecycle`
- reference this constant in `StreamableHttpTransport`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889f2cf156c832482a939869147f4fb