### PR TITLE
Refactor resource access checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -531,6 +531,12 @@ public final class McpServer implements AutoCloseable {
         return false;
     }
 
+    private boolean canAccessResource(String uri) {
+        if (!withinRoots(uri)) return false;
+        Resource meta = resources.get(uri);
+        return allowed(meta == null ? null : meta.annotations());
+    }
+
     private JsonRpcError invalidParams(JsonRpcRequest req, String message) {
         return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, message);
     }
@@ -610,17 +616,13 @@ public final class McpServer implements AutoCloseable {
             return invalidParams(req, e);
         }
         String uri = rrr.uri();
-        if (!withinRoots(uri)) {
+        if (!canAccessResource(uri)) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         ResourceBlock block = resources.read(uri);
         if (block == null) {
             return JsonRpcError.of(req.id(), -32002, "Resource not found",
                     Json.createObjectBuilder().add("uri", uri).build());
-        }
-        Resource resMeta = resources.get(uri);
-        if (!allowed(resMeta != null ? resMeta.annotations() : null)) {
-            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         ReadResourceResult result = new ReadResourceResult(List.of(block));
         return new JsonRpcResponse(req.id(), ResourcesCodec.toJsonObject(result));
@@ -672,17 +674,13 @@ public final class McpServer implements AutoCloseable {
             return invalidParams(req, e);
         }
         String uri = sr.uri();
-        if (!withinRoots(uri)) {
+        if (!canAccessResource(uri)) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         ResourceBlock existing = resources.read(uri);
         if (existing == null) {
             return JsonRpcError.of(req.id(), -32002, "Resource not found",
                     Json.createObjectBuilder().add("uri", uri).build());
-        }
-        Resource resMeta = resources.get(uri);
-        if (!allowed(resMeta != null ? resMeta.annotations() : null)) {
-            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         try {
             ResourceSubscription sub = resources.subscribe(uri, update -> {
@@ -716,7 +714,7 @@ public final class McpServer implements AutoCloseable {
             return invalidParams(req, e);
         }
         String uri = ur.uri();
-        if (!withinRoots(uri)) {
+        if (!canAccessResource(uri)) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         ResourceSubscription sub = resourceSubscriptions.remove(uri);


### PR DESCRIPTION
## Summary
- centralize resource permission checks
- use helper in readResource/subscribeResource/unsubscribeResource

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a1e2c00148324bc0d796a41cab25c