### PR TITLE
Fix resources to match spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -603,7 +603,8 @@ public final class McpServer implements AutoCloseable {
             return JsonRpcError.of(req.id(), -32002, "Resource not found",
                     Json.createObjectBuilder().add("uri", uri).build());
         }
-        if (!allowed(block.annotations())) {
+        Resource resMeta = resources.get(uri);
+        if (!allowed(resMeta != null ? resMeta.annotations() : null)) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         ReadResourceResult result = new ReadResourceResult(List.of(block));
@@ -664,7 +665,8 @@ public final class McpServer implements AutoCloseable {
             return JsonRpcError.of(req.id(), -32002, "Resource not found",
                     Json.createObjectBuilder().add("uri", uri).build());
         }
-        if (!allowed(existing.annotations())) {
+        Resource resMeta = resources.get(uri);
+        if (!allowed(resMeta != null ? resMeta.annotations() : null)) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         try {
@@ -993,7 +995,7 @@ public final class McpServer implements AutoCloseable {
 
     private static ResourceProvider createDefaultResources() {
         Resource r = new Resource("test://example", "example", null, null, "text/plain", 5L, null, null);
-        ResourceBlock.Text block = new ResourceBlock.Text("test://example", "text/plain", "hello", null, null);
+        ResourceBlock.Text block = new ResourceBlock.Text("test://example", "text/plain", "hello", null);
         ResourceTemplate t = new ResourceTemplate("test://template", "example_template", null, null, "text/plain", null, null);
         return new InMemoryResourceProvider(List.of(r), Map.of(r.uri(), block), List.of(t));
     }

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -43,6 +43,14 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     @Override
+    public Resource get(String uri) {
+        for (Resource r : resources) {
+            if (r.uri().equals(uri)) return r;
+        }
+        return null;
+    }
+
+    @Override
     public ResourceListSubscription subscribeList(ResourceListListener listener) {
         var sub = listChangeSupport.subscribe(listener);
         return sub::close;

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceBlock.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceBlock.java
@@ -1,6 +1,5 @@
 package com.amannmalik.mcp.server.resources;
 
-import com.amannmalik.mcp.annotations.Annotations;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriValidator;
@@ -11,11 +10,9 @@ public sealed interface ResourceBlock permits ResourceBlock.Text, ResourceBlock.
 
     String mimeType();
 
-    Annotations annotations();
-
     JsonObject _meta();
 
-    record Text(String uri, String mimeType, String text, Annotations annotations, JsonObject _meta) implements ResourceBlock {
+    record Text(String uri, String mimeType, String text, JsonObject _meta) implements ResourceBlock {
         public Text {
             uri = UriValidator.requireAbsolute(uri);
             mimeType = InputSanitizer.cleanNullable(mimeType);
@@ -24,7 +21,7 @@ public sealed interface ResourceBlock permits ResourceBlock.Text, ResourceBlock.
         }
     }
 
-    record Binary(String uri, String mimeType, byte[] blob, Annotations annotations, JsonObject _meta) implements ResourceBlock {
+    record Binary(String uri, String mimeType, byte[] blob, JsonObject _meta) implements ResourceBlock {
         public Binary {
             uri = UriValidator.requireAbsolute(uri);
             mimeType = InputSanitizer.cleanNullable(mimeType);

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -7,6 +7,10 @@ public interface ResourceProvider extends AutoCloseable {
 
     ResourceBlock read(String uri);
 
+    default Resource get(String uri) {
+        return null;
+    }
+
     Pagination.Page<ResourceTemplate> listTemplates(String cursor);
 
     ResourceSubscription subscribe(String uri, ResourceListener listener);

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -73,7 +73,6 @@ public final class ResourcesCodec {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("uri", block.uri());
         if (block.mimeType() != null) b.add("mimeType", block.mimeType());
-        if (block.annotations() != null) b.add("annotations", AnnotationsCodec.toJsonObject(block.annotations()));
         if (block._meta() != null) b.add("_meta", block._meta());
         switch (block) {
             case ResourceBlock.Text t -> b.add("text", t.text());
@@ -88,7 +87,6 @@ public final class ResourcesCodec {
         if (uri == null) throw new IllegalArgumentException("uri required");
         String mime = obj.getString("mimeType", null);
         JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
-        Annotations ann = obj.containsKey("annotations") ? AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations")) : null;
 
         boolean hasText = obj.containsKey("text");
         boolean hasBlob = obj.containsKey("blob");
@@ -97,17 +95,17 @@ public final class ResourcesCodec {
         }
 
         for (String key : obj.keySet()) {
-            if (!Set.of("uri", "mimeType", "_meta", "annotations", "text", "blob").contains(key)) {
+            if (!Set.of("uri", "mimeType", "_meta", "text", "blob").contains(key)) {
                 throw new IllegalArgumentException("unexpected field: " + key);
             }
         }
 
         if (hasText) {
-            return new ResourceBlock.Text(uri, mime, obj.getString("text"), ann, meta);
+            return new ResourceBlock.Text(uri, mime, obj.getString("text"), meta);
         }
 
         byte[] data = Base64Util.decode(obj.getString("blob"));
-        return new ResourceBlock.Binary(uri, mime, data, ann, meta);
+        return new ResourceBlock.Binary(uri, mime, data, meta);
     }
 
 


### PR DESCRIPTION
## Summary
- remove annotations from `ResourceBlock` per spec
- adapt codec and server logic
- allow looking up resource metadata

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0b7dd914832486d2fe67e57fb5a8