### PR TITLE
Improve SSE event parsing

### DIFF
--- a/src/test/java/com/amannmalik/mcp/transport/SseReaderTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/SseReaderTest.java
@@ -1,0 +1,41 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.JsonObject;
+import jakarta.json.Json;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SseReaderTest {
+    @Test
+    public void parsesEvents() throws Exception {
+        String input = "id: test-1\n" +
+                "data: {\"a\":1}\n" +
+                "\n" +
+                "id: test-2\n" +
+                "data: {\"b\":2}\n" +
+                "\n";
+        BlockingQueue<JsonObject> queue = new LinkedBlockingQueue<>();
+        java.util.Set<StreamableHttpClientTransport.SseReader> container = new java.util.HashSet<>();
+        StreamableHttpClientTransport.SseReader reader = new StreamableHttpClientTransport.SseReader(
+                new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)),
+                queue,
+                container
+        );
+        Thread t = new Thread(reader);
+        t.start();
+        t.join(100);
+        reader.close();
+        t.join(100);
+        assertEquals(2, queue.size());
+        JsonObject first = queue.take();
+        assertEquals(Json.createObjectBuilder().add("a", 1).build(), first);
+        JsonObject second = queue.take();
+        assertEquals(Json.createObjectBuilder().add("b", 2).build(), second);
+    }
+}


### PR DESCRIPTION
## Summary
- refine `StreamableHttpClientTransport` SSE reader
- support newline separated `data:` segments and expose a package-private reader
- add unit test for SSE reader

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d4f34b6d483249c3e8f6c80712084