### PR TITLE
Centralize ASCII validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -10,6 +10,7 @@ import com.amannmalik.mcp.jsonrpc.RequestId;
 import com.amannmalik.mcp.lifecycle.Protocol;
 import com.amannmalik.mcp.security.OriginValidator;
 import com.amannmalik.mcp.util.Base64Util;
+import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.wire.RequestMethod;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -244,12 +245,12 @@ public final class StreamableHttpTransport implements Transport {
             String session = sessionId.get();
             String last = lastSessionId.get();
             String header = req.getHeader(TransportHeaders.SESSION_ID);
-            if (header != null && !isVisibleAscii(header)) {
+            if (header != null && !InputSanitizer.isVisibleAscii(header)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
             String version = req.getHeader(PROTOCOL_HEADER);
-            if (version != null && !isVisibleAscii(version)) {
+            if (version != null && !InputSanitizer.isVisibleAscii(version)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -433,12 +434,12 @@ public final class StreamableHttpTransport implements Transport {
             String session = sessionId.get();
             String last = lastSessionId.get();
             String header = req.getHeader(TransportHeaders.SESSION_ID);
-            if (header != null && !isVisibleAscii(header)) {
+            if (header != null && !InputSanitizer.isVisibleAscii(header)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
             String version = req.getHeader(PROTOCOL_HEADER);
-            if (version != null && !isVisibleAscii(version)) {
+            if (version != null && !InputSanitizer.isVisibleAscii(version)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -560,12 +561,12 @@ public final class StreamableHttpTransport implements Transport {
             }
             String session = sessionId.get();
             String header = req.getHeader(TransportHeaders.SESSION_ID);
-            if (header != null && !isVisibleAscii(header)) {
+            if (header != null && !InputSanitizer.isVisibleAscii(header)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
             String version = req.getHeader(PROTOCOL_HEADER);
-            if (version != null && !isVisibleAscii(version)) {
+            if (version != null && !InputSanitizer.isVisibleAscii(version)) {
                 resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 return;
             }
@@ -697,11 +698,4 @@ public final class StreamableHttpTransport implements Transport {
     private record SseEvent(long id, JsonObject msg) {
     }
 
-    private static boolean isVisibleAscii(String value) {
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            if (c < 0x21 || c > 0x7E) return false;
-        }
-        return true;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/validation/InputSanitizer.java
+++ b/src/main/java/com/amannmalik/mcp/validation/InputSanitizer.java
@@ -7,6 +7,15 @@ public final class InputSanitizer {
     private InputSanitizer() {
     }
 
+    public static boolean isVisibleAscii(String value) {
+        if (value == null) return false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 0x21 || c > 0x7E) return false;
+        }
+        return true;
+    }
+
     public static String requireClean(String value) {
         if (value == null) throw new IllegalArgumentException("value is required");
         for (int i = 0; i < value.length(); i++) {


### PR DESCRIPTION
## Summary
- add InputSanitizer.isVisibleAscii helper
- reuse helper from StreamableHttpTransport

## Testing
- `./verify.sh` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a2868c7288324b30ebf24e1c48037