### PR TITLE
Add DisplayNameProvider interface

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
@@ -6,13 +6,15 @@ import jakarta.json.JsonObject;
 
 import java.util.List;
 
+import com.amannmalik.mcp.util.DisplayNameProvider;
+
 public record Prompt(
         String name,
         String title,
         String description,
         List<PromptArgument> arguments,
         JsonObject _meta
-) {
+) implements DisplayNameProvider {
     public Prompt {
         name = InputSanitizer.requireClean(name);
         arguments = arguments == null || arguments.isEmpty() ? List.of() : List.copyOf(arguments);
@@ -21,7 +23,4 @@ public record Prompt(
         MetaValidator.requireValid(_meta);
     }
 
-    public String displayName() {
-        return title != null ? title : name;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.prompts;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
+import com.amannmalik.mcp.util.DisplayNameProvider;
 
 public record PromptArgument(
         String name,
@@ -10,7 +11,7 @@ public record PromptArgument(
         String description,
         boolean required,
         JsonObject _meta
-) {
+) implements DisplayNameProvider {
     public PromptArgument {
         name = InputSanitizer.requireClean(name);
         title = InputSanitizer.cleanNullable(title);
@@ -18,7 +19,4 @@ public record PromptArgument(
         MetaValidator.requireValid(_meta);
     }
 
-    public String displayName() {
-        return title != null ? title : name;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
@@ -5,6 +5,7 @@ import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriValidator;
 import jakarta.json.JsonObject;
+import com.amannmalik.mcp.util.DisplayNameProvider;
 
 public record Resource(
         String uri,
@@ -15,7 +16,7 @@ public record Resource(
         Long size,
         Annotations annotations,
         JsonObject _meta
-) {
+) implements DisplayNameProvider {
     public Resource {
         uri = UriValidator.requireAbsolute(uri);
         name = InputSanitizer.requireClean(name);
@@ -28,7 +29,4 @@ public record Resource(
         MetaValidator.requireValid(_meta);
     }
 
-    public String displayName() {
-        return title != null ? title : name;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
@@ -5,6 +5,7 @@ import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import com.amannmalik.mcp.validation.UriTemplateValidator;
 import jakarta.json.JsonObject;
+import com.amannmalik.mcp.util.DisplayNameProvider;
 
 public record ResourceTemplate(
         String uriTemplate,
@@ -14,7 +15,7 @@ public record ResourceTemplate(
         String mimeType,
         Annotations annotations,
         JsonObject _meta
-) {
+) implements DisplayNameProvider {
     public ResourceTemplate {
         uriTemplate = UriTemplateValidator.requireAbsoluteTemplate(uriTemplate);
         name = InputSanitizer.requireClean(name);
@@ -24,7 +25,4 @@ public record ResourceTemplate(
         MetaValidator.requireValid(_meta);
     }
 
-    public String displayName() {
-        return title != null ? title : name;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/Tool.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.server.tools;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
+import com.amannmalik.mcp.util.DisplayNameProvider;
 
 public record Tool(String name,
                    String title,
@@ -10,7 +11,7 @@ public record Tool(String name,
                    JsonObject inputSchema,
                    JsonObject outputSchema,
                    ToolAnnotations annotations,
-                   JsonObject _meta) {
+                   JsonObject _meta) implements DisplayNameProvider {
     public Tool {
         name = InputSanitizer.requireClean(name);
         if (inputSchema == null) {
@@ -28,6 +29,7 @@ public record Tool(String name,
         MetaValidator.requireValid(_meta);
     }
 
+    @Override
     public String displayName() {
         if (title != null) return title;
         if (annotations != null && annotations.title() != null) return annotations.title();

--- a/src/main/java/com/amannmalik/mcp/util/DisplayNameProvider.java
+++ b/src/main/java/com/amannmalik/mcp/util/DisplayNameProvider.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.util;
+
+/**
+ * Simple interface for entities that may expose a title for display purposes.
+ */
+public interface DisplayNameProvider {
+    String name();
+    String title();
+
+    default String displayName() {
+        String title = title();
+        return title == null || title.isBlank() ? name() : title;
+    }
+}


### PR DESCRIPTION
## Summary
- add `DisplayNameProvider` interface
- implement it across prompt, resource, template, and tool records
- override `Tool.displayName` to respect annotations

## Testing
- `gradle classes`
- `./verify.sh` *(fails: tests require JDK 24 which isn't available)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b0ec178832490ea2a0872cd266e