### PR TITLE
Ensure OAuth metadata endpoint is valid

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -66,6 +66,9 @@ public final class ServerCommand implements Callable<Integer> {
             TransportType type = httpPort == null ? TransportType.STDIO : TransportType.HTTP;
             int port = httpPort == null ? 0 : httpPort;
             if (stdio) type = TransportType.STDIO;
+            if (authServers == null || authServers.isEmpty()) {
+                throw new IllegalArgumentException("--auth-server is required");
+            }
             cfg = new ServerConfig(type, port, null, expectedAudience, resourceMetadataUrl, authServers);
         }
 

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -102,9 +102,10 @@ public final class StreamableHttpTransport implements Transport {
         } else {
             this.canonicalResource = "http://127.0.0.1:" + this.port;
         }
-        this.authorizationServers = authorizationServers == null || authorizationServers.isEmpty()
-                ? java.util.List.of()
-                : java.util.List.copyOf(authorizationServers);
+        if (authorizationServers == null || authorizationServers.isEmpty()) {
+            throw new IllegalArgumentException("authorizationServers required");
+        }
+        this.authorizationServers = java.util.List.copyOf(authorizationServers);
         // Until initialization negotiates a version, assume the prior revision
         // as the default when no MCP-Protocol-Version header is present.
         this.protocolVersion = COMPATIBILITY_VERSION;

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -82,7 +82,8 @@ public final class McpConformanceSteps {
                 args.add(jacocoAgent);
             }
             args.addAll(List.of("-cp", System.getProperty("java.class.path"),
-                    "com.amannmalik.mcp.Main", "server", "--http", "0", "-v"));
+                    "com.amannmalik.mcp.Main", "server", "--http", "0",
+                    "--auth-server", "http://127.0.0.1/auth", "-v"));
             ProcessBuilder pb = new ProcessBuilder(args);
             serverProcess = pb.start();
             var err = new BufferedReader(new InputStreamReader(
@@ -115,7 +116,8 @@ public final class McpConformanceSteps {
                 args.add(jacocoAgent);
             }
             args.addAll(List.of("-cp", System.getProperty("java.class.path"),
-                    "com.amannmalik.mcp.Main", "server", "--stdio", "-v"));
+                    "com.amannmalik.mcp.Main", "server", "--stdio",
+                    "--auth-server", "http://127.0.0.1/auth", "-v"));
             ProcessBuilder pb = new ProcessBuilder(args);
             serverProcess = pb.start();
             long end = System.currentTimeMillis() + 500;


### PR DESCRIPTION
## Summary
- enforce passing `--auth-server` when launching the server
- reject empty authorization server lists in HTTP transport
- update tests to supply an authorization server

## Testing
- `./verify.sh` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a28897b188324a0838e2ec0e6a427