### PR TITLE
Refactor RequestId encoding

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestIdCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestIdCodec.java
@@ -1,0 +1,35 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import jakarta.json.Json;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+public final class RequestIdCodec {
+    private RequestIdCodec() {
+    }
+
+    public static void add(JsonObjectBuilder builder, String key, RequestId id) {
+        builder.add(key, toJsonValue(id));
+    }
+
+    public static JsonValue toJsonValue(RequestId id) {
+        return switch (id) {
+            case RequestId.StringId s -> Json.createValue(s.value());
+            case RequestId.NumericId n -> Json.createValue(n.value());
+            case RequestId.NullId ignored -> JsonValue.NULL;
+        };
+    }
+
+    public static RequestId from(JsonValue value) {
+        if (value == null || value.getValueType() == JsonValue.ValueType.NULL) {
+            throw new IllegalArgumentException("id is required");
+        }
+        return switch (value.getValueType()) {
+            case STRING -> new RequestId.StringId(((JsonString) value).getString());
+            case NUMBER -> new RequestId.NumericId(((JsonNumber) value).longValue());
+            default -> throw new IllegalArgumentException("Invalid id type");
+        };
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/util/CancellationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/CancellationCodec.java
@@ -1,11 +1,10 @@
 package com.amannmalik.mcp.util;
 
 import com.amannmalik.mcp.jsonrpc.RequestId;
+import com.amannmalik.mcp.jsonrpc.RequestIdCodec;
 import jakarta.json.Json;
-import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
 public final class CancellationCodec {
@@ -14,29 +13,14 @@ public final class CancellationCodec {
 
     public static JsonObject toJsonObject(CancelledNotification note) {
         JsonObjectBuilder b = Json.createObjectBuilder();
-        switch (note.requestId()) {
-            case RequestId.StringId s -> b.add("requestId", s.value());
-            case RequestId.NumericId n -> b.add("requestId", n.value());
-            default -> throw new IllegalArgumentException("Invalid requestId type");
-        }
+        RequestIdCodec.add(b, "requestId", note.requestId());
         if (note.reason() != null) b.add("reason", note.reason());
         return b.build();
     }
 
     public static CancelledNotification toCancelledNotification(JsonObject obj) {
-        RequestId id = toId(obj.get("requestId"));
+        RequestId id = RequestIdCodec.from(obj.get("requestId"));
         String reason = obj.getString("reason", null);
         return new CancelledNotification(id, reason);
-    }
-
-    private static RequestId toId(JsonValue v) {
-        if (v == null || v.getValueType() == JsonValue.ValueType.NULL) {
-            throw new IllegalArgumentException("requestId is required");
-        }
-        return switch (v.getValueType()) {
-            case STRING -> new RequestId.StringId(((JsonString) v).getString());
-            case NUMBER -> new RequestId.NumericId(((JsonNumber) v).longValue());
-            default -> throw new IllegalArgumentException("Invalid requestId type");
-        };
     }
 }


### PR DESCRIPTION
## Summary
- centralize JSON-RPC request ID encoding/decoding in a new `RequestIdCodec`
- simplify `JsonRpcCodec` and `CancellationCodec` by reusing `RequestIdCodec`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d6cd072bc832488935093590e7e68