### PR TITLE
Add _meta handling to requests and results

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/roots/ListRootsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/ListRootsRequest.java
@@ -1,4 +1,10 @@
 package com.amannmalik.mcp.client.roots;
 
-public record ListRootsRequest() {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record ListRootsRequest(JsonObject _meta) {
+    public ListRootsRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/client/roots/ListRootsResult.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/ListRootsResult.java
@@ -1,9 +1,12 @@
 package com.amannmalik.mcp.client.roots;
 
 import java.util.List;
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
 
-public record ListRootsResult(List<Root> roots) {
+public record ListRootsResult(List<Root> roots, JsonObject _meta) {
     public ListRootsResult {
         roots = roots == null || roots.isEmpty() ? List.of() : List.copyOf(roots);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
+++ b/src/main/java/com/amannmalik/mcp/client/roots/RootsCodec.java
@@ -1,11 +1,13 @@
 package com.amannmalik.mcp.client.roots;
 
 import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
+import com.amannmalik.mcp.util.JsonUtil;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
+import java.util.Set;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,18 +18,22 @@ public final class RootsCodec {
 
     public static JsonObject toJsonObject(ListRootsRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return JsonValue.EMPTY_JSON_OBJECT;
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        if (req._meta() != null) b.add("_meta", req._meta());
+        return b.build();
     }
 
     public static ListRootsRequest toListRootsRequest(JsonObject obj) {
-        if (obj != null && !obj.isEmpty()) {
-            throw new IllegalArgumentException("unexpected fields");
-        }
-        return new ListRootsRequest();
+        if (obj != null) JsonUtil.requireOnlyKeys(obj, Set.of("_meta"));
+        JsonObject meta = obj == null ? null : obj.getJsonObject("_meta");
+        return new ListRootsRequest(meta);
     }
 
     public static JsonObject toJsonObject(ListRootsResult result) {
-        return toJsonObject(result.roots());
+        JsonObjectBuilder b = Json.createObjectBuilder();
+        b.add("roots", toJsonObject(result.roots()).getJsonArray("roots"));
+        if (result._meta() != null) b.add("_meta", result._meta());
+        return b.build();
     }
 
     public static JsonObject toJsonObject(RootsListChangedNotification n) {

--- a/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingCodec.java
@@ -3,7 +3,11 @@ package com.amannmalik.mcp.ping;
 import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
 import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
 import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.util.JsonUtil;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
+import java.util.Set;
 
 public final class PingCodec {
     private PingCodec() {
@@ -11,10 +15,11 @@ public final class PingCodec {
 
     public static PingRequest toPingRequest(JsonRpcRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        if (req.params() != null && !req.params().isEmpty()) {
-            throw new IllegalArgumentException("no params expected");
-        }
-        return new PingRequest();
+        JsonObject params = req.params();
+        if (params != null) JsonUtil.requireOnlyKeys(params, Set.of("_meta"));
+        JsonObject meta = params == null ? null : params.getJsonObject("_meta");
+        MetaValidator.requireValid(meta);
+        return new PingRequest(meta);
     }
 
     public static JsonRpcResponse toResponse(RequestId id) {

--- a/src/main/java/com/amannmalik/mcp/ping/PingRequest.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingRequest.java
@@ -1,4 +1,10 @@
 package com.amannmalik.mcp.ping;
 
-public record PingRequest() {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record PingRequest(JsonObject _meta) {
+    public PingRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
@@ -1,13 +1,18 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
 import java.util.Map;
 
-public record GetPromptRequest(String name, Map<String, String> arguments) {
+public record GetPromptRequest(String name,
+                               Map<String, String> arguments,
+                               JsonObject _meta) {
     public GetPromptRequest {
         if (name == null) throw new IllegalArgumentException("name required");
         name = InputSanitizer.requireClean(name);
         arguments = InputSanitizer.requireCleanMap(arguments);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
@@ -1,4 +1,10 @@
 package com.amannmalik.mcp.prompts;
 
-public record ListPromptsRequest(String cursor) {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record ListPromptsRequest(String cursor, JsonObject _meta) {
+    public ListPromptsRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
@@ -1,9 +1,14 @@
 package com.amannmalik.mcp.prompts;
 
 import java.util.List;
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
 
-public record ListPromptsResult(List<Prompt> prompts, String nextCursor) {
+public record ListPromptsResult(List<Prompt> prompts,
+                                String nextCursor,
+                                JsonObject _meta) {
     public ListPromptsResult {
         prompts = prompts == null ? List.of() : List.copyOf(prompts);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptCodec.java
@@ -5,9 +5,11 @@ import com.amannmalik.mcp.server.resources.ResourcesCodec;
 import com.amannmalik.mcp.util.Base64Util;
 import com.amannmalik.mcp.util.EmptyJsonObjectCodec;
 import com.amannmalik.mcp.util.PaginatedRequest;
+import com.amannmalik.mcp.util.PaginatedResult;
 import com.amannmalik.mcp.util.Pagination;
 import com.amannmalik.mcp.util.PaginationCodec;
 import com.amannmalik.mcp.util.PaginationJson;
+import com.amannmalik.mcp.util.JsonUtil;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -21,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public final class PromptCodec {
     private PromptCodec() {
@@ -60,17 +63,17 @@ public final class PromptCodec {
         return obj.build();
     }
 
-    public static JsonObject toJsonObject(Pagination.Page<Prompt> page) {
-        return PaginationJson.toJson("prompts", page, PromptCodec::toJsonObject);
+    public static JsonObject toJsonObject(Pagination.Page<Prompt> page, JsonObject meta) {
+        return PaginationJson.toJson("prompts", page, PromptCodec::toJsonObject, meta);
     }
 
     public static JsonObject toJsonObject(ListPromptsRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor(), req._meta()));
     }
 
     public static JsonObject toJsonObject(ListPromptsResult page) {
-        return toJsonObject(new Pagination.Page<>(page.prompts(), page.nextCursor()));
+        return toJsonObject(new Pagination.Page<>(page.prompts(), page.nextCursor()), page._meta());
     }
 
     public static JsonObject toJsonObject(PromptListChangedNotification n) {
@@ -119,11 +122,13 @@ public final class PromptCodec {
 
     public static GetPromptRequest toGetPromptRequest(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("params required");
+        JsonUtil.requireOnlyKeys(obj, Set.of("name", "arguments", "_meta"));
         String name = obj.getString("name", null);
         if (name == null) throw new IllegalArgumentException("name required");
         JsonObject argsObj = obj.getJsonObject("arguments");
         Map<String, String> args = toArguments(argsObj);
-        return new GetPromptRequest(name, args);
+        JsonObject meta = obj.getJsonObject("_meta");
+        return new GetPromptRequest(name, args, meta);
     }
 
     public static Map<String, String> toArguments(JsonObject obj) {
@@ -194,12 +199,13 @@ public final class PromptCodec {
 
     public static ListPromptsResult toListPromptsResult(JsonObject obj) {
         Pagination.Page<Prompt> page = toPromptPage(obj);
-        return new ListPromptsResult(page.items(), page.nextCursor());
+        PaginatedResult pr = PaginationCodec.toPaginatedResult(obj);
+        return new ListPromptsResult(page.items(), page.nextCursor(), pr._meta());
     }
 
     public static ListPromptsRequest toListPromptsRequest(JsonObject obj) {
-        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
-        return new ListPromptsRequest(cursor);
+        PaginatedRequest pr = PaginationCodec.toPaginatedRequest(obj);
+        return new ListPromptsRequest(pr.cursor(), pr._meta());
     }
 
     private static PromptArgument toPromptArgument(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -135,7 +135,7 @@ public final class HostProcess implements AutoCloseable {
         McpClient client = clients.get(clientId);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, ServerCapability.TOOLS);
-        JsonObject params = PaginationCodec.toJsonObject(new PaginatedRequest(cursor));
+        JsonObject params = PaginationCodec.toJsonObject(new PaginatedRequest(cursor, null));
         JsonRpcMessage resp = client.request(RequestMethod.TOOLS_LIST, params);
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toListToolsResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -602,7 +602,7 @@ public final class McpServer implements AutoCloseable {
             }
         }
 
-        ListResourcesResult result = new ListResourcesResult(filteredResources, list.nextCursor());
+        ListResourcesResult result = new ListResourcesResult(filteredResources, list.nextCursor(), null);
         JsonObject resultJson = ResourcesCodec.toJsonObject(result);
         return new JsonRpcResponse(req.id(), resultJson);
     }
@@ -660,7 +660,7 @@ public final class McpServer implements AutoCloseable {
             }
         }
 
-        ListResourceTemplatesResult result = new ListResourceTemplatesResult(filteredTemplates, page.nextCursor());
+        ListResourceTemplatesResult result = new ListResourceTemplatesResult(filteredTemplates, page.nextCursor(), null);
         JsonObject resultJson = ResourcesCodec.toJsonObject(result);
         return new JsonRpcResponse(req.id(), resultJson);
     }
@@ -744,7 +744,7 @@ public final class McpServer implements AutoCloseable {
         } catch (IllegalArgumentException e) {
             return invalidParams(req, e);
         }
-        JsonObject result = ToolCodec.toJsonObject(page);
+        JsonObject result = ToolCodec.toJsonObject(page, null);
         return new JsonRpcResponse(req.id(), result);
     }
 
@@ -808,7 +808,7 @@ public final class McpServer implements AutoCloseable {
         } catch (IllegalArgumentException e) {
             return invalidParams(req, e);
         }
-        JsonObject result = PromptCodec.toJsonObject(page);
+        JsonObject result = PromptCodec.toJsonObject(page, null);
         return new JsonRpcResponse(req.id(), result);
     }
 

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteRequest.java
@@ -10,12 +10,14 @@ import java.util.Map;
 public record CompleteRequest(
         Ref ref,
         Argument argument,
-        Context context
+        Context context,
+        JsonObject _meta
 ) {
     public CompleteRequest {
         if (ref == null || argument == null) {
             throw new IllegalArgumentException("ref and argument are required");
         }
+        MetaValidator.requireValid(_meta);
     }
 
     public record Argument(String name, String value) {

--- a/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/LoggingCodec.java
@@ -47,14 +47,15 @@ public final class LoggingCodec {
     }
 
     public static JsonObject toJsonObject(SetLevelRequest req) {
-        return Json.createObjectBuilder()
-                .add("level", req.level().name().toLowerCase())
-                .build();
+        JsonObjectBuilder b = Json.createObjectBuilder()
+                .add("level", req.level().name().toLowerCase());
+        if (req._meta() != null) b.add("_meta", req._meta());
+        return b.build();
     }
 
     public static SetLevelRequest toSetLevelRequest(JsonObject obj) {
         if (obj == null) throw new IllegalArgumentException("level required");
-        JsonUtil.requireOnlyKeys(obj, Set.of("level"));
+        JsonUtil.requireOnlyKeys(obj, Set.of("level", "_meta"));
         String raw;
         try {
             raw = obj.getString("level");
@@ -62,6 +63,7 @@ public final class LoggingCodec {
             throw new IllegalArgumentException("level required", e);
         }
         LoggingLevel level = LoggingLevel.fromString(raw);
-        return new SetLevelRequest(level);
+        JsonObject meta = obj.getJsonObject("_meta");
+        return new SetLevelRequest(level, meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/logging/SetLevelRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/logging/SetLevelRequest.java
@@ -1,9 +1,13 @@
 package com.amannmalik.mcp.server.logging;
 
-public record SetLevelRequest(LoggingLevel level) {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record SetLevelRequest(LoggingLevel level, JsonObject _meta) {
     public SetLevelRequest {
         if (level == null) {
             throw new IllegalArgumentException("level is required");
         }
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesRequest.java
@@ -1,4 +1,10 @@
 package com.amannmalik.mcp.server.resources;
 
-public record ListResourceTemplatesRequest(String cursor) {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record ListResourceTemplatesRequest(String cursor, JsonObject _meta) {
+    public ListResourceTemplatesRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesResult.java
@@ -1,9 +1,14 @@
 package com.amannmalik.mcp.server.resources;
 
 import java.util.List;
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
 
-public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, String nextCursor) {
+public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates,
+                                          String nextCursor,
+                                          JsonObject _meta) {
     public ListResourceTemplatesResult {
         resourceTemplates = resourceTemplates == null ? List.of() : List.copyOf(resourceTemplates);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesRequest.java
@@ -1,4 +1,10 @@
 package com.amannmalik.mcp.server.resources;
 
-public record ListResourcesRequest(String cursor) {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record ListResourcesRequest(String cursor, JsonObject _meta) {
+    public ListResourcesRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesResult.java
@@ -1,10 +1,15 @@
 package com.amannmalik.mcp.server.resources;
 
 import java.util.List;
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
 
 
-public record ListResourcesResult(List<Resource> resources, String nextCursor) {
+public record ListResourcesResult(List<Resource> resources,
+                                  String nextCursor,
+                                  JsonObject _meta) {
     public ListResourcesResult {
         resources = resources == null ? List.of() : List.copyOf(resources);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ReadResourceRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ReadResourceRequest.java
@@ -1,9 +1,12 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.UriValidator;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
-public record ReadResourceRequest(String uri) {
+public record ReadResourceRequest(String uri, JsonObject _meta) {
     public ReadResourceRequest {
         uri = UriValidator.requireAbsolute(uri);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ReadResourceResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ReadResourceResult.java
@@ -1,9 +1,12 @@
 package com.amannmalik.mcp.server.resources;
 
 import java.util.List;
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
 
-public record ReadResourceResult(List<ResourceBlock> contents) {
+public record ReadResourceResult(List<ResourceBlock> contents, JsonObject _meta) {
     public ReadResourceResult {
         contents = contents == null ? List.of() : List.copyOf(contents);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -174,7 +174,10 @@ public final class ResourcesCodec {
     public static JsonObject toJsonObject(ReadResourceResult result) {
         var arr = Json.createArrayBuilder();
         result.contents().forEach(c -> arr.add(toJsonObject(c)));
-        return Json.createObjectBuilder().add("contents", arr.build()).build();
+        JsonObjectBuilder b = Json.createObjectBuilder()
+                .add("contents", arr.build());
+        if (result._meta() != null) b.add("_meta", result._meta());
+        return b.build();
     }
 
     public static JsonObject toJsonObject(ListResourcesResult result) {
@@ -182,27 +185,28 @@ public final class ResourcesCodec {
         return PaginationJson.toJson(
                 "resources",
                 new Pagination.Page<>(result.resources(), result.nextCursor()),
-                ResourcesCodec::toJsonObject);
+                ResourcesCodec::toJsonObject,
+                result._meta());
     }
 
     public static JsonObject toJsonObject(ListResourcesRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor(), req._meta()));
     }
 
     public static ListResourcesRequest toListResourcesRequest(JsonObject obj) {
-        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
-        return new ListResourcesRequest(cursor);
+        PaginatedRequest page = PaginationCodec.toPaginatedRequest(obj);
+        return new ListResourcesRequest(page.cursor(), page._meta());
     }
 
     public static JsonObject toJsonObject(ListResourceTemplatesRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor()));
+        return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor(), req._meta()));
     }
 
     public static ListResourceTemplatesRequest toListResourceTemplatesRequest(JsonObject obj) {
-        String cursor = PaginationCodec.toPaginatedRequest(obj).cursor();
-        return new ListResourceTemplatesRequest(cursor);
+        PaginatedRequest page = PaginationCodec.toPaginatedRequest(obj);
+        return new ListResourceTemplatesRequest(page.cursor(), page._meta());
     }
 
     public static JsonObject toJsonObject(ListResourceTemplatesResult result) {
@@ -210,7 +214,8 @@ public final class ResourcesCodec {
         return PaginationJson.toJson(
                 "resourceTemplates",
                 new Pagination.Page<>(result.resourceTemplates(), result.nextCursor()),
-                ResourcesCodec::toJsonObject);
+                ResourcesCodec::toJsonObject,
+                result._meta());
     }
 
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/SubscribeRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/SubscribeRequest.java
@@ -1,9 +1,12 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.UriValidator;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
-public record SubscribeRequest(String uri) {
+public record SubscribeRequest(String uri, JsonObject _meta) {
     public SubscribeRequest {
         uri = UriValidator.requireAbsolute(uri);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/UnsubscribeRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/UnsubscribeRequest.java
@@ -1,9 +1,12 @@
 package com.amannmalik.mcp.server.resources;
 
 import com.amannmalik.mcp.validation.UriValidator;
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
 
-public record UnsubscribeRequest(String uri) {
+public record UnsubscribeRequest(String uri, JsonObject _meta) {
     public UnsubscribeRequest {
         uri = UriValidator.requireAbsolute(uri);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/CallToolRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/CallToolRequest.java
@@ -1,13 +1,17 @@
 package com.amannmalik.mcp.server.tools;
 
 import com.amannmalik.mcp.validation.InputSanitizer;
+import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 
-public record CallToolRequest(String name, JsonObject arguments) {
+public record CallToolRequest(String name,
+                              JsonObject arguments,
+                              JsonObject _meta) {
     public CallToolRequest {
         if (name == null) throw new IllegalArgumentException("name required");
         name = InputSanitizer.requireClean(name);
         arguments = arguments == null ? JsonValue.EMPTY_JSON_OBJECT : arguments;
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ListToolsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ListToolsRequest.java
@@ -1,4 +1,10 @@
 package com.amannmalik.mcp.server.tools;
 
-public record ListToolsRequest(String cursor) {
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
+
+public record ListToolsRequest(String cursor, JsonObject _meta) {
+    public ListToolsRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ListToolsResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ListToolsResult.java
@@ -1,9 +1,14 @@
 package com.amannmalik.mcp.server.tools;
 
 import java.util.List;
+import jakarta.json.JsonObject;
+import com.amannmalik.mcp.validation.MetaValidator;
 
-public record ListToolsResult(List<Tool> tools, String nextCursor) {
+public record ListToolsResult(List<Tool> tools,
+                              String nextCursor,
+                              JsonObject _meta) {
     public ListToolsResult {
         tools = tools == null || tools.isEmpty() ? List.of() : List.copyOf(tools);
+        MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/util/PaginatedRequest.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginatedRequest.java
@@ -1,4 +1,13 @@
 package com.amannmalik.mcp.util;
 
-public record PaginatedRequest(String cursor) {
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
+
+/**
+ * Common pagination parameters for requests.
+ */
+public record PaginatedRequest(String cursor, JsonObject _meta) {
+    public PaginatedRequest {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/util/PaginatedResult.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginatedResult.java
@@ -1,4 +1,13 @@
 package com.amannmalik.mcp.util;
 
-public record PaginatedResult(String nextCursor) {
+import com.amannmalik.mcp.validation.MetaValidator;
+import jakarta.json.JsonObject;
+
+/**
+ * Common pagination information for results.
+ */
+public record PaginatedResult(String nextCursor, JsonObject _meta) {
+    public PaginatedResult {
+        MetaValidator.requireValid(_meta);
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/util/PaginationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginationCodec.java
@@ -4,29 +4,40 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
+import java.util.Set;
+
 public final class PaginationCodec {
     private PaginationCodec() {
     }
 
+    private static final Set<String> REQUEST_KEYS = Set.of("cursor", "_meta");
+    private static final Set<String> RESULT_KEYS = Set.of("nextCursor", "_meta");
+
     public static JsonObject toJsonObject(PaginatedRequest req) {
         JsonObjectBuilder b = Json.createObjectBuilder();
         if (req.cursor() != null) b.add("cursor", req.cursor());
+        if (req._meta() != null) b.add("_meta", req._meta());
         return b.build();
     }
 
     public static PaginatedRequest toPaginatedRequest(JsonObject obj) {
+        if (obj != null) JsonUtil.requireOnlyKeys(obj, REQUEST_KEYS);
         String cursor = obj == null ? null : obj.getString("cursor", null);
-        return new PaginatedRequest(cursor);
+        JsonObject meta = obj == null ? null : obj.getJsonObject("_meta");
+        return new PaginatedRequest(cursor, meta);
     }
 
     public static JsonObject toJsonObject(PaginatedResult result) {
         JsonObjectBuilder b = Json.createObjectBuilder();
         if (result.nextCursor() != null) b.add("nextCursor", result.nextCursor());
+        if (result._meta() != null) b.add("_meta", result._meta());
         return b.build();
     }
 
     public static PaginatedResult toPaginatedResult(JsonObject obj) {
+        if (obj != null) JsonUtil.requireOnlyKeys(obj, RESULT_KEYS);
         String cursor = obj == null ? null : obj.getString("nextCursor", null);
-        return new PaginatedResult(cursor);
+        JsonObject meta = obj == null ? null : obj.getJsonObject("_meta");
+        return new PaginatedResult(cursor, meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/util/PaginationJson.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginationJson.java
@@ -14,11 +14,12 @@ public final class PaginationJson {
 
     public static <T> JsonObject toJson(String itemsField,
                                         Pagination.Page<T> page,
-                                        Function<T, JsonValue> encoder) {
+                                        Function<T, JsonValue> encoder,
+                                        JsonObject meta) {
         JsonArrayBuilder arr = Json.createArrayBuilder();
         page.items().forEach(item -> arr.add(encoder.apply(item)));
         JsonObjectBuilder b = Json.createObjectBuilder().add(itemsField, arr.build());
-        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor()))
+        PaginationCodec.toJsonObject(new PaginatedResult(page.nextCursor(), meta))
                 .forEach(b::add);
         return b.build();
     }


### PR DESCRIPTION
## Summary
- support `_meta` data in `PaginatedRequest` and `PaginatedResult`
- propagate `_meta` through request/response records
- extend codecs to read and write the new fields
- adjust server code to work with new constructors

## Testing
- `./verify.sh` *(fails: gradle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a28897b188324a0838e2ec0e6a427