### PR TITLE
Refactor request handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -101,6 +101,7 @@ import com.amannmalik.mcp.util.ProgressManager;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ProgressUtil;
+import com.amannmalik.mcp.util.JsonRpcRequestProcessor;
 import com.amannmalik.mcp.util.ListChangeListener;
 import com.amannmalik.mcp.util.ListChangeSubscription;
 import com.amannmalik.mcp.util.Timeouts;
@@ -139,6 +140,8 @@ public final class McpServer implements AutoCloseable {
     private final ProgressManager progressManager = new ProgressManager(new RateLimiter(20, 1000));
     private final CancellationTracker cancellationTracker = new CancellationTracker();
     private final IdTracker idTracker = new IdTracker();
+    private final JsonRpcRequestProcessor requestProcessor =
+            new JsonRpcRequestProcessor(progressManager, cancellationTracker, this::send, idTracker);
     private final ResourceProvider resources;
     private final ToolProvider tools;
     private final PromptProvider prompts;
@@ -374,60 +377,8 @@ public final class McpServer implements AutoCloseable {
         }
 
         boolean cancellable = method.get() != RequestMethod.INITIALIZE;
-        processRequest(req, handler, cancellable);
-    }
-
-    private void processRequest(JsonRpcRequest req, RequestHandler handler, boolean cancellable) throws IOException {
-        Optional<ProgressToken> token;
-        try {
-            idTracker.register(req.id());
-        } catch (IllegalArgumentException e) {
-            send(JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_REQUEST, e.getMessage()));
-            return;
-        }
-
-        try {
-            token = progressManager.register(req.id(), req.params());
-            token.ifPresent(t -> {
-                try {
-                    progressManager.send(new ProgressNotification(t, 0.0, 1.0, null), this::send);
-                } catch (IOException ignore) {
-                }
-            });
-        } catch (IllegalArgumentException e) {
-            send(invalidParams(req, e));
-            return;
-        }
-
-        if (cancellable) {
-            cancellationTracker.register(req.id());
-        }
-
-        JsonRpcMessage resp;
-        try {
-            resp = handler.handle(req);
-        } catch (IllegalArgumentException e) {
-            send(invalidParams(req, e));
-            return;
-        } catch (Exception e) {
-            send(JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage()));
-            return;
-        }
-
-        boolean cancelled = cancellable && cancellationTracker.isCancelled(req.id());
-        if (!cancelled && resp != null) {
-            send(resp);
-        }
-        if (!cancelled) {
-            token.ifPresent(t -> {
-                try {
-                    progressManager.send(new ProgressNotification(t, 1.0, 1.0, null), this::send);
-                } catch (IOException ignore) {
-                }
-            });
-        }
-
-        cleanup(req.id());
+        JsonRpcMessage resp = requestProcessor.process(req, cancellable, handler::handle);
+        if (resp != null) send(resp);
     }
 
     private void onNotification(JsonRpcNotification note) throws IOException {
@@ -543,16 +494,6 @@ public final class McpServer implements AutoCloseable {
                     reason == null ? JsonValue.NULL : Json.createValue(reason));
         } catch (IOException ignore) {
         }
-    }
-
-    private void cleanup(RequestId id) {
-        progressManager.release(id);
-        cancellationTracker.release(id);
-        idTracker.release(id);
-    }
-
-    private void sendProgress(ProgressNotification note) throws IOException {
-        progressManager.send(note, this::send);
     }
 
     private String sanitizeCursor(String cursor) {

--- a/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
+++ b/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
@@ -1,0 +1,111 @@
+package com.amannmalik.mcp.util;
+
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.jsonrpc.IdTracker;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Handles common request lifecycle concerns like progress tracking,
+ * cancellation and id management.
+ */
+public final class JsonRpcRequestProcessor {
+    private final ProgressManager progressManager;
+    private final CancellationTracker cancellationTracker;
+    private final NotificationSender sender;
+    private final IdTracker idTracker;
+
+    public JsonRpcRequestProcessor(
+            ProgressManager progressManager,
+            CancellationTracker cancellationTracker,
+            NotificationSender sender,
+            IdTracker idTracker
+    ) {
+        if (progressManager == null || cancellationTracker == null || sender == null) {
+            throw new IllegalArgumentException("manager, tracker and sender required");
+        }
+        this.progressManager = progressManager;
+        this.cancellationTracker = cancellationTracker;
+        this.sender = sender;
+        this.idTracker = idTracker;
+    }
+
+    public JsonRpcRequestProcessor(
+            ProgressManager progressManager,
+            CancellationTracker cancellationTracker,
+            NotificationSender sender
+    ) {
+        this(progressManager, cancellationTracker, sender, null);
+    }
+
+    /**
+     * Process a request using the provided handler. The handler is expected to
+     * perform the actual request logic and return a response or null. If the
+     * request was cancelled the return value will be null.
+     */
+    public JsonRpcMessage process(
+            JsonRpcRequest req,
+            boolean cancellable,
+            Function<JsonRpcRequest, JsonRpcMessage> handler
+    ) throws IOException {
+        if (req == null || handler == null) throw new IllegalArgumentException("request and handler required");
+        if (idTracker != null) {
+            try {
+                idTracker.register(req.id());
+            } catch (IllegalArgumentException e) {
+                return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_REQUEST, e.getMessage());
+            }
+        }
+
+        Optional<ProgressToken> token;
+        try {
+            token = progressManager.register(req.id(), req.params());
+            token.ifPresent(t -> {
+                try {
+                    progressManager.send(new ProgressNotification(t, 0.0, 1.0, null), sender);
+                } catch (IOException ignore) {
+                }
+            });
+        } catch (IllegalArgumentException e) {
+            cleanup(req.id());
+            return JsonRpcError.invalidParams(req.id(), e.getMessage());
+        }
+
+        if (cancellable) {
+            cancellationTracker.register(req.id());
+        }
+
+        JsonRpcMessage resp;
+        try {
+            resp = handler.apply(req);
+        } catch (IllegalArgumentException e) {
+            resp = JsonRpcError.invalidParams(req.id(), e.getMessage());
+        } catch (Exception e) {
+            resp = JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());
+        }
+
+        boolean cancelled = cancellable && cancellationTracker.isCancelled(req.id());
+        if (!cancelled) {
+            token.ifPresent(t -> {
+                try {
+                    progressManager.send(new ProgressNotification(t, 1.0, 1.0, null), sender);
+                } catch (IOException ignore) {
+                }
+            });
+        }
+        cleanup(req.id());
+        return cancelled ? null : resp;
+    }
+
+    private void cleanup(RequestId id) {
+        progressManager.release(id);
+        cancellationTracker.release(id);
+        if (idTracker != null) idTracker.release(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add JsonRpcRequestProcessor for shared request lifecycle logic
- use JsonRpcRequestProcessor in server and client
- drop unused progress helpers

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d543f139c8324845032c3c7f7c7f3