### PR TITLE
Refine ping scheduling logic

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -274,7 +274,7 @@ public final class McpClient implements AutoCloseable {
                     disconnect();
                 } catch (IOException ignore) {
                 }
-            });
+            }, 3);
             pinger.start();
         }
     }

--- a/src/main/java/com/amannmalik/mcp/ping/PingScheduler.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingScheduler.java
@@ -7,22 +7,39 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Periodically sends ping requests and invokes a callback on failure.
+ * Periodically sends ping requests and invokes a callback when a configured
+ * number of consecutive pings fail.
  */
 public final class PingScheduler implements AutoCloseable {
     private final McpClient client;
     private final long interval;
     private final long timeout;
     private final Runnable onFailure;
+    private final int maxFailures;
+    private int failureCount;
     private ScheduledExecutorService exec;
 
-    public PingScheduler(McpClient client, long intervalMillis, long timeoutMillis, Runnable onFailure) {
+    public PingScheduler(McpClient client,
+                         long intervalMillis,
+                         long timeoutMillis,
+                         Runnable onFailure) {
+        this(client, intervalMillis, timeoutMillis, onFailure, 1);
+    }
+
+    public PingScheduler(McpClient client,
+                         long intervalMillis,
+                         long timeoutMillis,
+                         Runnable onFailure,
+                         int maxFailures) {
         if (client == null || onFailure == null) throw new IllegalArgumentException("client and onFailure required");
         if (intervalMillis <= 0 || timeoutMillis <= 0) throw new IllegalArgumentException("invalid timing");
+        if (maxFailures <= 0) throw new IllegalArgumentException("maxFailures must be > 0");
         this.client = client;
         this.interval = intervalMillis;
         this.timeout = timeoutMillis;
         this.onFailure = onFailure;
+        this.maxFailures = maxFailures;
+        this.failureCount = 0;
     }
 
     public synchronized void start() {
@@ -32,11 +49,19 @@ public final class PingScheduler implements AutoCloseable {
     }
 
     private void check() {
-        if (!PingMonitor.isAlive(client, timeout)) {
+        if (PingMonitor.isAlive(client, timeout)) {
+            failureCount = 0;
+            return;
+        }
+
+        failureCount++;
+        if (failureCount >= maxFailures) {
             if (System.err != null) System.err.println("Ping failed");
             try {
                 onFailure.run();
             } catch (Exception ignore) {
+            } finally {
+                failureCount = 0;
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow configuring failure threshold for ping monitoring
- adjust client to wait for three consecutive failures

## Testing
- `gradle check` *(fails: 11 tests, 11 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a26e27b308324bf87ee2cbe4c9fd6