### PR TITLE
refactor: streamline wire method lookups

### DIFF
--- a/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
@@ -1,6 +1,9 @@
 package com.amannmalik.mcp.wire;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public enum NotificationMethod implements WireMethod {
     INITIALIZED("notifications/initialized"),
@@ -14,6 +17,8 @@ public enum NotificationMethod implements WireMethod {
     ROOTS_LIST_CHANGED("notifications/roots/list_changed");
 
     private final String method;
+    private static final Map<String, NotificationMethod> BY_METHOD = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(NotificationMethod::method, e -> e));
 
     NotificationMethod(String method) {
         this.method = method;
@@ -24,7 +29,8 @@ public enum NotificationMethod implements WireMethod {
     }
 
     public static Optional<NotificationMethod> from(String method) {
-        return WireMethod.from(NotificationMethod.class, method);
+        if (method == null) return Optional.empty();
+        return Optional.ofNullable(BY_METHOD.get(method));
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
@@ -2,7 +2,10 @@ package com.amannmalik.mcp.wire;
 
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public enum RequestMethod implements WireMethod {
     INITIALIZE("initialize"),
@@ -24,6 +27,8 @@ public enum RequestMethod implements WireMethod {
 
     private final String method;
     private final Optional<ServerCapability> capability;
+    private static final Map<String, RequestMethod> BY_METHOD = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(RequestMethod::method, e -> e));
 
     RequestMethod(String method) {
         this.method = method;
@@ -40,7 +45,8 @@ public enum RequestMethod implements WireMethod {
     }
 
     public static Optional<RequestMethod> from(String method) {
-        return WireMethod.from(RequestMethod.class, method);
+        if (method == null) return Optional.empty();
+        return Optional.ofNullable(BY_METHOD.get(method));
     }
 
     public Optional<ServerCapability> requiredCapability() {

--- a/src/main/java/com/amannmalik/mcp/wire/WireMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/WireMethod.java
@@ -1,24 +1,6 @@
 package com.amannmalik.mcp.wire;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 /** Common interface for request and notification method enums. */
 public sealed interface WireMethod permits RequestMethod, NotificationMethod {
     String method();
-
-    /**
-     * Lookup the enum constant with the provided wire method name.
-     * @param type enum class implementing {@code WireMethod}
-     * @param method wire method string
-     * @return optional enum constant
-     */
-    static <T extends Enum<T> & WireMethod> Optional<T> from(Class<T> type, String method) {
-        if (method == null) return Optional.empty();
-        Map<String, T> byMethod = Arrays.stream(type.getEnumConstants())
-                .collect(Collectors.toUnmodifiableMap(WireMethod::method, e -> e));
-        return Optional.ofNullable(byMethod.get(method));
-    }
 }


### PR DESCRIPTION
## Summary
- cache wire method enums to remove per-call map creation
- simplify WireMethod interface to expose only method name

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d6c41eb9c83248002f18d3dc3fb84