### PR TITLE
Fix response validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -59,6 +59,9 @@ public final class JsonRpcCodec {
         var method = obj.getString("method", null);
         var hasError = obj.containsKey("error");
         var hasResult = obj.containsKey("result");
+        if (hasError && hasResult) {
+            throw new IllegalArgumentException("response cannot contain both result and error");
+        }
 
         if (method != null && idValue != null && idValue.getValueType() != JsonValue.ValueType.NULL) {
             return new JsonRpcRequest(toId(idValue), method, obj.getJsonObject("params"));


### PR DESCRIPTION
## Summary
- validate that JSON-RPC response objects do not contain both `result` and `error`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0f85a45c83249859816517997d42