### PR TITLE
Fix JSON-RPC response validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -27,7 +27,7 @@ public final class JsonRpcCodec {
             }
             case JsonRpcResponse r -> {
                 addId(builder, r.id());
-                builder.add("result", r.result() != null ? r.result() : JsonValue.NULL);
+                builder.add("result", r.result());
             }
             case JsonRpcError e -> {
                 addId(builder, e.id());
@@ -74,7 +74,11 @@ public final class JsonRpcCodec {
             if (idValue == null || idValue.getValueType() == JsonValue.ValueType.NULL) {
                 throw new IllegalArgumentException("id is required for response");
             }
-            return new JsonRpcResponse(toId(idValue), obj.getJsonObject("result"));
+            var resultVal = obj.get("result");
+            if (resultVal == null || resultVal.getValueType() != JsonValue.ValueType.OBJECT) {
+                throw new IllegalArgumentException("result must be an object");
+            }
+            return new JsonRpcResponse(toId(idValue), resultVal.asJsonObject());
         }
         if (hasError) {
             RequestId id;

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcResponse.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcResponse.java
@@ -7,6 +7,9 @@ public record JsonRpcResponse(RequestId id, JsonObject result) implements JsonRp
         if (id == null) {
             throw new IllegalArgumentException("id is required");
         }
+        if (result == null) {
+            throw new IllegalArgumentException("result is required");
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- enforce that `JsonRpcResponse` always carries a non-null result object
- validate decoded responses to ensure `result` is a JSON object

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a1591031083249e9cb1d152aaa308