### PR TITLE
Fix MCP HTTP transport authorization when no auth manager

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -238,8 +238,10 @@ public final class StreamableHttpTransport implements Transport {
         };
     }
 
+    private static final Principal DEFAULT_PRINCIPAL = new Principal("default", Set.of());
+
     Principal authorize(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        if (authManager == null) return null;
+        if (authManager == null) return DEFAULT_PRINCIPAL;
         try {
             return authManager.authorize(req.getHeader("Authorization"));
         } catch (AuthorizationException e) {


### PR DESCRIPTION
## Summary
- return default principal when StreamableHttpTransport has no AuthorizationManager to prevent server errors during initialization

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e0c7ea220832483007c8609a5e35e