### PR TITLE
Implement HTTP Authorization support

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -326,7 +326,7 @@ public final class McpClient implements AutoCloseable {
     public void setLogLevel(LoggingLevel level) throws IOException {
         if (level == null) throw new IllegalArgumentException("level required");
         JsonRpcMessage msg = request(RequestMethod.LOGGING_SET_LEVEL,
-                LoggingCodec.toJsonObject(new SetLevelRequest(level))); 
+                LoggingCodec.toJsonObject(new SetLevelRequest(level)));
         if (msg instanceof JsonRpcResponse) {
             return;
         }
@@ -334,6 +334,22 @@ public final class McpClient implements AutoCloseable {
             throw new IOException(err.error().message());
         }
         throw new IOException("Unexpected message type: " + msg.getClass().getSimpleName());
+    }
+
+    public void setAccessToken(String token) {
+        if (!(transport instanceof StreamableHttpClientTransport http)) {
+            throw new IllegalStateException("HTTP transport required");
+        }
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("token required");
+        }
+        http.setAuthorization(token);
+    }
+
+    public void clearAccessToken() {
+        if (transport instanceof StreamableHttpClientTransport http) {
+            http.clearAuthorization();
+        }
     }
 
     public JsonRpcMessage request(String method, JsonObject params) throws IOException {

--- a/src/main/java/com/amannmalik/mcp/transport/TransportHeaders.java
+++ b/src/main/java/com/amannmalik/mcp/transport/TransportHeaders.java
@@ -6,5 +6,6 @@ public final class TransportHeaders {
 
     public static final String PROTOCOL_VERSION = "MCP-Protocol-Version";
     public static final String SESSION_ID = "Mcp-Session-Id";
+    public static final String AUTHORIZATION = "Authorization";
 }
 


### PR DESCRIPTION
## Summary
- allow StreamableHttpClientTransport to set Authorization header
- expose token APIs on McpClient
- add Authorization header constant

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a12a51afc8324aac64268740579ac