### PR TITLE
Refactor session & SSE management

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
@@ -1,0 +1,123 @@
+package com.amannmalik.mcp.transport;
+
+import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.util.Base64Util;
+import com.amannmalik.mcp.validation.InputSanitizer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+final class SessionManager {
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private final AtomicReference<String> sessionId = new AtomicReference<>();
+    private final AtomicReference<String> lastSessionId = new AtomicReference<>();
+    private final AtomicReference<String> sessionOwner = new AtomicReference<>();
+    private final AtomicReference<Principal> sessionPrincipal = new AtomicReference<>();
+    private volatile String protocolVersion;
+    private final String compatibilityVersion;
+
+    SessionManager(String compatibilityVersion) {
+        this.compatibilityVersion = compatibilityVersion;
+        this.protocolVersion = compatibilityVersion;
+    }
+
+    String protocolVersion() {
+        return protocolVersion;
+    }
+
+    void protocolVersion(String version) {
+        this.protocolVersion = version;
+    }
+
+    boolean validate(HttpServletRequest req,
+                     HttpServletResponse resp,
+                     Principal principal,
+                     boolean initializing) throws IOException {
+        String session = sessionId.get();
+        String last = lastSessionId.get();
+        String header = req.getHeader(TransportHeaders.SESSION_ID);
+        String version = req.getHeader(TransportHeaders.PROTOCOL_VERSION);
+        if (!sanitizeHeaders(header, version, resp)) {
+            return false;
+        }
+        return checkSession(req, resp, principal, initializing, session, last, header, version);
+    }
+
+    private boolean sanitizeHeaders(String sessionHeader,
+                                    String versionHeader,
+                                    HttpServletResponse resp) throws IOException {
+        if (sessionHeader != null && !InputSanitizer.isVisibleAscii(sessionHeader)) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+        if (versionHeader != null && !InputSanitizer.isVisibleAscii(versionHeader)) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkSession(HttpServletRequest req,
+                                 HttpServletResponse resp,
+                                 Principal principal,
+                                 boolean initializing,
+                                 String session,
+                                 String last,
+                                 String header,
+                                 String version) throws IOException {
+        if (session == null && initializing) {
+            byte[] bytes = new byte[32];
+            RANDOM.nextBytes(bytes);
+            session = Base64Util.encodeUrl(bytes);
+            sessionId.set(session);
+            sessionOwner.set(req.getRemoteAddr());
+            sessionPrincipal.set(principal);
+            lastSessionId.set(null);
+            resp.setHeader(TransportHeaders.SESSION_ID, session);
+            return true;
+        }
+        if (session == null) {
+            if (header != null && header.equals(last)) {
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            } else {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            }
+            return false;
+        }
+        if (header == null) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+        if (!session.equals(header) || !req.getRemoteAddr().equals(sessionOwner.get())) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return false;
+        }
+        var stored = sessionPrincipal.get();
+        if (stored != null && !stored.id().equals(principal.id())) {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+        if (!initializing && (version == null || !version.equals(protocolVersion))) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+        return true;
+    }
+
+    void terminate(boolean recordId) {
+        if (recordId) {
+            lastSessionId.set(sessionId.get());
+        } else {
+            lastSessionId.set(null);
+        }
+        sessionId.set(null);
+        sessionOwner.set(null);
+        sessionPrincipal.set(null);
+        protocolVersion = compatibilityVersion;
+    }
+}
+

--- a/src/main/java/com/amannmalik/mcp/transport/SseClient.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseClient.java
@@ -1,0 +1,95 @@
+package com.amannmalik.mcp.transport;
+
+import com.amannmalik.mcp.util.Base64Util;
+import jakarta.json.JsonObject;
+import jakarta.servlet.AsyncContext;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.SecureRandom;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicLong;
+
+final class SseClient implements AutoCloseable {
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int HISTORY_LIMIT = 100;
+
+    private AsyncContext context;
+    private PrintWriter out;
+    final String prefix;
+    private final Deque<SseEvent> history = new ArrayDeque<>();
+    private final AtomicLong nextId = new AtomicLong(1);
+    private volatile boolean closed;
+
+    SseClient(AsyncContext context) throws IOException {
+        byte[] bytes = new byte[8];
+        RANDOM.nextBytes(bytes);
+        this.prefix = Base64Util.encodeUrl(bytes);
+        attach(context, 0);
+    }
+
+    void attach(AsyncContext ctx, long lastId) throws IOException {
+        this.context = ctx;
+        this.out = ctx.getResponse().getWriter();
+        this.closed = false;
+        sendHistory(lastId);
+    }
+
+    boolean isActive() {
+        return !closed && context != null;
+    }
+
+    void send(JsonObject msg) {
+        long id = nextId.getAndIncrement();
+        history.addLast(new SseEvent(id, msg));
+        while (history.size() > HISTORY_LIMIT) {
+            history.removeFirst();
+        }
+        if (closed || context == null) {
+            return;
+        }
+        try {
+            out.write("id: " + prefix + '-' + id + "\n");
+            out.write("data: " + msg + "\n\n");
+            out.flush();
+        } catch (Exception e) {
+            System.err.println("SSE send failed: " + e.getMessage());
+            closed = true;
+        }
+    }
+
+    private void sendHistory(long lastId) throws IOException {
+        if (context == null) {
+            return;
+        }
+        for (SseEvent ev : history) {
+            if (ev.id > lastId) {
+                out.write("id: " + prefix + '-' + ev.id + "\n");
+                out.write("data: " + ev.msg + "\n\n");
+            }
+        }
+        out.flush();
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            if (context != null && !context.hasOriginalRequestAndResponse()) {
+                context.complete();
+            }
+        } catch (Exception e) {
+            System.err.println("SSE close failed: " + e.getMessage());
+        } finally {
+            context = null;
+            out = null;
+        }
+    }
+
+    private record SseEvent(long id, JsonObject msg) { }
+}
+


### PR DESCRIPTION
## Summary
- centralize session negotiation in dedicated SessionManager
- extract SSE client tracking into separate SseClient class
- streamline StreamableHttpTransport by delegating session lifecycle

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_688d6cea931c8324bae43facc1048e75