### PR TITLE
Allow reserved _meta prefixes

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -34,9 +34,6 @@ public final class MetaValidator {
                 if (!LABEL.matcher(label).matches()) {
                     throw new IllegalArgumentException("Invalid _meta prefix: " + key);
                 }
-                if (i < labels.length - 1 && ("modelcontextprotocol".equals(label) || "mcp".equals(label))) {
-                    throw new IllegalArgumentException("Reserved _meta prefix: " + key);
-                }
             }
         }
 


### PR DESCRIPTION
## Summary
- permit `_meta` keys using prefixes reserved for MCP use

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a16dea2d0832480ee76cd3dedacc2