### PR TITLE
Handle null URIs in RootChecker

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/RootChecker.java
+++ b/src/main/java/com/amannmalik/mcp/util/RootChecker.java
@@ -14,6 +14,7 @@ public final class RootChecker {
 
     public static boolean withinRoots(String uri, List<Root> roots) {
         Objects.requireNonNull(roots);
+        if (uri == null) return false;
         final URI target;
         try {
             target = URI.create(uri);

--- a/src/test/java/com/amannmalik/mcp/util/RootCheckerTest.java
+++ b/src/test/java/com/amannmalik/mcp/util/RootCheckerTest.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.util;
+
+import com.amannmalik.mcp.client.roots.Root;
+import jakarta.json.Json;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class RootCheckerTest {
+    @Test
+    void nullUriIsOutsideRoots() throws Exception {
+        var dir = Files.createTempDirectory("root");
+        var root = new Root(dir.toUri().toString(), null, Json.createObjectBuilder().build());
+        assertFalse(RootChecker.withinRoots(null, List.of(root)));
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null URIs in RootChecker
- add regression test for null URIs

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_688e3b1172308324b4cc68a84fac2f23