### PR TITLE
Refactor RPC utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.ping;
 
+import com.amannmalik.mcp.RequestMethod;
 import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
 import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
 import com.amannmalik.mcp.jsonrpc.RequestId;
@@ -11,7 +12,7 @@ public final class PingCodec {
 
     public static JsonRpcRequest toRequest(RequestId id) {
         if (id == null) throw new IllegalArgumentException("id required");
-        return new JsonRpcRequest(id, "ping", null);
+        return new JsonRpcRequest(id, RequestMethod.PING.method(), null);
     }
 
     public static PingRequest toPingRequest(JsonRpcRequest req) {

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -138,7 +138,7 @@ public final class HostProcess implements AutoCloseable {
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, Optional.of(ServerCapability.TOOLS));
         JsonObject params = PaginationCodec.toJsonObject(new PaginatedRequest(cursor));
-        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_LIST.method(), params);
+        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_LIST, params);
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toListToolsResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
@@ -154,7 +154,7 @@ public final class HostProcess implements AutoCloseable {
                 .add("name", name)
                 .add("arguments", args == null ? JsonValue.EMPTY_JSON_OBJECT : args)
                 .build();
-        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_CALL.method(), params);
+        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_CALL, params);
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toToolResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
@@ -166,7 +166,7 @@ public final class HostProcess implements AutoCloseable {
         if (!client.connected()) throw new IllegalStateException("Client not connected: " + clientId);
         consents.requireConsent(principal, "sampling");
         samplingAccess.requireAllowed(principal);
-        JsonRpcMessage resp = client.request(RequestMethod.SAMPLING_CREATE_MESSAGE.method(), params);
+        JsonRpcMessage resp = client.request(RequestMethod.SAMPLING_CREATE_MESSAGE, params);
         if (resp instanceof JsonRpcResponse r) return r.result();
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.transport;
 import com.amannmalik.mcp.auth.AuthorizationException;
 import com.amannmalik.mcp.auth.AuthorizationManager;
 import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.RequestMethod;
 import com.amannmalik.mcp.jsonrpc.JsonRpcCodec;
 import com.amannmalik.mcp.jsonrpc.JsonRpcError;
 import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
@@ -254,7 +255,8 @@ public final class StreamableHttpTransport implements Transport {
             try (JsonReader reader = Json.createReader(req.getInputStream())) {
                 obj = reader.readObject();
             }
-            boolean initializing = "initialize".equals(obj.getString("method", null));
+            boolean initializing = RequestMethod.INITIALIZE.method()
+                    .equals(obj.getString("method", null));
 
             if (session == null && initializing) {
                 byte[] bytes = new byte[32];


### PR DESCRIPTION
## Summary
- centralize JSON-RPC method constants using enums
- update PingCodec and client/server helpers to use RequestMethod enums
- add typed notification helper to `McpClient`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0b62d4848324b23973392ca3e430