### PR TITLE
Refactor annotations handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/annotations/Annotations.java
+++ b/src/main/java/com/amannmalik/mcp/annotations/Annotations.java
@@ -7,6 +7,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 public record Annotations(Set<Role> audience, Double priority, Instant lastModified) {
+    public static final Annotations EMPTY = new Annotations(Set.of(), null, null);
+
     public Annotations {
         audience = audience == null || audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience);
         if (priority != null && (priority < 0.0 || priority > 1.0)) {

--- a/src/main/java/com/amannmalik/mcp/annotations/AnnotationsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/annotations/AnnotationsCodec.java
@@ -29,7 +29,7 @@ public final class AnnotationsCodec {
     }
 
     public static Annotations toAnnotations(JsonObject obj) {
-        if (obj == null) return null;
+        if (obj == null) return Annotations.EMPTY;
         Set<Role> audience = EnumSet.noneOf(Role.class);
         var arr = obj.getJsonArray("audience");
         if (arr != null) {
@@ -45,6 +45,10 @@ public final class AnnotationsCodec {
                 throw new IllegalArgumentException("Invalid lastModified", e);
             }
         }
-        return new Annotations(audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience), priority, lastModified);
+        Annotations ann = new Annotations(audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience), priority, lastModified);
+        if (ann.audience().isEmpty() && ann.priority() == null && ann.lastModified() == null) {
+            return Annotations.EMPTY;
+        }
+        return ann;
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/sampling/SamplingCodec.java
@@ -102,7 +102,9 @@ public final class SamplingCodec {
 
     static JsonObject toJsonObject(MessageContent content) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("type", content.type());
-        if (content.annotations() != null) b.add("annotations", AnnotationsCodec.toJsonObject(content.annotations()));
+        if (content.annotations() != Annotations.EMPTY) {
+            b.add("annotations", AnnotationsCodec.toJsonObject(content.annotations()));
+        }
         if (content._meta() != null) b.add("_meta", content._meta());
         switch (content) {
             case MessageContent.Text t -> b.add("text", t.text());

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.prompts;
 
+import com.amannmalik.mcp.annotations.Annotations;
 import com.amannmalik.mcp.annotations.AnnotationsCodec;
 import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.util.Base64Util;
@@ -80,7 +81,7 @@ public final class PromptCodec {
 
     static JsonObject toJsonObject(PromptContent content) {
         JsonObjectBuilder b = Json.createObjectBuilder().add("type", content.type());
-        if (content.annotations() != null) {
+        if (content.annotations() != Annotations.EMPTY) {
             b.add("annotations", AnnotationsCodec.toJsonObject(content.annotations()));
         }
         switch (content) {
@@ -101,7 +102,7 @@ public final class PromptCodec {
             case PromptContent.EmbeddedResource r -> {
                 if (content._meta() != null) b.add("_meta", content._meta());
                 b.add("resource", ResourcesCodec.toJsonObject(r.resource()));
-                if (r.annotations() != null) {
+                if (r.annotations() != Annotations.EMPTY) {
                     b.add("annotations", AnnotationsCodec.toJsonObject(r.annotations()));
                 }
             }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.annotations.Annotations;
 import com.amannmalik.mcp.annotations.AnnotationsCodec;
 import com.amannmalik.mcp.util.Base64Util;
 import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
@@ -26,7 +27,9 @@ public final class ResourcesCodec {
         if (r.description() != null) b.add("description", r.description());
         if (r.mimeType() != null) b.add("mimeType", r.mimeType());
         if (r.size() != null) b.add("size", r.size());
-        if (r.annotations() != null) b.add("annotations", AnnotationsCodec.toJsonObject(r.annotations()));
+        if (r.annotations() != Annotations.EMPTY) {
+            b.add("annotations", AnnotationsCodec.toJsonObject(r.annotations()));
+        }
         if (r._meta() != null) b.add("_meta", r._meta());
         return b.build();
     }
@@ -39,7 +42,7 @@ public final class ResourcesCodec {
                 obj.getString("description", null),
                 obj.getString("mimeType", null),
                 obj.containsKey("size") ? obj.getJsonNumber("size").longValue() : null,
-                obj.containsKey("annotations") ? AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations")) : null,
+                obj.containsKey("annotations") ? AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations")) : Annotations.EMPTY,
                 obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null
         );
     }
@@ -51,7 +54,9 @@ public final class ResourcesCodec {
         if (t.title() != null) b.add("title", t.title());
         if (t.description() != null) b.add("description", t.description());
         if (t.mimeType() != null) b.add("mimeType", t.mimeType());
-        if (t.annotations() != null) b.add("annotations", AnnotationsCodec.toJsonObject(t.annotations()));
+        if (t.annotations() != Annotations.EMPTY) {
+            b.add("annotations", AnnotationsCodec.toJsonObject(t.annotations()));
+        }
         if (t._meta() != null) b.add("_meta", t._meta());
         return b.build();
     }
@@ -63,7 +68,7 @@ public final class ResourcesCodec {
                 obj.getString("title", null),
                 obj.getString("description", null),
                 obj.getString("mimeType", null),
-                obj.containsKey("annotations") ? AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations")) : null,
+                obj.containsKey("annotations") ? AnnotationsCodec.toAnnotations(obj.getJsonObject("annotations")) : Annotations.EMPTY,
                 obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null
         );
     }


### PR DESCRIPTION
## Summary
- add `Annotations.EMPTY` constant
- ensure codecs avoid `null` annotations
- only emit annotations in JSON when not empty

## Testing
- `./verify.sh` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a2868c7288324b30ebf24e1c48037