### PR TITLE
Refactor ping monitor and tighten JSON key checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
@@ -3,17 +3,19 @@ package com.amannmalik.mcp.ping;
 import com.amannmalik.mcp.client.McpClient;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class PingMonitor {
     private PingMonitor() {
     }
 
     public static boolean isAlive(McpClient client, long timeoutMillis) {
+        Objects.requireNonNull(client);
         try {
             client.ping(timeoutMillis);
             return true;
         } catch (IOException | RuntimeException e) {
-            if (System.err != null) System.err.println("Ping failure: " + e.getMessage());
+            System.err.println("Ping failure: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/com/amannmalik/mcp/util/JsonUtil.java
+++ b/src/main/java/com/amannmalik/mcp/util/JsonUtil.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.util;
 
 import jakarta.json.JsonObject;
 
+import java.util.Objects;
 import java.util.Set;
 
 public final class JsonUtil {
@@ -9,11 +10,10 @@ public final class JsonUtil {
     }
 
     public static void requireOnlyKeys(JsonObject obj, Set<String> allowed) {
-        if (obj == null || allowed == null) return;
+        Objects.requireNonNull(obj);
+        Objects.requireNonNull(allowed);
         for (String key : obj.keySet()) {
-            if (!allowed.contains(key)) {
-                throw new IllegalArgumentException("unexpected field: " + key);
-            }
+            if (!allowed.contains(key)) throw new IllegalArgumentException("unexpected field: " + key);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure PingMonitor validates the client and always logs ping failures
- require non-null inputs and fail-fast when unexpected JSON keys appear

## Testing
- `gradle check --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_688d72c649288324a08089435b83042f