### PR TITLE
Refactor method enums

### DIFF
--- a/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
@@ -1,11 +1,8 @@
 package com.amannmalik.mcp.wire;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-public enum NotificationMethod {
+public enum NotificationMethod implements WireMethod {
     INITIALIZED("notifications/initialized"),
     CANCELLED("notifications/cancelled"),
     PROGRESS("notifications/progress"),
@@ -16,16 +13,10 @@ public enum NotificationMethod {
     MESSAGE("notifications/message"),
     ROOTS_LIST_CHANGED("notifications/roots/list_changed");
 
-    private static final Map<String, NotificationMethod> BY_METHOD;
     private final String method;
 
     NotificationMethod(String method) {
         this.method = method;
-    }
-
-    static {
-        BY_METHOD = Arrays.stream(values())
-                .collect(Collectors.toUnmodifiableMap(m -> m.method, m -> m));
     }
 
     public String method() {
@@ -33,8 +24,7 @@ public enum NotificationMethod {
     }
 
     public static Optional<NotificationMethod> from(String method) {
-        if (method == null) return Optional.empty();
-        return Optional.ofNullable(BY_METHOD.get(method));
+        return WireMethod.from(NotificationMethod.class, method);
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
@@ -1,11 +1,8 @@
 package com.amannmalik.mcp.wire;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-public enum RequestMethod {
+public enum RequestMethod implements WireMethod {
     INITIALIZE("initialize"),
     PING("ping"),
     RESOURCES_LIST("resources/list"),
@@ -23,13 +20,7 @@ public enum RequestMethod {
     ROOTS_LIST("roots/list"),
     ELICITATION_CREATE("elicitation/create");
 
-    private static final Map<String, RequestMethod> BY_METHOD;
     private final String method;
-
-    static {
-        BY_METHOD = Arrays.stream(values())
-                .collect(Collectors.toUnmodifiableMap(m -> m.method, m -> m));
-    }
 
     RequestMethod(String method) {
         this.method = method;
@@ -40,7 +31,6 @@ public enum RequestMethod {
     }
 
     public static Optional<RequestMethod> from(String method) {
-        if (method == null) return Optional.empty();
-        return Optional.ofNullable(BY_METHOD.get(method));
+        return WireMethod.from(RequestMethod.class, method);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/wire/WireMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/WireMethod.java
@@ -1,0 +1,24 @@
+package com.amannmalik.mcp.wire;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Common interface for request and notification method enums. */
+public sealed interface WireMethod permits RequestMethod, NotificationMethod {
+    String method();
+
+    /**
+     * Lookup the enum constant with the provided wire method name.
+     * @param type enum class implementing {@code WireMethod}
+     * @param method wire method string
+     * @return optional enum constant
+     */
+    static <T extends Enum<T> & WireMethod> Optional<T> from(Class<T> type, String method) {
+        if (method == null) return Optional.empty();
+        Map<String, T> byMethod = Arrays.stream(type.getEnumConstants())
+                .collect(Collectors.toUnmodifiableMap(WireMethod::method, e -> e));
+        return Optional.ofNullable(byMethod.get(method));
+    }
+}


### PR DESCRIPTION
## Summary
- add `WireMethod` sealed interface shared by `RequestMethod` and `NotificationMethod`
- use generic lookup for wire method enums

## Testing
- `./verify.sh` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b0ec178832490ea2a0872cd266e