### PR TITLE
Add protocol version compatibility

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -225,15 +225,18 @@ public final class McpClient implements AutoCloseable {
         }
         if (msg instanceof JsonRpcResponse resp) {
             InitializeResponse ir = LifecycleCodec.toInitializeResponse(resp.result());
-            if (!Protocol.LATEST_VERSION.equals(ir.protocolVersion())) {
+            String serverVersion = ir.protocolVersion();
+            if (!Protocol.LATEST_VERSION.equals(serverVersion) &&
+                    !Protocol.PREVIOUS_VERSION.equals(serverVersion)) {
                 try {
                     transport.close();
                 } catch (IOException ignore) {
                 }
-                throw new UnsupportedProtocolVersionException(ir.protocolVersion(), Protocol.LATEST_VERSION);
+                throw new UnsupportedProtocolVersionException(serverVersion,
+                        Protocol.LATEST_VERSION + " or " + Protocol.PREVIOUS_VERSION);
             }
             if (transport instanceof StreamableHttpClientTransport http) {
-                http.setProtocolVersion(ir.protocolVersion());
+                http.setProtocolVersion(serverVersion);
             }
             serverCapabilities = ir.capabilities().server();
             instructions = ir.instructions();

--- a/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycle.java
@@ -29,8 +29,13 @@ public class ProtocolLifecycle {
                 : EnumSet.copyOf(requested);
         clientFeatures = request.features() == null ? ClientFeatures.EMPTY : request.features();
 
-        if (request.protocolVersion() != null && request.protocolVersion().equals(Protocol.LATEST_VERSION)) {
-            protocolVersion = request.protocolVersion();
+        if (request.protocolVersion() != null) {
+            if (request.protocolVersion().equals(Protocol.LATEST_VERSION) ||
+                    request.protocolVersion().equals(Protocol.PREVIOUS_VERSION)) {
+                protocolVersion = request.protocolVersion();
+            } else {
+                protocolVersion = Protocol.LATEST_VERSION;
+            }
         } else {
             protocolVersion = Protocol.LATEST_VERSION;
         }


### PR DESCRIPTION
## Summary
- support 2025-03-26 protocol negotiation in `ProtocolLifecycle`
- accept older version in `McpClient.connect`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a1591031083249e9cb1d152aaa308