### PR TITLE
Fix constructors and server config

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerConfig.java
@@ -33,11 +33,22 @@ public record ServerConfig(
             for (String as : authorizationServers) {
                 try {
                     var uri = java.net.URI.create(as);
-                    if (!uri.isAbsolute() || uri.getFragment() != null
-                            || !"https".equalsIgnoreCase(uri.getScheme())) {
+                    if (!uri.isAbsolute() || uri.getFragment() != null) {
                         throw new IllegalArgumentException();
                     }
-                    validated.add(as);
+                    String scheme = uri.getScheme();
+                    if ("https".equalsIgnoreCase(scheme)) {
+                        validated.add(as);
+                        continue;
+                    }
+                    if ("http".equalsIgnoreCase(scheme)) {
+                        String host = uri.getHost();
+                        if ("localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host)) {
+                            validated.add(as);
+                            continue;
+                        }
+                    }
+                    throw new IllegalArgumentException();
                 } catch (Exception e) {
                     throw new IllegalArgumentException("invalid authorizationServer: " + as, e);
                 }

--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -323,8 +323,10 @@ public final class McpClient implements AutoCloseable {
 
     public void setLogLevel(LoggingLevel level) throws IOException {
         if (level == null) throw new IllegalArgumentException("level required");
-        JsonRpcMessage msg = request(RequestMethod.LOGGING_SET_LEVEL,
-                LoggingCodec.toJsonObject(new SetLevelRequest(level)));
+        JsonRpcMessage msg = request(
+                RequestMethod.LOGGING_SET_LEVEL,
+                LoggingCodec.toJsonObject(new SetLevelRequest(level, null))
+        );
         if (msg instanceof JsonRpcResponse) {
             return;
         }

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -605,7 +605,7 @@ public final class McpServer implements AutoCloseable {
             return JsonRpcError.of(req.id(), -32002, "Resource not found",
                     Json.createObjectBuilder().add("uri", uri).build());
         }
-        ReadResourceResult result = new ReadResourceResult(List.of(block));
+        ReadResourceResult result = new ReadResourceResult(List.of(block), null);
         return new JsonRpcResponse(req.id(), ResourcesCodec.toJsonObject(result));
     }
 
@@ -905,7 +905,10 @@ public final class McpServer implements AutoCloseable {
 
     private List<Root> fetchRoots() throws IOException {
         requireClientCapability(ClientCapability.ROOTS);
-        JsonRpcMessage msg = sendRequest(RequestMethod.ROOTS_LIST, RootsCodec.toJsonObject(new ListRootsRequest()));
+        JsonRpcMessage msg = sendRequest(
+                RequestMethod.ROOTS_LIST,
+                RootsCodec.toJsonObject(new ListRootsRequest(null))
+        );
         if (msg instanceof JsonRpcResponse resp) {
             return RootsCodec.toRoots(resp.result());
         }

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompletionCodec.java
@@ -58,7 +58,7 @@ public final class CompletionCodec {
             }
             ctx = new CompleteRequest.Context(InputSanitizer.requireCleanMap(args));
         }
-        return new CompleteRequest(ref, argument, ctx);
+        return new CompleteRequest(ref, argument, ctx, null);
     }
 
     public static JsonObject toJsonObject(CompleteResult result) {

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -137,43 +137,48 @@ public final class ResourcesCodec {
 
     public static JsonObject toJsonObject(SubscribeRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return Json.createObjectBuilder()
-                .add("uri", req.uri())
-                .build();
+        JsonObjectBuilder b = Json.createObjectBuilder().add("uri", req.uri());
+        if (req._meta() != null) b.add("_meta", req._meta());
+        return b.build();
     }
 
     public static SubscribeRequest toSubscribeRequest(JsonObject obj) {
         if (obj == null || !obj.containsKey("uri")) {
             throw new IllegalArgumentException("uri required");
         }
-        return new SubscribeRequest(obj.getString("uri"));
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new SubscribeRequest(obj.getString("uri"), meta);
     }
 
     public static JsonObject toJsonObject(UnsubscribeRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return Json.createObjectBuilder()
-                .add("uri", req.uri())
-                .build();
+        JsonObjectBuilder b = Json.createObjectBuilder().add("uri", req.uri());
+        if (req._meta() != null) b.add("_meta", req._meta());
+        return b.build();
     }
 
     public static UnsubscribeRequest toUnsubscribeRequest(JsonObject obj) {
         if (obj == null || !obj.containsKey("uri")) {
             throw new IllegalArgumentException("uri required");
         }
-        return new UnsubscribeRequest(obj.getString("uri"));
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new UnsubscribeRequest(obj.getString("uri"), meta);
     }
 
 
     public static JsonObject toJsonObject(ReadResourceRequest req) {
         if (req == null) throw new IllegalArgumentException("request required");
-        return Json.createObjectBuilder().add("uri", req.uri()).build();
+        JsonObjectBuilder b = Json.createObjectBuilder().add("uri", req.uri());
+        if (req._meta() != null) b.add("_meta", req._meta());
+        return b.build();
     }
 
     public static ReadResourceRequest toReadResourceRequest(JsonObject obj) {
         if (obj == null || !obj.containsKey("uri")) {
             throw new IllegalArgumentException("uri required");
         }
-        return new ReadResourceRequest(obj.getString("uri"));
+        JsonObject meta = obj.containsKey("_meta") ? obj.getJsonObject("_meta") : null;
+        return new ReadResourceRequest(obj.getString("uri"), meta);
     }
 
     public static JsonObject toJsonObject(ReadResourceResult result) {


### PR DESCRIPTION
## Summary
- pass meta objects to request/response constructors
- parse meta from resource codec
- allow local HTTP authorization servers

## Testing
- `./verify.sh` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a310d334483248200d881b137d340