### PR TITLE
Activate HTTP transport via cucumber tag

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -70,7 +70,17 @@ public final class McpConformanceSteps {
     private final List<ProgressNotification> progressEvents = new CopyOnWriteArrayList<>();
     private final List<LoggingMessageNotification> logEvents = new CopyOnWriteArrayList<>();
 
-    @Before
+    @Before("@http")
+    public void useHttpTransport() {
+        System.setProperty("mcp.test.transport", "http");
+    }
+
+    @Before("@stdio")
+    public void useStdioTransport() {
+        System.setProperty("mcp.test.transport", "stdio");
+    }
+
+    @Before(order = 1)
     public void startServer() throws Exception {
         String type = System.getProperty("mcp.test.transport", "stdio");
         Transport transport;

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -1,3 +1,4 @@
+@http
 Feature: MCP protocol conformance
 
   Scenario: Basic server interaction


### PR DESCRIPTION
## Summary
- set `@http` tag in mcp_conformance.feature
- detect transport tags in step definitions
- start server after applying tagged transport

## Testing
- `./verify.sh tests` *(fails: there were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a2620ae2c83249cd2418c60f31c16