### PR TITLE
Fix server startup check timing

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -128,7 +128,7 @@ public final class McpConformanceSteps {
                     "com.amannmalik.mcp.Main", "server", "--stdio", "-v"));
             ProcessBuilder pb = new ProcessBuilder(args);
             serverProcess = pb.start();
-            long end = System.currentTimeMillis() + 500;
+            long end = System.currentTimeMillis() + 2000;
             boolean started = false;
             while (System.currentTimeMillis() < end) {
                 if (serverProcess.isAlive()) {


### PR DESCRIPTION
## Summary
- increase wait time for server startup in conformance tests

## Testing
- `./verify.sh` *(fails: 11 tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b7f3f2c832484083c40302e175c