### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -46,6 +46,7 @@ public final class JsonRpcCodec {
         switch (id) {
             case RequestId.StringId s -> builder.add("id", s.value());
             case RequestId.NumericId n -> builder.add("id", n.value());
+            case RequestId.NullId ignored -> builder.add("id", JsonValue.NULL);
         }
     }
 
@@ -73,8 +74,11 @@ public final class JsonRpcCodec {
             return new JsonRpcResponse(toId(idValue), obj.getJsonObject("result"));
         }
         if (hasError) {
+            RequestId id;
             if (idValue == null || idValue.getValueType() == JsonValue.ValueType.NULL) {
-                throw new IllegalArgumentException("id is required for error");
+                id = new RequestId.NullId();
+            } else {
+                id = toId(idValue);
             }
             var errObj = obj.getJsonObject("error");
             var detail = new JsonRpcError.ErrorDetail(
@@ -82,7 +86,7 @@ public final class JsonRpcCodec {
                     errObj.getString("message"),
                     errObj.get("data")
             );
-            return new JsonRpcError(toId(idValue), detail);
+            return new JsonRpcError(id, detail);
         }
         throw new IllegalArgumentException("Unknown message type");
     }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.jsonrpc;
 
-public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId {
+public sealed interface RequestId permits RequestId.StringId, RequestId.NumericId, RequestId.NullId {
 
     static RequestId parse(String raw) {
         if (raw == null) throw new IllegalArgumentException("raw required");
@@ -26,6 +26,14 @@ public sealed interface RequestId permits RequestId.StringId, RequestId.NumericI
         @Override
         public String toString() {
             return Long.toString(value);
+        }
+    }
+
+    /** Represents a missing ID for error responses. */
+    final class NullId implements RequestId {
+        @Override
+        public String toString() {
+            return "null";
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -298,6 +298,11 @@ public final class McpServer implements AutoCloseable {
             } catch (JsonParsingException e) {
                 System.err.println("Parse error: " + e.getMessage());
                 sendLog(LoggingLevel.ERROR, "parser", Json.createValue(e.getMessage()));
+                try {
+                    send(JsonRpcError.of(new RequestId.NullId(), JsonRpcErrorCode.PARSE_ERROR, e.getMessage()));
+                } catch (IOException ioe) {
+                    System.err.println("Failed to send error: " + ioe.getMessage());
+                }
                 continue;
             }
 
@@ -320,6 +325,11 @@ public final class McpServer implements AutoCloseable {
             } catch (IllegalArgumentException e) {
                 System.err.println("Invalid request: " + e.getMessage());
                 sendLog(LoggingLevel.WARNING, "server", Json.createValue(e.getMessage()));
+                try {
+                    send(JsonRpcError.of(new RequestId.NullId(), JsonRpcErrorCode.INVALID_REQUEST, e.getMessage()));
+                } catch (IOException ioe) {
+                    System.err.println("Failed to send error: " + ioe.getMessage());
+                }
             } catch (IOException e) {
                 System.err.println("Error processing message: " + e.getMessage());
                 sendLog(LoggingLevel.ERROR, "server", Json.createValue(e.getMessage()));


### PR DESCRIPTION
## Summary
- add `RequestId.NullId` sentinel for missing JSON-RPC ids
- emit PARSE_ERROR and INVALID_REQUEST responses as required
- allow JsonRpcCodec to handle `null` ids

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0f85a45c83249859816517997d42