### PR TITLE
Simplify error logging by removing redundant System.err null checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -715,7 +715,7 @@ public final class McpClient implements AutoCloseable {
         cancellationTracker.cancel(cn.requestId(), cn.reason());
         progressManager.release(cn.requestId());
         String reason = cancellationTracker.reason(cn.requestId());
-        if (reason != null && System.err != null) {
+        if (reason != null) {
             System.err.println("Request " + cn.requestId() + " cancelled: " + reason);
         }
     }

--- a/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingMonitor.java
@@ -13,7 +13,7 @@ public final class PingMonitor {
             client.ping(timeoutMillis);
             return true;
         } catch (IOException | RuntimeException e) {
-            if (System.err != null) System.err.println("Ping failure: " + e.getMessage());
+            System.err.println("Ping failure: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/com/amannmalik/mcp/ping/PingScheduler.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingScheduler.java
@@ -52,7 +52,7 @@ public final class PingScheduler implements AutoCloseable {
 
         failureCount++;
         if (failureCount >= maxFailures) {
-            if (System.err != null) System.err.println("Ping failed");
+            System.err.println("Ping failed");
             try {
                 onFailure.run();
             } catch (Exception ignore) {


### PR DESCRIPTION
## Summary
- drop no-op `System.err` null guards in ping monitor, ping scheduler, and cancellation handling

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688d70713e808324ad52d6f1f11067d2