### PR TITLE
Fix list change notification encoding

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -7,6 +7,7 @@ import com.amannmalik.mcp.client.elicitation.ElicitResult;
 import com.amannmalik.mcp.client.elicitation.ElicitationAction;
 import com.amannmalik.mcp.client.elicitation.ElicitationProvider;
 import com.amannmalik.mcp.client.roots.RootsCodec;
+import com.amannmalik.mcp.client.roots.RootsListChangedNotification;
 import com.amannmalik.mcp.client.roots.RootsProvider;
 import com.amannmalik.mcp.client.roots.RootsSubscription;
 import com.amannmalik.mcp.client.sampling.CreateMessageRequest;
@@ -256,7 +257,8 @@ public final class McpClient implements AutoCloseable {
             try {
                 rootsSubscription = roots.subscribe(() -> {
                     try {
-                        notify(NotificationMethod.ROOTS_LIST_CHANGED, null);
+                        notify(NotificationMethod.ROOTS_LIST_CHANGED,
+                                RootsCodec.toJsonObject(new RootsListChangedNotification()));
                     } catch (IOException ignore) {
                     }
                 });

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -74,6 +74,7 @@ import com.amannmalik.mcp.server.resources.ResourceBlock;
 import com.amannmalik.mcp.server.resources.ResourceListSubscription;
 import com.amannmalik.mcp.server.resources.ResourceProvider;
 import com.amannmalik.mcp.server.resources.ResourceSubscription;
+import com.amannmalik.mcp.server.resources.ResourceListChangedNotification;
 import com.amannmalik.mcp.server.resources.ResourceTemplate;
 import com.amannmalik.mcp.server.resources.ResourceUpdatedNotification;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
@@ -88,6 +89,7 @@ import com.amannmalik.mcp.server.tools.ToolListChangedNotification;
 import com.amannmalik.mcp.server.tools.ToolListSubscription;
 import com.amannmalik.mcp.server.tools.ToolProvider;
 import com.amannmalik.mcp.server.tools.ToolResult;
+import com.amannmalik.mcp.prompts.PromptListChangedNotification;
 import com.amannmalik.mcp.transport.Transport;
 import com.amannmalik.mcp.util.CancellationCodec;
 import com.amannmalik.mcp.util.CancellationTracker;
@@ -208,7 +210,9 @@ public final class McpServer implements AutoCloseable {
                 resourceListSubscription = resources.subscribeList(() -> {
                     if (lifecycle.state() != LifecycleState.OPERATION) return;
                     try {
-                        send(new JsonRpcNotification(NotificationMethod.RESOURCES_LIST_CHANGED.method(), null));
+                        send(new JsonRpcNotification(
+                                NotificationMethod.RESOURCES_LIST_CHANGED.method(),
+                                ResourcesCodec.toJsonObject(new ResourceListChangedNotification())));
                     } catch (IOException ignore) {
                     }
                 });
@@ -236,7 +240,9 @@ public final class McpServer implements AutoCloseable {
                 promptsSubscription = prompts.subscribe(() -> {
                     if (lifecycle.state() != LifecycleState.OPERATION) return;
                     try {
-                        send(new JsonRpcNotification(NotificationMethod.PROMPTS_LIST_CHANGED.method(), null));
+                        send(new JsonRpcNotification(
+                                NotificationMethod.PROMPTS_LIST_CHANGED.method(),
+                                PromptCodec.toJsonObject(new PromptListChangedNotification())));
                     } catch (IOException ignore) {
                     }
                 });


### PR DESCRIPTION
## Summary
- ensure roots, resources, and prompts list change notifications use their codecs

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a16dea2d0832480ee76cd3dedacc2