### PR TITLE
Refactor request handling to eliminate null responses

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -377,8 +377,8 @@ public final class McpServer implements AutoCloseable {
         }
 
         boolean cancellable = method.get() != RequestMethod.INITIALIZE;
-        JsonRpcMessage resp = requestProcessor.process(req, cancellable, handler::handle);
-        if (resp != null) send(resp);
+        var resp = requestProcessor.process(req, cancellable, handler::handle);
+        if (resp.isPresent()) send(resp.get());
     }
 
     private void onNotification(JsonRpcNotification note) throws IOException {


### PR DESCRIPTION
## Summary
- Return `Optional<JsonRpcMessage>` from `JsonRpcRequestProcessor` instead of `null`
- Update server and client to handle Optional results when processing requests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d6c41eb9c83248002f18d3dc3fb84