### PR TITLE
Fix server startup

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -11,8 +11,8 @@ public record ServerConfig(
         List<String> authorizationServers) implements CliConfig {
     public ServerConfig {
         if (transport == null) throw new IllegalArgumentException("transport");
-        if (transport == TransportType.HTTP && port <= 0) {
-            throw new IllegalArgumentException("port required for HTTP");
+        if (transport == TransportType.HTTP && port < 0) {
+            throw new IllegalArgumentException("port must be >= 0 for HTTP");
         }
 
         if (resourceMetadataUrl != null && !resourceMetadataUrl.isBlank()) {

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -99,7 +99,7 @@ public final class McpConformanceSteps {
                     serverProcess.getErrorStream(), StandardCharsets.UTF_8));
             String line;
             int port = -1;
-            long end = System.currentTimeMillis() + 2000;
+            long end = System.currentTimeMillis() + 5000;
             while (System.currentTimeMillis() < end && (line = err.readLine()) != null) {
                 if (line.startsWith("Listening on http://127.0.0.1:")) {
                     port = Integer.parseInt(line.substring(line.lastIndexOf(':') + 1));


### PR DESCRIPTION
## Summary
- allow ephemeral port 0 when launching HTTP server
- give tests more time to detect the HTTP port

## Testing
- `./verify.sh` *(fails: there were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b83e0088324b1426988b3a3bbe4