### PR TITLE
Fix resource link encoding

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -107,6 +107,7 @@ public final class PromptCodec {
             }
             case PromptContent.ResourceLink l -> {
                 JsonObject obj = ResourcesCodec.toJsonObject(l.resource());
+                b.add("type", "resource_link");
                 obj.forEach((k, v) -> {
                     if (!"_meta".equals(k)) b.add(k, v);
                 });


### PR DESCRIPTION
## Summary
- include `type: resource_link` when encoding resource links

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688a1334100483249a89bce95a91b85e