### PR TITLE
Fix logging codec validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
@@ -4,6 +4,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
+import com.amannmalik.mcp.util.JsonUtil;
+import java.util.Set;
 
 public final class LoggingCodec {
     private LoggingCodec() {
@@ -19,6 +21,7 @@ public final class LoggingCodec {
 
     public static LoggingMessageNotification toLoggingMessageNotification(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("object required");
+        JsonUtil.requireOnlyKeys(obj, Set.of("level", "logger", "data"));
 
         String rawLevel;
         try {
@@ -51,6 +54,7 @@ public final class LoggingCodec {
 
     public static SetLevelRequest toSetLevelRequest(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("level required");
+        JsonUtil.requireOnlyKeys(obj, Set.of("level"));
         String raw;
         try {
             raw = obj.getString("level");


### PR DESCRIPTION
## Summary
- tighten JSON field validation for logging messages

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a16dea2d0832480ee76cd3dedacc2