### PR TITLE
Simplify pagination decoding

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/PaginationCodec.java
+++ b/src/main/java/com/amannmalik/mcp/util/PaginationCodec.java
@@ -21,10 +21,9 @@ public final class PaginationCodec {
     }
 
     public static PaginatedRequest toPaginatedRequest(JsonObject obj) {
-        if (obj != null) JsonUtil.requireOnlyKeys(obj, REQUEST_KEYS);
-        String cursor = obj == null ? null : obj.getString("cursor", null);
-        JsonObject meta = obj == null ? null : obj.getJsonObject("_meta");
-        return new PaginatedRequest(cursor, meta);
+        if (obj == null) return new PaginatedRequest(null, null);
+        JsonUtil.requireOnlyKeys(obj, REQUEST_KEYS);
+        return new PaginatedRequest(obj.getString("cursor", null), obj.getJsonObject("_meta"));
     }
 
     public static JsonObject toJsonObject(PaginatedResult result) {
@@ -35,9 +34,8 @@ public final class PaginationCodec {
     }
 
     public static PaginatedResult toPaginatedResult(JsonObject obj) {
-        if (obj != null) JsonUtil.requireOnlyKeys(obj, RESULT_KEYS);
-        String cursor = obj == null ? null : obj.getString("nextCursor", null);
-        JsonObject meta = obj == null ? null : obj.getJsonObject("_meta");
-        return new PaginatedResult(cursor, meta);
+        if (obj == null) return new PaginatedResult(null, null);
+        JsonUtil.requireOnlyKeys(obj, RESULT_KEYS);
+        return new PaginatedResult(obj.getString("nextCursor", null), obj.getJsonObject("_meta"));
     }
 }

--- a/src/test/java/com/amannmalik/mcp/util/PaginationCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/util/PaginationCodecTest.java
@@ -1,0 +1,22 @@
+package com.amannmalik.mcp.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class PaginationCodecTest {
+    @Test
+    void nullRequest() {
+        var r = PaginationCodec.toPaginatedRequest(null);
+        assertNull(r.cursor());
+        assertNull(r._meta());
+    }
+
+    @Test
+    void nullResult() {
+        var r = PaginationCodec.toPaginatedResult(null);
+        assertNull(r.nextCursor());
+        assertNull(r._meta());
+    }
+}
+


### PR DESCRIPTION
## Summary
- streamline pagination decoding by removing repeated null checks and adopting early returns
- add tests confirming pagination codecs gracefully handle null input

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_688d72c649288324a08089435b83042f