### PR TITLE
Refactor wire method lookup

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -62,8 +62,6 @@ import com.amannmalik.mcp.util.ProgressListener;
 import com.amannmalik.mcp.util.ProgressManager;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
-import com.amannmalik.mcp.util.ProgressUtil;
-import com.amannmalik.mcp.util.JsonRpcRequestProcessor;
 import com.amannmalik.mcp.util.Timeouts;
 import com.amannmalik.mcp.jsonrpc.RpcHandlerRegistry;
 import com.amannmalik.mcp.validation.SchemaValidator;

--- a/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/NotificationMethod.java
@@ -1,9 +1,6 @@
 package com.amannmalik.mcp.wire;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public enum NotificationMethod implements WireMethod {
     INITIALIZED("notifications/initialized"),
@@ -17,8 +14,6 @@ public enum NotificationMethod implements WireMethod {
     ROOTS_LIST_CHANGED("notifications/roots/list_changed");
 
     private final String method;
-    private static final Map<String, NotificationMethod> BY_METHOD = Arrays.stream(values())
-            .collect(Collectors.toUnmodifiableMap(NotificationMethod::method, e -> e));
 
     NotificationMethod(String method) {
         this.method = method;
@@ -29,8 +24,7 @@ public enum NotificationMethod implements WireMethod {
     }
 
     public static Optional<NotificationMethod> from(String method) {
-        if (method == null) return Optional.empty();
-        return Optional.ofNullable(BY_METHOD.get(method));
+        return WireMethod.from(NotificationMethod.class, method);
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
@@ -2,10 +2,7 @@ package com.amannmalik.mcp.wire;
 
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public enum RequestMethod implements WireMethod {
     INITIALIZE("initialize"),
@@ -27,8 +24,6 @@ public enum RequestMethod implements WireMethod {
 
     private final String method;
     private final Optional<ServerCapability> capability;
-    private static final Map<String, RequestMethod> BY_METHOD = Arrays.stream(values())
-            .collect(Collectors.toUnmodifiableMap(RequestMethod::method, e -> e));
 
     RequestMethod(String method) {
         this.method = method;
@@ -45,8 +40,7 @@ public enum RequestMethod implements WireMethod {
     }
 
     public static Optional<RequestMethod> from(String method) {
-        if (method == null) return Optional.empty();
-        return Optional.ofNullable(BY_METHOD.get(method));
+        return WireMethod.from(RequestMethod.class, method);
     }
 
     public Optional<ServerCapability> requiredCapability() {

--- a/src/main/java/com/amannmalik/mcp/wire/WireMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/WireMethod.java
@@ -1,6 +1,16 @@
 package com.amannmalik.mcp.wire;
 
+import java.util.Optional;
+
 /** Common interface for request and notification method enums. */
 public sealed interface WireMethod permits RequestMethod, NotificationMethod {
     String method();
+
+    static <T extends Enum<T> & WireMethod> Optional<T> from(Class<T> type, String method) {
+        if (method == null) return Optional.empty();
+        for (T value : type.getEnumConstants()) {
+            if (value.method().equals(method)) return Optional.of(value);
+        }
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
## Summary
- centralize method lookup in `WireMethod.from`
- drop redundant per-enum lookup maps
- tidy client imports

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_688e05ff83d083248794d503525a53bc