### PR TITLE
Fix server HTTP port validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -11,8 +11,8 @@ public record ServerConfig(
         List<String> authorizationServers) implements CliConfig {
     public ServerConfig {
         if (transport == null) throw new IllegalArgumentException("transport");
-        if (transport == TransportType.HTTP && port <= 0) {
-            throw new IllegalArgumentException("port required for HTTP");
+        if (transport == TransportType.HTTP && port < 0) {
+            throw new IllegalArgumentException("port must be non-negative for HTTP");
         }
 
         if (resourceMetadataUrl != null && !resourceMetadataUrl.isBlank()) {


### PR DESCRIPTION
## Summary
- allow port 0 for HTTP so tests can bind to ephemeral ports

## Testing
- `./verify.sh` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b7f3f2c832484083c40302e175c