### PR TITLE
Refactor MCP internals

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
@@ -32,107 +32,110 @@ public final class JwtTokenValidator implements TokenValidator {
 
     @Override
     public Principal validate(String token) throws AuthorizationException {
+        JwtParts parts = decode(token);
+        verifySignature(parts);
+        JsonObject payload = parsePayload(parts.payloadJson());
+        String subject = extractSubject(payload);
+        validateAudience(payload);
+        validateResource(payload);
+        validateTimestamps(payload);
+        Set<String> scopes = extractScopes(payload);
+        return new Principal(subject, scopes);
+    }
+
+    private record JwtParts(String headerJson, String payloadJson, String signature) {
+    }
+
+    private JwtParts decode(String token) throws AuthorizationException {
         token = InputSanitizer.requireNonBlank(token);
         String[] parts = token.split("\\.");
-        if (parts.length != 3) {
-            throw new AuthorizationException("invalid token format");
-        }
-        String headerJson;
-        String payloadJson;
+        if (parts.length != 3) throw new AuthorizationException("invalid token format");
         try {
-            headerJson = new String(Base64Util.decodeUrl(parts[0]));
-            payloadJson = new String(Base64Util.decodeUrl(parts[1]));
+            String header = new String(Base64Util.decodeUrl(parts[0]));
+            String payload = new String(Base64Util.decodeUrl(parts[1]));
+            return new JwtParts(header, payload, parts[2]);
         } catch (IllegalArgumentException e) {
             throw new AuthorizationException("invalid token encoding");
         }
-        if (secret != null) {
-            try (JsonReader hr = Json.createReader(new StringReader(headerJson))) {
-                JsonObject header = hr.readObject();
-                String alg = header.getString("alg", null);
-                if (!"HS256".equals(alg)) {
-                    throw new AuthorizationException("unsupported alg");
-                }
-            } catch (Exception e) {
-                throw new AuthorizationException("invalid token header");
-            }
-            try {
-                Mac mac = Mac.getInstance("HmacSHA256");
-                mac.init(new SecretKeySpec(secret, "HmacSHA256"));
-                byte[] expected = mac.doFinal((parts[0] + "." + parts[1]).getBytes(StandardCharsets.US_ASCII));
-                byte[] actual = Base64Util.decodeUrl(parts[2]);
-                if (!MessageDigest.isEqual(expected, actual)) {
-                    throw new AuthorizationException("invalid signature");
-                }
-            } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-                throw new AuthorizationException("signature verification failed");
-            }
+    }
+
+    private void verifySignature(JwtParts parts) throws AuthorizationException {
+        if (secret == null) return;
+        JsonObject header;
+        try (JsonReader hr = Json.createReader(new StringReader(parts.headerJson()))) {
+            header = hr.readObject();
+        } catch (Exception e) {
+            throw new AuthorizationException("invalid token header");
         }
-        JsonObject payload;
+        String alg = header.getString("alg", null);
+        if (!"HS256".equals(alg)) throw new AuthorizationException("unsupported alg");
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+            byte[] expected = mac.doFinal((parts.headerJson() + "." + parts.payloadJson()).getBytes(StandardCharsets.US_ASCII));
+            byte[] actual = Base64Util.decodeUrl(parts.signature());
+            if (!MessageDigest.isEqual(expected, actual)) throw new AuthorizationException("invalid signature");
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new AuthorizationException("signature verification failed");
+        }
+    }
+
+    private JsonObject parsePayload(String payloadJson) throws AuthorizationException {
         try (JsonReader reader = Json.createReader(new StringReader(payloadJson))) {
-            payload = reader.readObject();
+            return reader.readObject();
         } catch (Exception e) {
             throw new AuthorizationException("invalid token payload");
         }
-        boolean audOk = false;
-        String aud = payload.getString("aud", null);
-        if (aud != null) audOk = expectedAudience.equals(aud);
-        if (!audOk) {
-            JsonArray arr = payload.getJsonArray("aud");
-            if (arr != null) {
-                for (var js : arr.getValuesAs(jakarta.json.JsonString.class)) {
-                    if (expectedAudience.equals(js.getString())) {
-                        audOk = true;
-                        break;
-                    }
-                }
-            }
-        }
-        if (!audOk) {
-            throw new AuthorizationException("audience mismatch");
-        }
+    }
 
-        if (payload.containsKey("resource")) {
-            boolean resourceOk = false;
-            switch (payload.get("resource").getValueType()) {
-                case STRING -> resourceOk = expectedAudience.equals(payload.getString("resource"));
-                case ARRAY -> {
-                    JsonArray arr = payload.getJsonArray("resource");
-                    for (var js : arr.getValuesAs(jakarta.json.JsonString.class)) {
-                        if (expectedAudience.equals(js.getString())) {
-                            resourceOk = true;
-                            break;
-                        }
-                    }
-                }
-                default -> {
-                }
-            }
-            if (!resourceOk) {
-                throw new AuthorizationException("resource mismatch");
-            }
-        }
+    private String extractSubject(JsonObject payload) throws AuthorizationException {
         String sub = payload.getString("sub", null);
-        if (sub == null || sub.isBlank()) {
-            throw new AuthorizationException("subject required");
+        if (sub == null || sub.isBlank()) throw new AuthorizationException("subject required");
+        return sub;
+    }
+
+    private void validateAudience(JsonObject payload) throws AuthorizationException {
+        String aud = payload.getString("aud", null);
+        if (aud != null && expectedAudience.equals(aud)) return;
+        JsonArray arr = payload.getJsonArray("aud");
+        if (arr != null) {
+            for (var js : arr.getValuesAs(jakarta.json.JsonString.class)) {
+                if (expectedAudience.equals(js.getString())) return;
+            }
         }
+        throw new AuthorizationException("audience mismatch");
+    }
+
+    private void validateResource(JsonObject payload) throws AuthorizationException {
+        if (!payload.containsKey("resource")) return;
+        boolean ok = false;
+        switch (payload.get("resource").getValueType()) {
+            case STRING -> ok = expectedAudience.equals(payload.getString("resource"));
+            case ARRAY -> {
+                JsonArray arr = payload.getJsonArray("resource");
+                for (var js : arr.getValuesAs(jakarta.json.JsonString.class)) {
+                    if (expectedAudience.equals(js.getString())) { ok = true; break; }
+                }
+            }
+            default -> {}
+        }
+        if (!ok) throw new AuthorizationException("resource mismatch");
+    }
+
+    private void validateTimestamps(JsonObject payload) throws AuthorizationException {
         long now = System.currentTimeMillis() / 1000;
         if (payload.containsKey("exp") && payload.get("exp").getValueType() == jakarta.json.JsonValue.ValueType.NUMBER) {
             long exp = payload.getJsonNumber("exp").longValue();
-            if (now >= exp) {
-                throw new AuthorizationException("token expired");
-            }
+            if (now >= exp) throw new AuthorizationException("token expired");
         }
         if (payload.containsKey("nbf") && payload.get("nbf").getValueType() == jakarta.json.JsonValue.ValueType.NUMBER) {
             long nbf = payload.getJsonNumber("nbf").longValue();
-            if (now < nbf) {
-                throw new AuthorizationException("token not active");
-            }
+            if (now < nbf) throw new AuthorizationException("token not active");
         }
-        Set<String> scopes = Set.of();
+    }
+
+    private Set<String> extractScopes(JsonObject payload) {
         var scopeStr = payload.getString("scope", null);
-        if (scopeStr != null && !scopeStr.isBlank()) {
-            scopes = Set.of(scopeStr.split(" "));
-        }
-        return new Principal(sub, scopes);
+        return (scopeStr == null || scopeStr.isBlank()) ? Set.of() : Set.of(scopeStr.split(" "));
     }
 }


### PR DESCRIPTION
## Summary
- break up `JwtTokenValidator.validate` into helper methods
- extract initialization helpers in `McpClient`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d543f139c8324845032c3c7f7c7f3