### PR TITLE
Handle null JSON-RPC ids

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcCodec.java
@@ -76,7 +76,7 @@ public final class JsonRpcCodec {
         if (hasError) {
             RequestId id;
             if (idValue == null || idValue.getValueType() == JsonValue.ValueType.NULL) {
-                id = new RequestId.NullId();
+                id = RequestId.NullId.INSTANCE;
             } else {
                 id = RequestIdCodec.from(idValue);
             }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/RequestId.java
@@ -4,6 +4,7 @@ public sealed interface RequestId permits RequestId.StringId, RequestId.NumericI
 
     static RequestId parse(String raw) {
         if (raw == null) throw new IllegalArgumentException("raw required");
+        if (raw.equals("null")) return NullId.INSTANCE;
         if (raw.startsWith("\"") && raw.endsWith("\"") && raw.length() > 1) {
             return new StringId(raw.substring(1, raw.length() - 1));
         }
@@ -28,10 +29,9 @@ public sealed interface RequestId permits RequestId.StringId, RequestId.NumericI
         }
     }
 
-    /**
-     * Represents a missing ID for error responses.
-     */
-    final class NullId implements RequestId {
+    enum NullId implements RequestId {
+        INSTANCE;
+
         @Override
         public String toString() {
             return "null";

--- a/src/main/java/com/amannmalik/mcp/server/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/server/McpServer.java
@@ -230,7 +230,7 @@ public final class McpServer implements AutoCloseable {
         System.err.println("Parse error: " + e.getMessage());
         try {
             sendLog(LoggingLevel.ERROR, "parser", Json.createValue(e.getMessage()));
-            send(JsonRpcError.of(new RequestId.NullId(), JsonRpcErrorCode.PARSE_ERROR, e.getMessage()));
+            send(JsonRpcError.of(RequestId.NullId.INSTANCE, JsonRpcErrorCode.PARSE_ERROR, e.getMessage()));
         } catch (IOException ioe) {
             System.err.println("Failed to send error: " + ioe.getMessage());
         }
@@ -257,7 +257,7 @@ public final class McpServer implements AutoCloseable {
         System.err.println("Invalid request: " + e.getMessage());
         try {
             sendLog(LoggingLevel.WARNING, "server", Json.createValue(e.getMessage()));
-            send(JsonRpcError.of(new RequestId.NullId(), JsonRpcErrorCode.INVALID_REQUEST, e.getMessage()));
+            send(JsonRpcError.of(RequestId.NullId.INSTANCE, JsonRpcErrorCode.INVALID_REQUEST, e.getMessage()));
         } catch (IOException ioe) {
             System.err.println("Failed to send error: " + ioe.getMessage());
         }

--- a/src/test/java/com/amannmalik/mcp/jsonrpc/RequestIdTest.java
+++ b/src/test/java/com/amannmalik/mcp/jsonrpc/RequestIdTest.java
@@ -1,0 +1,22 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class RequestIdTest {
+    @Test
+    void parse() {
+        RequestId numeric = RequestId.parse("7");
+        assertTrue(numeric instanceof RequestId.NumericId);
+        assertEquals("7", numeric.toString());
+
+        RequestId string = RequestId.parse("\"x\"");
+        assertTrue(string instanceof RequestId.StringId);
+        assertEquals("x", string.toString());
+
+        RequestId nullId = RequestId.parse("null");
+        assertSame(RequestId.NullId.INSTANCE, nullId);
+        assertEquals("null", nullId.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- parse "null" as a dedicated JSON-RPC id value
- use a singleton enum for missing request ids
- cover id parsing logic

## Testing
- `gradle test`
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e3b1172308324b4cc68a84fac2f23