### PR TITLE
Refactor ResourceProvider API

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -539,8 +539,10 @@ public final class McpServer implements AutoCloseable {
 
     private boolean canAccessResource(String uri) {
         if (!withinRoots(uri)) return false;
-        Resource meta = resources.get(uri);
-        return allowed(meta == null ? null : meta.annotations());
+        return resources.get(uri)
+                .map(Resource::annotations)
+                .map(this::allowed)
+                .orElse(true);
     }
 
     private JsonRpcError invalidParams(JsonRpcRequest req, String message) {

--- a/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/InMemoryResourceProvider.java
@@ -5,6 +5,7 @@ import com.amannmalik.mcp.util.Pagination;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -43,11 +44,13 @@ public final class InMemoryResourceProvider implements ResourceProvider {
     }
 
     @Override
-    public Resource get(String uri) {
+    public java.util.Optional<Resource> get(String uri) {
         for (Resource r : resources) {
-            if (r.uri().equals(uri)) return r;
+            if (r.uri().equals(uri)) {
+                return java.util.Optional.of(r);
+            }
         }
-        return null;
+        return java.util.Optional.empty();
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceProvider.java
@@ -1,14 +1,15 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.util.Pagination;
+import java.util.Optional;
 
 public interface ResourceProvider extends AutoCloseable {
     Pagination.Page<Resource> list(String cursor);
 
     ResourceBlock read(String uri);
 
-    default Resource get(String uri) {
-        return null;
+    default Optional<Resource> get(String uri) {
+        return Optional.empty();
     }
 
     Pagination.Page<ResourceTemplate> listTemplates(String cursor);


### PR DESCRIPTION
## Summary
- avoid returning null when fetching resources
- adjust `McpServer` and `InMemoryResourceProvider` to use `Optional`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a21e8d93c8324bac602b463d1326e