### PR TITLE
Add HTTP GET listener for server events

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -142,6 +142,14 @@ public final class McpClient implements AutoCloseable {
         JsonRpcMessage msg = sendInitialization();
         handleInitialization(msg);
         notifyInitialized();
+        if (transport instanceof StreamableHttpClientTransport http) {
+            try {
+                http.listen();
+            } catch (UnauthorizedException e) {
+                handleUnauthorized(e);
+                throw e;
+            }
+        }
         connected = true;
         subscribeRootsIfNeeded();
         startBackgroundTasks();


### PR DESCRIPTION
## Summary
- open an SSE stream via HTTP GET in `StreamableHttpClientTransport`
- call the new listener when connecting so the server's `doGet` endpoint is used

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e341e13e883249d98f04332709437