### PR TITLE
Refactor SSE helpers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/SseClient.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseClient.java
@@ -1,0 +1,92 @@
+package com.amannmalik.mcp.transport;
+
+import com.amannmalik.mcp.util.Base64Util;
+import jakarta.json.JsonObject;
+import jakarta.servlet.AsyncContext;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Server Sent Event connection for a single client.
+ */
+final class SseClient implements AutoCloseable {
+    private static final int HISTORY_LIMIT = 100;
+
+    private AsyncContext context;
+    private PrintWriter out;
+    private final String prefix;
+    private final Deque<SseEvent> history = new ArrayDeque<>();
+    private final AtomicLong nextId = new AtomicLong(1);
+    private volatile boolean closed;
+
+    SseClient(AsyncContext context) throws IOException {
+        byte[] bytes = new byte[8];
+        StreamableHttpTransport.RANDOM.nextBytes(bytes);
+        this.prefix = Base64Util.encodeUrl(bytes);
+        attach(context, 0);
+    }
+
+    String prefix() {
+        return prefix;
+    }
+
+    void attach(AsyncContext ctx, long lastId) throws IOException {
+        this.context = ctx;
+        this.out = ctx.getResponse().getWriter();
+        this.closed = false;
+        sendHistory(lastId);
+    }
+
+    boolean isActive() {
+        return !closed && context != null;
+    }
+
+    void send(JsonObject msg) {
+        long id = nextId.getAndIncrement();
+        history.addLast(new SseEvent(id, msg));
+        while (history.size() > HISTORY_LIMIT) history.removeFirst();
+        if (closed || context == null) return;
+        try {
+            out.write("id: " + prefix + '-' + id + "\n");
+            out.write("data: " + msg.toString() + "\n\n");
+            out.flush();
+        } catch (Exception e) {
+            System.err.println("SSE send failed: " + e.getMessage());
+            closed = true;
+        }
+    }
+
+    private void sendHistory(long lastId) throws IOException {
+        if (context == null) return;
+        for (SseEvent ev : history) {
+            if (ev.id > lastId) {
+                out.write("id: " + prefix + '-' + ev.id + "\n");
+                out.write("data: " + ev.msg.toString() + "\n\n");
+            }
+        }
+        out.flush();
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        try {
+            if (context != null && !context.hasOriginalRequestAndResponse()) {
+                context.complete();
+            }
+        } catch (Exception e) {
+            System.err.println("SSE close failed: " + e.getMessage());
+        } finally {
+            context = null;
+            out = null;
+        }
+    }
+
+    private record SseEvent(long id, JsonObject msg) {
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/SseReader.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseReader.java
@@ -1,0 +1,77 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Reads an SSE stream and enqueues each event as a {@link JsonObject}.
+ * The last processed event ID is exposed for reconnection logic.
+ */
+final class SseReader implements Runnable {
+    private final InputStream input;
+    private final BlockingQueue<JsonObject> queue;
+    private final Set<SseReader> container;
+    private volatile boolean closed;
+    private String lastEventId;
+
+    SseReader(InputStream input, BlockingQueue<JsonObject> queue, Set<SseReader> container) {
+        this.input = input;
+        this.queue = queue;
+        this.container = container;
+    }
+
+    @Override
+    public void run() {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            String line;
+            StringBuilder data = new StringBuilder();
+            String eventId = null;
+            while (!closed && (line = br.readLine()) != null) {
+                if (line.startsWith("id:")) {
+                    eventId = line.substring(line.indexOf(':') + 1).trim();
+                } else if (line.startsWith("data:")) {
+                    if (!data.isEmpty()) data.append('\n');
+                    data.append(line.substring(line.indexOf(':') + 1).trim());
+                } else if (line.isEmpty()) {
+                    if (!data.isEmpty()) {
+                        try (JsonReader jr = Json.createReader(new StringReader(data.toString()))) {
+                            queue.add(jr.readObject());
+                        } catch (Exception ignore) {
+                        }
+                        data.setLength(0);
+                        if (eventId != null) {
+                            lastEventId = eventId;
+                            eventId = null;
+                        }
+                    }
+                }
+            }
+        } catch (IOException ignore) {
+        } finally {
+            if (container != null) container.remove(this);
+            close();
+        }
+    }
+
+    void close() {
+        closed = true;
+        try {
+            input.close();
+        } catch (IOException ignore) {
+        }
+    }
+
+    String lastEventId() {
+        return lastEventId;
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -6,21 +6,21 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+
+// internal
+import com.amannmalik.mcp.transport.SseReader;
 
 public final class StreamableHttpClientTransport implements Transport {
     private final HttpClient client = HttpClient.newHttpClient();
@@ -126,64 +126,5 @@ public final class StreamableHttpClientTransport implements Transport {
         }
         streams.forEach(SseReader::close);
         streams.clear();
-    }
-
-    static class SseReader implements Runnable {
-        private final InputStream input;
-        private final BlockingQueue<JsonObject> queue;
-        private final Set<SseReader> container;
-        private volatile boolean closed;
-        private String lastEventId;
-
-        SseReader(InputStream input, BlockingQueue<JsonObject> queue, Set<SseReader> container) {
-            this.input = input;
-            this.queue = queue;
-            this.container = container;
-        }
-
-        @Override
-        public void run() {
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
-                String line;
-                StringBuilder data = new StringBuilder();
-                String eventId = null;
-                while (!closed && (line = br.readLine()) != null) {
-                    if (line.startsWith("id:")) {
-                        eventId = line.substring(line.indexOf(':') + 1).trim();
-                    } else if (line.startsWith("data:")) {
-                        if (!data.isEmpty()) data.append('\n');
-                        data.append(line.substring(line.indexOf(':') + 1).trim());
-                    } else if (line.isEmpty()) {
-                        if (!data.isEmpty()) {
-                            try (JsonReader jr = Json.createReader(new StringReader(data.toString()))) {
-                                queue.add(jr.readObject());
-                            } catch (Exception ignore) {
-                            }
-                            data.setLength(0);
-                            if (eventId != null) {
-                                lastEventId = eventId;
-                                eventId = null;
-                            }
-                        }
-                    }
-                }
-            } catch (IOException ignore) {
-            } finally {
-                if (container != null) container.remove(this);
-                close();
-            }
-        }
-
-        void close() {
-            closed = true;
-            try {
-                input.close();
-            } catch (IOException ignore) {
-            }
-        }
-
-        String lastEventId() {
-            return lastEventId;
-        }
     }
 }

--- a/src/test/java/com/amannmalik/mcp/transport/SseReaderTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/SseReaderTest.java
@@ -6,8 +6,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+
+import com.amannmalik.mcp.transport.SseReader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,8 +24,8 @@ public class SseReaderTest {
                 "data: {\"b\":2}\n" +
                 "\n";
         BlockingQueue<JsonObject> queue = new LinkedBlockingQueue<>();
-        java.util.Set<StreamableHttpClientTransport.SseReader> container = new java.util.HashSet<>();
-        StreamableHttpClientTransport.SseReader reader = new StreamableHttpClientTransport.SseReader(
+        java.util.Set<SseReader> container = new java.util.HashSet<>();
+        SseReader reader = new SseReader(
                 new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)),
                 queue,
                 container


### PR DESCRIPTION
## Summary
- split out SseClient and SseReader from HTTP transport implementations
- update transports to use the new helpers
- adjust SSE tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d570d82948324a6185ffb2269898f