### PR TITLE
Add optional JWT signature verification

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -12,6 +12,7 @@ import picocli.CommandLine;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -75,7 +76,10 @@ public final class ServerCommand implements Callable<Integer> {
                 OriginValidator originValidator = new OriginValidator(Set.of("http://localhost", "http://127.0.0.1"));
                 AuthorizationManager authManager = null;
                 if (cfg.expectedAudience() != null && !cfg.expectedAudience().isBlank()) {
-                    JwtTokenValidator tokenValidator = new JwtTokenValidator(cfg.expectedAudience());
+                    String secretEnv = System.getenv("MCP_JWT_SECRET");
+                    JwtTokenValidator tokenValidator = secretEnv == null || secretEnv.isBlank()
+                            ? new JwtTokenValidator(cfg.expectedAudience())
+                            : new JwtTokenValidator(cfg.expectedAudience(), secretEnv.getBytes(StandardCharsets.UTF_8));
                     BearerTokenAuthorizationStrategy authStrategy = new BearerTokenAuthorizationStrategy(tokenValidator);
                     authManager = new AuthorizationManager(List.of(authStrategy));
                 }


### PR DESCRIPTION
## Summary
- add secret-based validation to `JwtTokenValidator`
- allow specifying secret via `MCP_JWT_SECRET` in the server command

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a1e1d8f848324bcb9117c211f0de1