### PR TITLE
Fix oversight in sampling message validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/MessageContent.java
@@ -31,6 +31,7 @@ public sealed interface MessageContent permits MessageContent.Text, MessageConte
                 throw new IllegalArgumentException("data and mimeType are required");
             }
             data = data.clone();
+            mimeType = InputSanitizer.requireClean(mimeType);
             MetaValidator.requireValid(_meta);
         }
 
@@ -46,6 +47,7 @@ public sealed interface MessageContent permits MessageContent.Text, MessageConte
                 throw new IllegalArgumentException("data and mimeType are required");
             }
             data = data.clone();
+            mimeType = InputSanitizer.requireClean(mimeType);
             MetaValidator.requireValid(_meta);
         }
 


### PR DESCRIPTION
## Summary
- sanitize `mimeType` fields in sampling `MessageContent`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a21a4d1c08324ab8e068c4ad85115