### PR TITLE
Align roots result naming with spec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/ListRootsResult.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/ListRootsResult.java
@@ -2,8 +2,8 @@ package com.amannmalik.mcp.client.roots;
 
 import java.util.List;
 
-public record ListRootsResponse(List<Root> roots) {
-    public ListRootsResponse {
+public record ListRootsResult(List<Root> roots) {
+    public ListRootsResult {
         roots = roots == null || roots.isEmpty() ? List.of() : List.copyOf(roots);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -26,8 +26,8 @@ public final class RootsCodec {
         return new ListRootsRequest();
     }
 
-    public static JsonObject toJsonObject(ListRootsResponse resp) {
-        return toJsonObject(resp.roots());
+    public static JsonObject toJsonObject(ListRootsResult result) {
+        return toJsonObject(result.roots());
     }
 
     public static JsonObject toJsonObject(RootsListChangedNotification n) {


### PR DESCRIPTION
## Summary
- rename `ListRootsResponse` record to `ListRootsResult`
- adjust `RootsCodec` for the new type

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0b62d4848324b23973392ca3e430