### PR TITLE
Refactor cursor handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
@@ -22,6 +22,10 @@ public record JsonRpcError(RequestId id, ErrorDetail error) implements JsonRpcMe
         return new JsonRpcError(id, new ErrorDetail(code, message, data));
     }
 
+    public static JsonRpcError invalidParams(RequestId id, String message) {
+        return of(id, JsonRpcErrorCode.INVALID_PARAMS, message);
+    }
+
     public JsonRpcError {
         if (id == null || error == null) {
             throw new IllegalArgumentException("id and error are required");

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -524,16 +524,13 @@ public final class McpServer implements AutoCloseable {
     }
 
     private JsonRpcError invalidParams(JsonRpcRequest req, String message) {
-        return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, message);
+        return JsonRpcError.invalidParams(req.id(), message);
     }
 
     private JsonRpcError invalidParams(JsonRpcRequest req, IllegalArgumentException e) {
         return invalidParams(req, e.getMessage());
     }
 
-    private static String sanitizeCursor(String cursor) {
-        return cursor == null ? null : Pagination.requireValidCursor(cursor);
-    }
 
 
     private void cancelled(JsonRpcNotification note) {
@@ -564,7 +561,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = lr.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(InputSanitizer.cleanNullable(cursor));
+                cursor = Pagination.sanitize(InputSanitizer.cleanNullable(cursor));
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }
@@ -622,7 +619,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = request.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(InputSanitizer.cleanNullable(cursor));
+                cursor = Pagination.sanitize(InputSanitizer.cleanNullable(cursor));
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }
@@ -715,7 +712,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = ltr.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(InputSanitizer.cleanNullable(cursor));
+                cursor = Pagination.sanitize(InputSanitizer.cleanNullable(cursor));
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }
@@ -779,7 +776,7 @@ public final class McpServer implements AutoCloseable {
         String cursor = lpr.cursor();
         if (cursor != null) {
             try {
-                cursor = sanitizeCursor(InputSanitizer.cleanNullable(cursor));
+                cursor = Pagination.sanitize(InputSanitizer.cleanNullable(cursor));
             } catch (IllegalArgumentException e) {
                 return invalidParams(req, e);
             }

--- a/src/main/java/com/amannmalik/mcp/util/Pagination.java
+++ b/src/main/java/com/amannmalik/mcp/util/Pagination.java
@@ -37,6 +37,10 @@ public final class Pagination {
         return cursor;
     }
 
+    public static String sanitize(String cursor) {
+        return cursor == null ? null : requireValidCursor(cursor);
+    }
+
     public record Page<T>(List<T> items, String nextCursor) {
         public Page {
             items = items == null ? List.of() : List.copyOf(items);


### PR DESCRIPTION
## Summary
- add `invalidParams` helper in `JsonRpcError`
- support cursor sanitizing in `Pagination`
- call the new helpers from `McpServer`

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688d4aa4081c8324be916bc4af7c941b