### PR TITLE
Refactor wire method lookup

### DIFF
--- a/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
@@ -1,9 +1,6 @@
 package com.amannmalik.mcp.wire;
 
 import java.util.Optional;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public enum NotificationMethod implements WireMethod {
     INITIALIZED("notifications/initialized"),
@@ -17,9 +14,6 @@ public enum NotificationMethod implements WireMethod {
     ROOTS_LIST_CHANGED("notifications/roots/list_changed");
 
     private final String method;
-    private static final Map<String, NotificationMethod> BY_METHOD =
-            Arrays.stream(values())
-                    .collect(Collectors.toUnmodifiableMap(NotificationMethod::method, m -> m));
 
     NotificationMethod(String method) {
         this.method = method;
@@ -30,8 +24,7 @@ public enum NotificationMethod implements WireMethod {
     }
 
     public static Optional<NotificationMethod> from(String method) {
-        if (method == null) return Optional.empty();
-        return Optional.ofNullable(BY_METHOD.get(method));
+        return WireMethod.from(NotificationMethod.class, method);
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
@@ -2,10 +2,7 @@ package com.amannmalik.mcp.wire;
 
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public enum RequestMethod implements WireMethod {
     INITIALIZE("initialize"),
@@ -26,18 +23,16 @@ public enum RequestMethod implements WireMethod {
     ELICITATION_CREATE("elicitation/create");
 
     private final String method;
-    private final ServerCapability capability;
-    private static final Map<String, RequestMethod> BY_METHOD =
-            Arrays.stream(values())
-                    .collect(Collectors.toUnmodifiableMap(RequestMethod::method, m -> m));
+    private final Optional<ServerCapability> capability;
 
     RequestMethod(String method) {
-        this(method, null);
+        this.method = method;
+        this.capability = Optional.empty();
     }
 
     RequestMethod(String method, ServerCapability capability) {
         this.method = method;
-        this.capability = capability;
+        this.capability = Optional.of(capability);
     }
 
     public String method() {
@@ -45,11 +40,10 @@ public enum RequestMethod implements WireMethod {
     }
 
     public static Optional<RequestMethod> from(String method) {
-        if (method == null) return Optional.empty();
-        return Optional.ofNullable(BY_METHOD.get(method));
+        return WireMethod.from(RequestMethod.class, method);
     }
 
     public Optional<ServerCapability> requiredCapability() {
-        return Optional.ofNullable(capability);
+        return capability;
     }
 }


### PR DESCRIPTION
## Summary
- use shared lookup for request and notification wire methods
- avoid nullable server capability on RequestMethod

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d68cc6d4483248c7aa8d2e45ad043