### PR TITLE
Allow missing protocol version header after negotiation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
@@ -83,7 +83,7 @@ final class McpServlet extends HttpServlet {
                 }
                 resp.setContentType("application/json");
                 resp.setCharacterEncoding("UTF-8");
-                resp.setHeader(StreamableHttpTransport.PROTOCOL_HEADER, transport.sessions.protocolVersion());
+                resp.setHeader(TransportHeaders.PROTOCOL_VERSION, transport.sessions.protocolVersion());
                 resp.getWriter().write(response.toString());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -95,7 +95,7 @@ final class McpServlet extends HttpServlet {
             resp.setStatus(HttpServletResponse.SC_OK);
             resp.setContentType("text/event-stream;charset=UTF-8");
             resp.setHeader("Cache-Control", "no-cache");
-            resp.setHeader(StreamableHttpTransport.PROTOCOL_HEADER, transport.sessions.protocolVersion());
+            resp.setHeader(TransportHeaders.PROTOCOL_VERSION, transport.sessions.protocolVersion());
             resp.flushBuffer();
             AsyncContext ac = req.startAsync();
             ac.setTimeout(0);
@@ -124,7 +124,7 @@ final class McpServlet extends HttpServlet {
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType("text/event-stream;charset=UTF-8");
         resp.setHeader("Cache-Control", "no-cache");
-        resp.setHeader(StreamableHttpTransport.PROTOCOL_HEADER, transport.sessions.protocolVersion());
+        resp.setHeader(TransportHeaders.PROTOCOL_VERSION, transport.sessions.protocolVersion());
         resp.flushBuffer();
         AsyncContext ac = req.startAsync();
         ac.setTimeout(0);

--- a/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
@@ -101,9 +101,14 @@ final class SessionManager {
             resp.sendError(HttpServletResponse.SC_FORBIDDEN);
             return false;
         }
-        if (!initializing && (version == null || !version.equals(protocolVersion))) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-            return false;
+        if (!initializing) {
+            // Per spec 2025-06-18, the client should send MCP-Protocol-Version on
+            // subsequent requests. For backwards compatibility, tolerate a
+            // missing header when the negotiated version is already known.
+            if (version != null && !version.equals(protocolVersion)) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return false;
+            }
         }
         return true;
     }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -40,7 +40,6 @@ public final class StreamableHttpTransport implements Transport {
     final java.util.List<String> authorizationServers;
 
 
-    static final String PROTOCOL_HEADER = TransportHeaders.PROTOCOL_VERSION;
     // Default to the previous protocol revision when the version header is
     // absent, as recommended for backwards compatibility.
     static final String COMPATIBILITY_VERSION =

--- a/src/test/java/com/amannmalik/mcp/transport/SessionManagerTest.java
+++ b/src/test/java/com/amannmalik/mcp/transport/SessionManagerTest.java
@@ -1,0 +1,90 @@
+package com.amannmalik.mcp.transport;
+
+import com.amannmalik.mcp.auth.Principal;
+import com.amannmalik.mcp.lifecycle.Protocol;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionManagerTest {
+
+    private static HttpServletRequest request(String session, String version, String remote) {
+        Map<String, String> headers = new HashMap<>();
+        if (session != null) headers.put(TransportHeaders.SESSION_ID, session);
+        if (version != null) headers.put(TransportHeaders.PROTOCOL_VERSION, version);
+        InvocationHandler h = (proxy, method, args) -> switch (method.getName()) {
+            case "getHeader" -> headers.get(args[0]);
+            case "getRemoteAddr" -> remote;
+            default -> defaultValue(method);
+        };
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                h);
+    }
+
+    private static class ResponseHandler implements InvocationHandler {
+        int status;
+        final Map<String, String> headers = new HashMap<>();
+        @Override public Object invoke(Object proxy, Method method, Object[] args) {
+            return switch (method.getName()) {
+                case "setHeader" -> { headers.put((String) args[0], (String) args[1]); yield null; }
+                case "sendError" -> { status = (int) args[0]; yield null; }
+                default -> defaultValue(method);
+            };
+        }
+    }
+
+    private static HttpServletResponse response(ResponseHandler h) {
+        return (HttpServletResponse) Proxy.newProxyInstance(
+                HttpServletResponse.class.getClassLoader(),
+                new Class<?>[]{HttpServletResponse.class},
+                h);
+    }
+
+    private static Object defaultValue(Method m) {
+        Class<?> rt = m.getReturnType();
+        if (rt.equals(boolean.class)) return false;
+        if (rt.equals(int.class)) return 0;
+        if (rt.equals(long.class)) return 0L;
+        return null;
+    }
+
+    @Test
+    void allowsMissingProtocolHeaderWhenSessionEstablished() throws Exception {
+        SessionManager mgr = new SessionManager(Protocol.PREVIOUS_VERSION);
+        Principal p = new Principal("u", Set.of());
+
+        ResponseHandler initResp = new ResponseHandler();
+        assertTrue(mgr.validate(request(null, null, "127.0.0.1"), response(initResp), p, true));
+        String session = initResp.headers.get(TransportHeaders.SESSION_ID);
+        mgr.protocolVersion(Protocol.LATEST_VERSION);
+
+        ResponseHandler resp = new ResponseHandler();
+        assertTrue(mgr.validate(request(session, null, "127.0.0.1"), response(resp), p, false));
+        assertEquals(0, resp.status);
+    }
+
+    @Test
+    void rejectsMismatchedProtocolVersion() throws Exception {
+        SessionManager mgr = new SessionManager(Protocol.PREVIOUS_VERSION);
+        Principal p = new Principal("u", Set.of());
+        ResponseHandler initResp = new ResponseHandler();
+        assertTrue(mgr.validate(request(null, null, "127.0.0.1"), response(initResp), p, true));
+        String session = initResp.headers.get(TransportHeaders.SESSION_ID);
+        mgr.protocolVersion(Protocol.LATEST_VERSION);
+
+        ResponseHandler resp = new ResponseHandler();
+        assertFalse(mgr.validate(request(session, "2024-01-01", "127.0.0.1"), response(resp), p, false));
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, resp.status);
+    }
+}


### PR DESCRIPTION
## Summary
- allow established sessions without repeating `MCP-Protocol-Version`
- drop redundant protocol header constant
- test session manager header handling

## Testing
- `gradle test --rerun-tasks --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_688d72c649288324a08089435b83042f