### PR TITLE
Fix meta prefix validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/MetaValidator.java
@@ -34,6 +34,9 @@ public final class MetaValidator {
                 if (!LABEL.matcher(label).matches()) {
                     throw new IllegalArgumentException("Invalid _meta prefix: " + key);
                 }
+                if (i < labels.length - 1 && (label.equals("modelcontextprotocol") || label.equals("mcp"))) {
+                    throw new IllegalArgumentException("Reserved _meta prefix: " + key);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- enforce reserved prefix rule in `MetaValidator`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a1e1d8f848324bcb9117c211f0de1