### PR TITLE
Refactor server loop

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -62,8 +62,6 @@ import com.amannmalik.mcp.util.ProgressManager;
 import com.amannmalik.mcp.util.ProgressNotification;
 import com.amannmalik.mcp.util.ProgressToken;
 import com.amannmalik.mcp.util.ListChangeSubscription;
-import com.amannmalik.mcp.util.ProgressUtil;
-import com.amannmalik.mcp.util.JsonRpcRequestProcessor;
 import com.amannmalik.mcp.util.Timeouts;
 import com.amannmalik.mcp.jsonrpc.RpcHandlerRegistry;
 import com.amannmalik.mcp.validation.SchemaValidator;


### PR DESCRIPTION
## Summary
- streamline `McpServer`'s message loop into discrete helper methods for receiving, parsing, and error handling
- remove stale `ProgressUtil` import from `McpClient`

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e0715de5883248208a9d09eefb9e9