### PR TITLE
Refactor schema validator and add tests

### DIFF
--- a/src/main/java/com/amannmalik/mcp/validation/SchemaValidator.java
+++ b/src/main/java/com/amannmalik/mcp/validation/SchemaValidator.java
@@ -16,82 +16,95 @@ public final class SchemaValidator {
 
     public static void validate(JsonObject schema, JsonObject value) {
         if (schema == null) return;
-        if ("object".equals(schema.getString("type", null))) {
-            JsonArray required = schema.getJsonArray("required");
-            if (required != null) {
-                for (JsonString r : required.getValuesAs(JsonString.class)) {
-                    if (!value.containsKey(r.getString())) {
-                        throw new IllegalArgumentException("Missing required field: " + r.getString());
-                    }
+        if (!"object".equals(schema.getString("type", null))) return;
+        validateObject(schema, value);
+    }
+
+    private static void validateObject(JsonObject schema, JsonObject value) {
+        JsonArray required = schema.getJsonArray("required");
+        if (required != null) {
+            for (JsonString r : required.getValuesAs(JsonString.class)) {
+                if (!value.containsKey(r.getString())) {
+                    throw new IllegalArgumentException("Missing required field: " + r.getString());
                 }
             }
-            JsonObject props = schema.getJsonObject("properties");
-            if (props != null) {
-                for (var e : props.entrySet()) {
-                    String name = e.getKey();
-                    JsonObject prop = e.getValue().asJsonObject();
-                    if (!value.containsKey(name)) continue;
-                    String t = prop.getString("type", null);
-                    if (t != null) {
-                        JsonValue v = value.get(name);
-                        switch (t) {
-                            case "string" -> {
-                                requireType(v, JsonValue.ValueType.STRING, name);
-                                String str = ((JsonString) v).getString();
-                                if (prop.containsKey("minLength") && str.length() < prop.getInt("minLength")) {
-                                    throw new IllegalArgumentException("minLength violated for " + name);
-                                }
-                                if (prop.containsKey("maxLength") && str.length() > prop.getInt("maxLength")) {
-                                    throw new IllegalArgumentException("maxLength violated for " + name);
-                                }
-                                if (prop.containsKey("enum")) {
-                                    boolean match = prop.getJsonArray("enum")
-                                            .getValuesAs(JsonString.class)
-                                            .stream()
-                                            .anyMatch(js -> js.getString().equals(str));
-                                    if (!match) {
-                                        throw new IllegalArgumentException("enum violation for " + name);
-                                    }
-                                }
-                                if (prop.containsKey("format")) {
-                                    String fmt = prop.getString("format");
-                                    validateFormat(str, fmt, name);
-                                }
-                            }
-                            case "number" -> {
-                                requireType(v, JsonValue.ValueType.NUMBER, name);
-                                double num = ((JsonNumber) v).doubleValue();
-                                if (prop.containsKey("minimum") && num < prop.getJsonNumber("minimum").doubleValue()) {
-                                    throw new IllegalArgumentException("minimum violated for " + name);
-                                }
-                                if (prop.containsKey("maximum") && num > prop.getJsonNumber("maximum").doubleValue()) {
-                                    throw new IllegalArgumentException("maximum violated for " + name);
-                                }
-                            }
-                            case "integer" -> {
-                                requireInteger(v, name);
-                                long num = ((JsonNumber) v).longValue();
-                                if (prop.containsKey("minimum") && num < prop.getJsonNumber("minimum").longValue()) {
-                                    throw new IllegalArgumentException("minimum violated for " + name);
-                                }
-                                if (prop.containsKey("maximum") && num > prop.getJsonNumber("maximum").longValue()) {
-                                    throw new IllegalArgumentException("maximum violated for " + name);
-                                }
-                            }
-                            case "boolean" -> requireType(v, JsonValue.ValueType.TRUE, JsonValue.ValueType.FALSE, name);
-                            case "array" -> requireType(v, JsonValue.ValueType.ARRAY, name);
-                            case "object" -> validate(prop, value.getJsonObject(name));
-                            default -> {
-                            }
-                        }
-                    }
-                }
-                for (String key : value.keySet()) {
-                    if (!props.containsKey(key)) {
-                        throw new IllegalArgumentException("Unexpected field: " + key);
-                    }
-                }
+        }
+        JsonObject props = schema.getJsonObject("properties");
+        if (props == null) return;
+        for (var e : props.entrySet()) {
+            String name = e.getKey();
+            if (!value.containsKey(name)) continue;
+            JsonObject prop = e.getValue().asJsonObject();
+            JsonValue v = value.get(name);
+            validateProperty(name, prop, v);
+        }
+        for (String key : value.keySet()) {
+            if (!props.containsKey(key)) {
+                throw new IllegalArgumentException("Unexpected field: " + key);
             }
+        }
+    }
+
+    private static void validateProperty(String name, JsonObject schema, JsonValue value) {
+        String t = schema.getString("type", null);
+        if (t == null) return;
+        switch (t) {
+            case "string" -> validateString(name, value, schema);
+            case "number" -> validateNumber(name, value, schema);
+            case "integer" -> validateInteger(name, value, schema);
+            case "boolean" -> requireType(value, JsonValue.ValueType.TRUE, JsonValue.ValueType.FALSE, name);
+            case "array" -> requireType(value, JsonValue.ValueType.ARRAY, name);
+            case "object" -> {
+                requireType(value, JsonValue.ValueType.OBJECT, name);
+                validate(schema, value.asJsonObject());
+            }
+            default -> {
+            }
+        }
+    }
+
+    private static void validateString(String field, JsonValue v, JsonObject schema) {
+        requireType(v, JsonValue.ValueType.STRING, field);
+        String str = ((JsonString) v).getString();
+        if (schema.containsKey("minLength") && str.length() < schema.getInt("minLength")) {
+            throw new IllegalArgumentException("minLength violated for " + field);
+        }
+        if (schema.containsKey("maxLength") && str.length() > schema.getInt("maxLength")) {
+            throw new IllegalArgumentException("maxLength violated for " + field);
+        }
+        if (schema.containsKey("enum")) {
+            boolean match = schema.getJsonArray("enum")
+                    .getValuesAs(JsonString.class)
+                    .stream()
+                    .anyMatch(js -> js.getString().equals(str));
+            if (!match) {
+                throw new IllegalArgumentException("enum violation for " + field);
+            }
+        }
+        if (schema.containsKey("format")) {
+            validateFormat(str, schema.getString("format"), field);
+        }
+    }
+
+    private static void validateNumber(String field, JsonValue v, JsonObject schema) {
+        requireType(v, JsonValue.ValueType.NUMBER, field);
+        double num = ((JsonNumber) v).doubleValue();
+        if (schema.containsKey("minimum") && num < schema.getJsonNumber("minimum").doubleValue()) {
+            throw new IllegalArgumentException("minimum violated for " + field);
+        }
+        if (schema.containsKey("maximum") && num > schema.getJsonNumber("maximum").doubleValue()) {
+            throw new IllegalArgumentException("maximum violated for " + field);
+        }
+    }
+
+    private static void validateInteger(String field, JsonValue v, JsonObject schema) {
+        requireInteger(v, field);
+        long num = ((JsonNumber) v).longValue();
+        if (schema.containsKey("minimum") && num < schema.getJsonNumber("minimum").longValue()) {
+            throw new IllegalArgumentException("minimum violated for " + field);
+        }
+        if (schema.containsKey("maximum") && num > schema.getJsonNumber("maximum").longValue()) {
+            throw new IllegalArgumentException("maximum violated for " + field);
         }
     }
 

--- a/src/test/java/com/amannmalik/mcp/validation/SchemaValidatorTest.java
+++ b/src/test/java/com/amannmalik/mcp/validation/SchemaValidatorTest.java
@@ -1,0 +1,36 @@
+package com.amannmalik.mcp.validation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SchemaValidatorTest {
+    @Test
+    public void failsOnMissingRequiredField() {
+        JsonObject schema = Json.createObjectBuilder()
+                .add("type", "object")
+                .add("required", Json.createArrayBuilder().add("a"))
+                .add("properties", Json.createObjectBuilder()
+                        .add("a", Json.createObjectBuilder().add("type", "string")))
+                .build();
+        JsonObject value = Json.createObjectBuilder().build();
+        assertThrows(IllegalArgumentException.class, () -> SchemaValidator.validate(schema, value));
+    }
+
+    @Test
+    public void validatesStringFormat() {
+        JsonObject schema = Json.createObjectBuilder()
+                .add("type", "object")
+                .add("properties", Json.createObjectBuilder()
+                        .add("email", Json.createObjectBuilder()
+                                .add("type", "string")
+                                .add("format", "email")))
+                .build();
+        JsonObject good = Json.createObjectBuilder().add("email", "a@b.c").build();
+        assertDoesNotThrow(() -> SchemaValidator.validate(schema, good));
+        JsonObject bad = Json.createObjectBuilder().add("email", "not an email").build();
+        assertThrows(IllegalArgumentException.class, () -> SchemaValidator.validate(schema, bad));
+    }
+}


### PR DESCRIPTION
## Summary
- factor SchemaValidator into focused helper methods for readability
- cover required fields and string format validation in new unit tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d70713e808324ad52d6f1f11067d2