### PR TITLE
Add displayName helpers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
@@ -20,4 +20,8 @@ public record Prompt(
         description = InputSanitizer.cleanNullable(description);
         MetaValidator.requireValid(_meta);
     }
+
+    public String displayName() {
+        return title != null ? title : name;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
@@ -17,4 +17,8 @@ public record PromptArgument(
         description = InputSanitizer.cleanNullable(description);
         MetaValidator.requireValid(_meta);
     }
+
+    public String displayName() {
+        return title != null ? title : name;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
@@ -27,4 +27,8 @@ public record Resource(
         }
         MetaValidator.requireValid(_meta);
     }
+
+    public String displayName() {
+        return title != null ? title : name;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
@@ -23,4 +23,8 @@ public record ResourceTemplate(
         mimeType = InputSanitizer.cleanNullable(mimeType);
         MetaValidator.requireValid(_meta);
     }
+
+    public String displayName() {
+        return title != null ? title : name;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
@@ -27,4 +27,10 @@ public record Tool(String name,
         ) ? null : annotations;
         MetaValidator.requireValid(_meta);
     }
+
+    public String displayName() {
+        if (title != null) return title;
+        if (annotations != null && annotations.title() != null) return annotations.title();
+        return name;
+    }
 }


### PR DESCRIPTION
## Summary
- add `displayName` helpers to main data records
- add display name precedence logic for tools

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a16c3e8488324ac969e78d5d99b13