### PR TITLE
Refactor base64 handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
@@ -9,7 +9,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 
-import java.util.Base64;
+import com.amannmalik.mcp.util.Base64Util;
 import java.util.List;
 
 public final class SamplingCodec {
@@ -106,9 +106,9 @@ public final class SamplingCodec {
         if (content._meta() != null) b.add("_meta", content._meta());
         switch (content) {
             case MessageContent.Text t -> b.add("text", t.text());
-            case MessageContent.Image i -> b.add("data", Base64.getEncoder().encodeToString(i.data()))
+            case MessageContent.Image i -> b.add("data", Base64Util.encode(i.data()))
                     .add("mimeType", i.mimeType());
-            case MessageContent.Audio a -> b.add("data", Base64.getEncoder().encodeToString(a.data()))
+            case MessageContent.Audio a -> b.add("data", Base64Util.encode(a.data()))
                     .add("mimeType", a.mimeType());
         }
         return b.build();
@@ -121,8 +121,8 @@ public final class SamplingCodec {
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
         return switch (obj.getString("type")) {
             case "text" -> new MessageContent.Text(obj.getString("text"), ann, meta);
-            case "image" -> new MessageContent.Image(Base64.getDecoder().decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
-            case "audio" -> new MessageContent.Audio(Base64.getDecoder().decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
+            case "image" -> new MessageContent.Image(Base64Util.decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
+            case "audio" -> new MessageContent.Audio(Base64Util.decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
             default -> throw new IllegalArgumentException("Unknown content type");
         };
     }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -18,7 +18,7 @@ import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
 import java.util.ArrayList;
-import java.util.Base64;
+import com.amannmalik.mcp.util.Base64Util;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,12 +91,12 @@ public final class PromptCodec {
             }
             case PromptContent.Image i -> {
                 if (content._meta() != null) b.add("_meta", content._meta());
-                b.add("data", Base64.getEncoder().encodeToString(i.data()))
+                b.add("data", Base64Util.encode(i.data()))
                         .add("mimeType", i.mimeType());
             }
             case PromptContent.Audio a -> {
                 if (content._meta() != null) b.add("_meta", content._meta());
-                b.add("data", Base64.getEncoder().encodeToString(a.data()))
+                b.add("data", Base64Util.encode(a.data()))
                         .add("mimeType", a.mimeType());
             }
             case PromptContent.EmbeddedResource r -> {
@@ -228,8 +228,8 @@ public final class PromptCodec {
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
         return switch (type) {
             case "text" -> new PromptContent.Text(obj.getString("text"), ann, meta);
-            case "image" -> new PromptContent.Image(Base64.getDecoder().decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
-            case "audio" -> new PromptContent.Audio(Base64.getDecoder().decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
+            case "image" -> new PromptContent.Image(Base64Util.decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
+            case "audio" -> new PromptContent.Audio(Base64Util.decode(obj.getString("data")), obj.getString("mimeType"), ann, meta);
             case "resource" -> new PromptContent.EmbeddedResource(ResourcesCodec.toResourceBlock(obj.getJsonObject("resource")), ann, meta);
             case "resource_link" -> new PromptContent.ResourceLink(ResourcesCodec.toResource(obj));
             default -> throw new IllegalArgumentException("unknown content type: " + type);

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -12,7 +12,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
-import java.util.Base64;
+import com.amannmalik.mcp.util.Base64Util;
 import java.util.Set;
 
 public final class ResourcesCodec {
@@ -77,7 +77,7 @@ public final class ResourcesCodec {
         if (block._meta() != null) b.add("_meta", block._meta());
         switch (block) {
             case ResourceBlock.Text t -> b.add("text", t.text());
-            case ResourceBlock.Binary b2 -> b.add("blob", Base64.getEncoder().encodeToString(b2.blob()));
+            case ResourceBlock.Binary b2 -> b.add("blob", Base64Util.encode(b2.blob()));
         }
         return b.build();
     }
@@ -106,7 +106,7 @@ public final class ResourcesCodec {
             return new ResourceBlock.Text(uri, mime, obj.getString("text"), ann, meta);
         }
 
-        byte[] data = Base64.getDecoder().decode(obj.getString("blob"));
+        byte[] data = Base64Util.decode(obj.getString("blob"));
         return new ResourceBlock.Binary(uri, mime, data, ann, meta);
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -13,7 +13,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
 
-import java.util.Base64;
+import com.amannmalik.mcp.util.Base64Util;
 
 public record ToolResult(JsonArray content,
                          JsonObject structuredContent,
@@ -72,10 +72,10 @@ public record ToolResult(JsonArray content,
     }
 
     private static JsonObject toImage(JsonObject obj) {
-        byte[] data = decodeBase64(obj.getString("data"));
+        byte[] data = Base64Util.decode(obj.getString("data"));
         JsonObjectBuilder result = Json.createObjectBuilder()
                 .add("type", "image")
-                .add("data", Base64.getEncoder().encodeToString(data))
+                .add("data", Base64Util.encode(data))
                 .add("mimeType", InputSanitizer.requireClean(obj.getString("mimeType")));
         if (obj.containsKey("annotations")) {
             var ann = AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations"));
@@ -89,10 +89,10 @@ public record ToolResult(JsonArray content,
     }
 
     private static JsonObject toAudio(JsonObject obj) {
-        byte[] data = decodeBase64(obj.getString("data"));
+        byte[] data = Base64Util.decode(obj.getString("data"));
         JsonObjectBuilder result = Json.createObjectBuilder()
                 .add("type", "audio")
-                .add("data", Base64.getEncoder().encodeToString(data))
+                .add("data", Base64Util.encode(data))
                 .add("mimeType", InputSanitizer.requireClean(obj.getString("mimeType")));
         if (obj.containsKey("annotations")) {
             var ann = AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations"));
@@ -133,14 +133,6 @@ public record ToolResult(JsonArray content,
             result.add("_meta", obj.getJsonObject("_meta"));
         }
         return result.build();
-    }
-
-    private static byte[] decodeBase64(String value) {
-        try {
-            return Base64.getDecoder().decode(value);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Invalid base64 data", e);
-        }
     }
 
 }

--- a/src/main/java/com/amannmalik/mcp/util/Base64Util.java
+++ b/src/main/java/com/amannmalik/mcp/util/Base64Util.java
@@ -1,0 +1,20 @@
+package com.amannmalik.mcp.util;
+
+import java.util.Base64;
+
+public final class Base64Util {
+    private Base64Util() {
+    }
+
+    public static byte[] decode(String value) {
+        try {
+            return Base64.getDecoder().decode(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid base64 data", e);
+        }
+    }
+
+    public static String encode(byte[] data) {
+        return Base64.getEncoder().encodeToString(data);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Base64Util` helper
- use helper for tool, resource, prompt and sampling codecs

## Testing
- `bash verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889f2cf156c832482a939869147f4fb