### PR TITLE
Refactor request dispatch

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -502,14 +502,18 @@ public final class McpClient implements AutoCloseable {
         boolean cancelled;
         JsonRpcMessage resp;
         try {
-            RequestHandler handler = RequestMethod.from(req.method())
-                    .map(requestHandlers::get)
-                    .orElse(null);
-            if (handler == null) {
+            var method = RequestMethod.from(req.method());
+            if (method.isEmpty()) {
                 resp = JsonRpcError.of(req.id(), JsonRpcErrorCode.METHOD_NOT_FOUND,
                         "Unknown method: " + req.method());
             } else {
-                resp = handler.handle(req);
+                RequestHandler handler = requestHandlers.get(method.get());
+                if (handler == null) {
+                    resp = JsonRpcError.of(req.id(), JsonRpcErrorCode.METHOD_NOT_FOUND,
+                            "Unknown method: " + req.method());
+                } else {
+                    resp = handler.handle(req);
+                }
             }
         } finally {
             cancelled = cancellationTracker.isCancelled(req.id());

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -341,9 +341,14 @@ public final class McpServer implements AutoCloseable {
                     null));
             return;
         }
-        var handler = RequestMethod.from(req.method())
-                .map(requestHandlers::get)
-                .orElse(null);
+        var method = RequestMethod.from(req.method());
+        if (method.isEmpty()) {
+            send(JsonRpcError.of(req.id(),
+                    JsonRpcErrorCode.METHOD_NOT_FOUND,
+                    "Unknown method: " + req.method()));
+            return;
+        }
+        RequestHandler handler = requestHandlers.get(method.get());
         if (handler == null) {
             send(JsonRpcError.of(req.id(),
                     JsonRpcErrorCode.METHOD_NOT_FOUND,

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -65,7 +65,7 @@ public final class StreamableHttpClientTransport implements Transport {
         int status = response.statusCode();
         String ct = response.headers().firstValue("Content-Type").orElse("");
         if (status == 401) {
-            String header = response.headers().firstValue("WWW-Authenticate").orElse(null);
+            String header = response.headers().firstValue("WWW-Authenticate").orElse("");
             response.body().close();
             throw new UnauthorizedException(header);
         }


### PR DESCRIPTION
## Summary
- avoid returning `null` when dispatching requests
- propagate any `WWW-Authenticate` header for HTTP 401 responses

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a0f7405b8832498e0336c8f79cbda