### PR TITLE
Refactor request processor to use Optional id tracker

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -141,7 +141,7 @@ public final class McpServer implements AutoCloseable {
     private final CancellationTracker cancellationTracker = new CancellationTracker();
     private final IdTracker idTracker = new IdTracker();
     private final JsonRpcRequestProcessor requestProcessor =
-            new JsonRpcRequestProcessor(progressManager, cancellationTracker, this::send, idTracker);
+            new JsonRpcRequestProcessor(progressManager, cancellationTracker, this::send, Optional.of(idTracker));
     private final ResourceProvider resources;
     private final ToolProvider tools;
     private final PromptProvider prompts;


### PR DESCRIPTION
## Summary
- simplify JSON-RPC request lifecycle by using `Optional<IdTracker>` instead of nullable field
- update server to pass `Optional` tracker

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d6cd072bc832488935093590e7e68