### PR TITLE
Refactor protocol version constants

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -30,10 +30,10 @@ import com.amannmalik.mcp.lifecycle.ClientInfo;
 import com.amannmalik.mcp.lifecycle.InitializeRequest;
 import com.amannmalik.mcp.lifecycle.InitializeResponse;
 import com.amannmalik.mcp.lifecycle.LifecycleCodec;
-import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.lifecycle.ServerFeatures;
 import com.amannmalik.mcp.lifecycle.UnsupportedProtocolVersionException;
+import com.amannmalik.mcp.lifecycle.Protocol;
 import com.amannmalik.mcp.ping.PingCodec;
 import com.amannmalik.mcp.ping.PingMonitor;
 import com.amannmalik.mcp.ping.PingResponse;
@@ -190,7 +190,7 @@ public final class McpClient implements AutoCloseable {
     public synchronized void connect() throws IOException {
         if (connected) return;
         InitializeRequest init = new InitializeRequest(
-                ProtocolLifecycle.SUPPORTED_VERSION,
+                Protocol.LATEST_VERSION,
                 new Capabilities(capabilities, Set.of(), Map.of(), Map.of()),
                 info,
                 new ClientFeatures(rootsListChangedSupported)
@@ -240,12 +240,12 @@ public final class McpClient implements AutoCloseable {
         }
         if (msg instanceof JsonRpcResponse resp) {
             InitializeResponse ir = LifecycleCodec.toInitializeResponse(resp.result());
-            if (!ProtocolLifecycle.SUPPORTED_VERSION.equals(ir.protocolVersion())) {
+            if (!Protocol.LATEST_VERSION.equals(ir.protocolVersion())) {
                 try {
                     transport.close();
                 } catch (IOException ignore) {
                 }
-                throw new UnsupportedProtocolVersionException(ir.protocolVersion(), ProtocolLifecycle.SUPPORTED_VERSION);
+                throw new UnsupportedProtocolVersionException(ir.protocolVersion(), Protocol.LATEST_VERSION);
             }
             if (transport instanceof StreamableHttpClientTransport http) {
                 http.setProtocolVersion(ir.protocolVersion());

--- a/src/main/java/com/amannmalik/mcp/lifecycle/Protocol.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/Protocol.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.lifecycle;
+
+/**
+ * Constants for protocol version negotiation.
+ */
+public final class Protocol {
+    private Protocol() {
+    }
+
+    /** Latest protocol revision supported by this implementation. */
+    public static final String LATEST_VERSION = "2025-06-18";
+
+    /** Previous revision used for backwards compatibility. */
+    public static final String PREVIOUS_VERSION = "2025-03-26";
+}
+

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -6,17 +6,11 @@ import java.util.Set;
 
 
 public class ProtocolLifecycle {
-    public static final String SUPPORTED_VERSION = "2025-06-18";
-    /**
-     * The most recent prior revision that implementations should fall back to
-     * when no protocol version is negotiated.
-     */
-    public static final String PREVIOUS_VERSION = "2025-03-26";
 
     private final Set<ServerCapability> serverCapabilities;
     private final ServerInfo serverInfo;
     private final String instructions;
-    private String protocolVersion = SUPPORTED_VERSION;
+    private String protocolVersion = Protocol.LATEST_VERSION;
     private LifecycleState state = LifecycleState.INIT;
     private Set<ClientCapability> clientCapabilities = Set.of();
     private ClientFeatures clientFeatures = ClientFeatures.EMPTY;
@@ -35,10 +29,10 @@ public class ProtocolLifecycle {
                 : EnumSet.copyOf(requested);
         clientFeatures = request.features() == null ? ClientFeatures.EMPTY : request.features();
 
-        if (request.protocolVersion() != null && request.protocolVersion().equals(SUPPORTED_VERSION)) {
+        if (request.protocolVersion() != null && request.protocolVersion().equals(Protocol.LATEST_VERSION)) {
             protocolVersion = request.protocolVersion();
         } else {
-            protocolVersion = SUPPORTED_VERSION;
+            protocolVersion = Protocol.LATEST_VERSION;
         }
 
         return new InitializeResponse(

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -1,6 +1,6 @@
 package com.amannmalik.mcp.transport;
 
-import com.amannmalik.mcp.lifecycle.ProtocolLifecycle;
+import com.amannmalik.mcp.lifecycle.Protocol;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
@@ -27,7 +27,7 @@ public final class StreamableHttpClientTransport implements Transport {
     private final BlockingQueue<JsonObject> incoming = new LinkedBlockingQueue<>();
     private final Set<SseReader> streams = ConcurrentHashMap.newKeySet();
     private volatile String sessionId;
-    private volatile String protocolVersion = ProtocolLifecycle.SUPPORTED_VERSION;
+    private volatile String protocolVersion = Protocol.LATEST_VERSION;
 
     public StreamableHttpClientTransport(URI endpoint) {
         this.endpoint = endpoint;

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.security.SecureRandom;
 import com.amannmalik.mcp.util.Base64Util;
+import com.amannmalik.mcp.lifecycle.Protocol;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Set;
@@ -54,7 +55,7 @@ public final class StreamableHttpTransport implements Transport {
     // Default to the previous protocol revision when the version header is
     // absent, as recommended for backwards compatibility.
     private static final String COMPATIBILITY_VERSION =
-            com.amannmalik.mcp.lifecycle.ProtocolLifecycle.PREVIOUS_VERSION;
+            Protocol.PREVIOUS_VERSION;
     private final BlockingQueue<JsonObject> incoming = new LinkedBlockingQueue<>();
     private final Set<SseClient> generalClients = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String, SseClient> requestStreams = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Summary
- centralize protocol version strings in new `Protocol` class
- update client and transports to use `Protocol` constants
- simplify lifecycle initialization logic

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0f7405b8832498e0336c8f79cbda