### PR TITLE
Add resource metadata codec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/ResourceMetadata.java
+++ b/src/main/java/com/amannmalik/mcp/transport/ResourceMetadata.java
@@ -1,0 +1,16 @@
+package com.amannmalik.mcp.transport;
+
+import java.util.List;
+
+/** Metadata for OAuth protected resources as defined in RFC9728. */
+public record ResourceMetadata(String resource, List<String> authorizationServers) {
+    public ResourceMetadata {
+        if (resource == null || resource.isBlank()) {
+            throw new IllegalArgumentException("resource required");
+        }
+        if (authorizationServers == null || authorizationServers.isEmpty()) {
+            throw new IllegalArgumentException("authorizationServers required");
+        }
+        authorizationServers = List.copyOf(authorizationServers);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/ResourceMetadataCodec.java
+++ b/src/main/java/com/amannmalik/mcp/transport/ResourceMetadataCodec.java
@@ -1,0 +1,36 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ResourceMetadataCodec {
+    private ResourceMetadataCodec() {
+    }
+
+    public static JsonObject toJsonObject(ResourceMetadata meta) {
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        meta.authorizationServers().forEach(arr::add);
+        return Json.createObjectBuilder()
+                .add("resource", meta.resource())
+                .add("authorization_servers", arr.build())
+                .build();
+    }
+
+    public static ResourceMetadata fromJsonObject(JsonObject obj) {
+        if (obj == null) throw new IllegalArgumentException("object required");
+        String resource = obj.getString("resource", null);
+        var arr = obj.getJsonArray("authorization_servers");
+        if (arr == null) throw new IllegalArgumentException("authorization_servers required");
+        List<String> servers = new ArrayList<>(arr.size());
+        for (JsonString js : arr.getValuesAs(JsonString.class)) {
+            servers.add(js.getString());
+        }
+        return new ResourceMetadata(resource, servers);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -12,6 +12,8 @@ import com.amannmalik.mcp.security.OriginValidator;
 import com.amannmalik.mcp.util.Base64Util;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.wire.RequestMethod;
+import com.amannmalik.mcp.transport.ResourceMetadata;
+import com.amannmalik.mcp.transport.ResourceMetadataCodec;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
@@ -612,12 +614,8 @@ public final class StreamableHttpTransport implements Transport {
     private class MetadataServlet extends HttpServlet {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-            var arr = jakarta.json.Json.createArrayBuilder();
-            for (String s : authorizationServers) arr.add(s);
-            var body = jakarta.json.Json.createObjectBuilder()
-                    .add("resource", canonicalResource)
-                    .add("authorization_servers", arr.build())
-                    .build();
+            ResourceMetadata meta = new ResourceMetadata(canonicalResource, authorizationServers);
+            JsonObject body = ResourceMetadataCodec.toJsonObject(meta);
             resp.setStatus(HttpServletResponse.SC_OK);
             resp.setContentType("application/json");
             resp.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
## Summary
- encode/decode OAuth resource metadata objects
- use the codec in StreamableHttpTransport

## Testing
- `gradle build -x test`
- `./verify.sh` *(fails: server failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b0ec178832490ea2a0872cd266e