### PR TITLE
Replace null-based wiring with Optionals

### DIFF
--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -28,7 +28,7 @@ public final class HostCommand implements Callable<Integer> {
     private boolean verbose;
 
     @CommandLine.Option(names = "--client", description = "Client as id:command", split = ",")
-    private List<String> clientSpecs;
+    private List<String> clientSpecs = new ArrayList<>();
 
     @CommandLine.Option(names = "--interactive", description = "Interactive mode for client management")
     private boolean interactive;
@@ -51,9 +51,7 @@ public final class HostCommand implements Callable<Integer> {
             if (!(loaded instanceof HostConfig hc)) throw new IllegalArgumentException("host config expected");
             cfg = hc;
         } else {
-            if (clientSpecs == null || clientSpecs.isEmpty()) {
-                throw new IllegalArgumentException("--client required");
-            }
+            if (clientSpecs.isEmpty()) throw new IllegalArgumentException("--client required");
             Map<String, String> map = new LinkedHashMap<>();
             for (String spec : clientSpecs) {
                 int idx = spec.indexOf(':');

--- a/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
@@ -20,8 +20,9 @@ final class McpServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        Principal principal = transport.authorize(req, resp);
-        if (principal == null && transport.authManager != null) return;
+        var principalOpt = transport.authorize(req, resp);
+        if (principalOpt.isEmpty()) return;
+        var principal = principalOpt.get();
         if (!transport.verifyOrigin(req, resp)) return;
         if (!transport.validateAccept(req, resp, true)) return;
 
@@ -113,11 +114,11 @@ final class McpServlet extends HttpServlet {
                                           HttpServletResponse resp,
                                           boolean requireAccept,
                                           boolean post) throws IOException {
-        Principal principal = transport.authorize(req, resp);
-        if (principal == null) return Optional.empty();
+        var principalOpt = transport.authorize(req, resp);
+        if (principalOpt.isEmpty()) return Optional.empty();
         if (!transport.verifyOrigin(req, resp)) return Optional.empty();
         if (requireAccept && !transport.validateAccept(req, resp, post)) return Optional.empty();
-        return Optional.of(principal);
+        return principalOpt;
     }
 
     private void enqueue(JsonObject obj, HttpServletResponse resp) throws IOException {

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -201,13 +201,13 @@ public final class StreamableHttpTransport implements Transport {
 
     private static final Principal DEFAULT_PRINCIPAL = new Principal("default", Set.of());
 
-    Principal authorize(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        if (authManager == null) return DEFAULT_PRINCIPAL;
+    Optional<Principal> authorize(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        if (authManager == null) return Optional.of(DEFAULT_PRINCIPAL);
         try {
-            return authManager.authorize(req.getHeader("Authorization"));
+            return Optional.of(authManager.authorize(req.getHeader("Authorization")));
         } catch (AuthorizationException e) {
             unauthorized(resp);
-            return null;
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
## Summary
- initialize HostCommand client specs to prevent accidental null and enforce required client argument
- return Optional from StreamableHttpTransport authorization to avoid null sentinels
- propagate Optional authorization through McpServlet, dropping null checks

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e18a038a4832482dae405f3adf138