### PR TITLE
Refactor request validation to avoid inverted checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
@@ -52,13 +52,19 @@ final class SessionManager {
     private boolean sanitizeHeaders(String sessionHeader,
                                     String versionHeader,
                                     HttpServletResponse resp) throws IOException {
-        if (sessionHeader != null && !InputSanitizer.isVisibleAscii(sessionHeader)) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-            return false;
+        if (sessionHeader != null) {
+            boolean ok = InputSanitizer.isVisibleAscii(sessionHeader);
+            if (!ok) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return false;
+            }
         }
-        if (versionHeader != null && !InputSanitizer.isVisibleAscii(versionHeader)) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-            return false;
+        if (versionHeader != null) {
+            boolean ok = InputSanitizer.isVisibleAscii(versionHeader);
+            if (!ok) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return false;
+            }
         }
         return true;
     }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -212,11 +212,13 @@ public final class StreamableHttpTransport implements Transport {
     }
 
     boolean verifyOrigin(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        if (!originValidator.isValid(req.getHeader("Origin"))) {
+        try {
+            originValidator.requireValid(req.getHeader("Origin"));
+            return true;
+        } catch (SecurityException e) {
             resp.sendError(HttpServletResponse.SC_FORBIDDEN);
             return false;
         }
-        return true;
     }
 
     boolean validateAccept(HttpServletRequest req, HttpServletResponse resp, boolean post) throws IOException {


### PR DESCRIPTION
## Summary
- refactor session, origin, and accept validation to avoid inverted boolean calls
- streamline JWT claim checks with explicit `requireMatch`
- simplify header sanitization logic to reduce negation

## Testing
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_688e13b952b8832485addac1f13e0674