### PR TITLE
Fix ToolResult optional error flag

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolResult.java
@@ -17,10 +17,11 @@ import com.amannmalik.mcp.util.Base64Util;
 
 public record ToolResult(JsonArray content,
                          JsonObject structuredContent,
-                         boolean isError,
+                         Boolean isError,
                          JsonObject _meta) {
     public ToolResult {
         content = sanitize(content == null ? JsonValue.EMPTY_JSON_ARRAY : content);
+        if (isError == null) isError = Boolean.FALSE;
         MetaValidator.requireValid(_meta);
     }
 


### PR DESCRIPTION
## Summary
- represent the `isError` flag in ToolResult as an optional Boolean

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0b7dd914832486d2fe67e57fb5a8