### PR TITLE
Use ToolCodec for tool requests

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -7,10 +7,8 @@ import com.amannmalik.mcp.lifecycle.ClientCapability;
 import com.amannmalik.mcp.lifecycle.ServerCapability;
 import com.amannmalik.mcp.prompts.Role;
 import com.amannmalik.mcp.server.tools.*;
-import com.amannmalik.mcp.util.PaginatedRequest;
-import com.amannmalik.mcp.util.PaginationCodec;
 import com.amannmalik.mcp.wire.RequestMethod;
-import jakarta.json.*;
+import jakarta.json.JsonObject;
 
 import java.io.IOException;
 import java.util.*;
@@ -140,8 +138,10 @@ public final class HostProcess implements AutoCloseable {
         McpClient client = clients.get(clientId);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, ServerCapability.TOOLS);
-        JsonObject params = PaginationCodec.toJsonObject(new PaginatedRequest(cursor, null));
-        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_LIST, params);
+        JsonRpcMessage resp = client.request(
+                RequestMethod.TOOLS_LIST,
+                ToolCodec.toJsonObject(new ListToolsRequest(cursor, null))
+        );
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toListToolsResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");
@@ -153,11 +153,10 @@ public final class HostProcess implements AutoCloseable {
         requireCapability(client, ServerCapability.TOOLS);
         consents.requireConsent(principal, "tool:" + name);
         toolAccess.requireAllowed(principal, name);
-        JsonObject params = Json.createObjectBuilder()
-                .add("name", name)
-                .add("arguments", args == null ? JsonValue.EMPTY_JSON_OBJECT : args)
-                .build();
-        JsonRpcMessage resp = client.request(RequestMethod.TOOLS_CALL, params);
+        JsonRpcMessage resp = client.request(
+                RequestMethod.TOOLS_CALL,
+                ToolCodec.toJsonObject(new CallToolRequest(name, args, null))
+        );
         if (resp instanceof JsonRpcResponse r) return ToolCodec.toToolResult(r.result());
         if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
         throw new IOException("Unexpected response");

--- a/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ToolCodec.java
@@ -30,6 +30,15 @@ public final class ToolCodec {
         return PaginationCodec.toJsonObject(new PaginatedRequest(req.cursor(), req._meta()));
     }
 
+    public static JsonObject toJsonObject(CallToolRequest req) {
+        if (req == null) throw new IllegalArgumentException("request required");
+        JsonObjectBuilder builder = Json.createObjectBuilder()
+                .add("name", req.name())
+                .add("arguments", req.arguments());
+        if (req._meta() != null) builder.add("_meta", req._meta());
+        return builder.build();
+    }
+
     public static JsonObject toJsonObject(ListToolsResult page) {
         return toJsonObject(new Pagination.Page<>(page.tools(), page.nextCursor()), page._meta());
     }


### PR DESCRIPTION
## Summary
- Route `tools/list` and `tools/call` through `ToolCodec` for consistent request handling
- Add `ToolCodec.toJsonObject(CallToolRequest)` for encoding tool invocations

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e27182708832499f65183cb25749a