### PR TITLE
Refactor protocol helpers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RpcHandlerRegistry.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RpcHandlerRegistry.java
@@ -4,7 +4,6 @@ import com.amannmalik.mcp.util.JsonRpcRequestProcessor;
 import com.amannmalik.mcp.wire.NotificationMethod;
 import com.amannmalik.mcp.wire.RequestMethod;
 
-import java.io.IOException;
 import java.util.*;
 
 public final class RpcHandlerRegistry {
@@ -24,7 +23,7 @@ public final class RpcHandlerRegistry {
         notificationHandlers.put(method, handler);
     }
 
-    public Optional<JsonRpcMessage> handle(JsonRpcRequest req, boolean cancellable) throws IOException {
+    public Optional<JsonRpcMessage> handle(JsonRpcRequest req, boolean cancellable) {
         return processor.process(req, cancellable, r -> {
             var method = RequestMethod.from(r.method());
             if (method.isEmpty()) {
@@ -38,7 +37,7 @@ public final class RpcHandlerRegistry {
         });
     }
 
-    public void handle(JsonRpcNotification note) throws IOException {
+    public void handle(JsonRpcNotification note) {
         var method = NotificationMethod.from(note.method());
         if (method.isEmpty()) return;
         var handler = notificationHandlers.get(method.get());
@@ -52,6 +51,6 @@ public final class RpcHandlerRegistry {
 
     @FunctionalInterface
     public interface NotificationHandler {
-        void handle(JsonRpcNotification notification) throws IOException;
+        void handle(JsonRpcNotification notification);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
@@ -5,7 +5,6 @@ import com.amannmalik.mcp.wire.RequestMethod;
 import jakarta.json.*;
 import jakarta.json.stream.JsonParsingException;
 import jakarta.servlet.AsyncContext;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.*;
 
 import java.io.IOException;
@@ -19,7 +18,7 @@ final class McpServlet extends HttpServlet {
     }
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         Principal principal = transport.authorize(req, resp);
         if (principal == null && transport.authManager != null) return;
         if (!transport.verifyOrigin(req, resp)) return;

--- a/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
@@ -52,11 +52,11 @@ final class SessionManager {
     private boolean sanitizeHeaders(String sessionHeader,
                                     String versionHeader,
                                     HttpServletResponse resp) throws IOException {
-        if (sessionHeader != null && !InputSanitizer.isVisibleAscii(sessionHeader)) {
+        if (sessionHeader != null && InputSanitizer.containsNonVisibleAscii(sessionHeader)) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return false;
         }
-        if (versionHeader != null && !InputSanitizer.isVisibleAscii(versionHeader)) {
+        if (versionHeader != null && InputSanitizer.containsNonVisibleAscii(versionHeader)) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return false;
         }

--- a/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
+++ b/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
@@ -39,7 +39,7 @@ public final class JsonRpcRequestProcessor {
             JsonRpcRequest req,
             boolean cancellable,
             Function<JsonRpcRequest, JsonRpcMessage> handler
-    ) throws IOException {
+    ) {
         if (req == null || handler == null) throw new IllegalArgumentException("request and handler required");
         if (idTracker != null) {
             try {

--- a/src/main/java/com/amannmalik/mcp/validation/InputSanitizer.java
+++ b/src/main/java/com/amannmalik/mcp/validation/InputSanitizer.java
@@ -7,13 +7,13 @@ public final class InputSanitizer {
     private InputSanitizer() {
     }
 
-    public static boolean isVisibleAscii(String value) {
-        if (value == null) return false;
+    public static boolean containsNonVisibleAscii(String value) {
+        if (value == null) return true;
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
-            if (c < 0x21 || c > 0x7E) return false;
+            if (c < 0x21 || c > 0x7E) return true;
         }
-        return true;
+        return false;
     }
 
     public static String requireClean(String value) {

--- a/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.wire;
 
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 
+import java.util.EnumSet;
 import java.util.Optional;
 
 public enum RequestMethod implements WireMethod {
@@ -23,16 +24,16 @@ public enum RequestMethod implements WireMethod {
     ELICITATION_CREATE("elicitation/create");
 
     private final String method;
-    private final Optional<ServerCapability> capability;
+    private final EnumSet<ServerCapability> capabilities;
 
     RequestMethod(String method) {
         this.method = method;
-        this.capability = Optional.empty();
+        this.capabilities = EnumSet.noneOf(ServerCapability.class);
     }
 
     RequestMethod(String method, ServerCapability capability) {
         this.method = method;
-        this.capability = Optional.of(capability);
+        this.capabilities = EnumSet.of(capability);
     }
 
     public String method() {
@@ -44,6 +45,6 @@ public enum RequestMethod implements WireMethod {
     }
 
     public Optional<ServerCapability> requiredCapability() {
-        return capability;
+        return capabilities.stream().findFirst();
     }
 }


### PR DESCRIPTION
## Summary
- replace enum capability Optional with EnumSet and compute capability on demand
- inline request processors and drop unused checked exceptions
- sanitize session headers using visible ASCII check

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e1412e9408324b470a7fea281a55f