### PR TITLE
Handle CLI parse errors

### DIFF
--- a/src/main/java/com/amannmalik/mcp/Main.java
+++ b/src/main/java/com/amannmalik/mcp/Main.java
@@ -4,46 +4,50 @@ import com.amannmalik.mcp.cli.*;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.ParseResult;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.UnmatchedArgumentException;
 
 public final class Main {
     public static void main(String[] args) {
         CommandSpec mainSpec = CommandSpec.create()
                 .name("mcp")
                 .mixinStandardHelpOptions(true);
-        
-        CommandSpec serverSpec = ServerCommand.createCommandSpec();
-        CommandSpec clientSpec = ClientCommand.createCommandSpec();
-        CommandSpec hostSpec = HostCommand.createCommandSpec();
-        CommandSpec configSpec = ConfigCommand.createCommandSpec();
-        
-        mainSpec.addSubcommand("server", serverSpec);
-        mainSpec.addSubcommand("client", clientSpec);
-        mainSpec.addSubcommand("host", hostSpec);
-        mainSpec.addSubcommand("config", configSpec);
-        
+
         CommandLine commandLine = new CommandLine(mainSpec);
-        commandLine.setExecutionStrategy(Main::execute);
-        
-        System.exit(commandLine.execute(args));
+        commandLine.addSubcommand("server", ServerCommand.createCommandSpec());
+        commandLine.addSubcommand("client", ClientCommand.createCommandSpec());
+        commandLine.addSubcommand("host", HostCommand.createCommandSpec());
+        commandLine.addSubcommand("config", ConfigCommand.createCommandSpec());
+
+        try {
+            ParseResult parseResult = commandLine.parseArgs(args);
+            Integer helpExitCode = CommandLine.executeHelpRequest(parseResult);
+            if (helpExitCode != null) System.exit(helpExitCode);
+            System.exit(execute(parseResult));
+        } catch (ParameterException e) {
+            CommandLine cmd = e.getCommandLine();
+            cmd.getErr().println(e.getMessage());
+            if (!UnmatchedArgumentException.printSuggestions(e, cmd.getErr())) cmd.usage(cmd.getErr());
+            System.exit(cmd.getCommandSpec().exitCodeOnInvalidInput());
+        } catch (Exception e) {
+            commandLine.getErr().println("ERROR: " + e.getMessage());
+            System.exit(commandLine.getCommandSpec().exitCodeOnExecutionException());
+        }
     }
-    
+
     private static int execute(ParseResult parseResult) {
-        Integer helpExitCode = CommandLine.executeHelpRequest(parseResult);
-        if (helpExitCode != null) return helpExitCode;
-        
         if (parseResult.hasSubcommand()) {
             ParseResult subResult = parseResult.subcommand();
-            String subcommandName = subResult.commandSpec().name();
-            
-            return switch (subcommandName) {
+            String name = subResult.commandSpec().name();
+            return switch (name) {
                 case "server" -> ServerCommand.execute(subResult);
                 case "client" -> ClientCommand.execute(subResult);
                 case "host" -> HostCommand.execute(subResult);
                 case "config" -> ConfigCommand.execute(subResult);
-                default -> throw new IllegalStateException("Unknown subcommand: " + subcommandName);
+                default -> throw new IllegalStateException("Unknown subcommand: " + name);
             };
         }
-        
+
         CommandLine.usage(parseResult.commandSpec(), System.out);
         return 0;
     }


### PR DESCRIPTION
## Summary
- handle parse errors at CLI entrypoint using picocli programmatic API

## Testing
- `gradle run --args="client --command ls"` (fails with expected error)
- `gradle run --args="--help"`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_688e70e8d6f88324a3ab4a823f5c37fa