### PR TITLE
refactor: centralize immutable collections

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.prompts;
 
+import com.amannmalik.mcp.util.Immutable;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
@@ -9,7 +10,7 @@ public record ListPromptsResult(List<Prompt> prompts,
                                 String nextCursor,
                                 JsonObject _meta) {
     public ListPromptsResult {
-        prompts = prompts == null ? List.of() : List.copyOf(prompts);
+        prompts = Immutable.list(prompts);
         MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptTemplate.java
@@ -2,16 +2,18 @@ package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.content.ContentBlock;
 
+import com.amannmalik.mcp.util.Immutable;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
 public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages) {
     public PromptTemplate {
-        messages = messages == null || messages.isEmpty() ? List.of() : List.copyOf(messages);
+        messages = Immutable.list(messages);
     }
 
     PromptInstance instantiate(Map<String, String> args) {
-        Map<String, String> provided = args == null ? Map.of() : Map.copyOf(args);
+        Map<String, String> provided = Immutable.map(args);
 
         if (!prompt.arguments().isEmpty()) {
             Set<String> allowed = prompt.arguments().stream()
@@ -51,10 +53,8 @@ public record PromptTemplate(Prompt prompt, List<PromptMessageTemplate> messages
 
     private static String substitute(String template, Map<String, String> args) {
         String result = template;
-        if (args != null) {
-            for (Map.Entry<String, String> e : args.entrySet()) {
-                result = result.replace("{" + e.getKey() + "}", e.getValue());
-            }
+        for (Map.Entry<String, String> e : args.entrySet()) {
+            result = result.replace("{" + e.getKey() + "}", e.getValue());
         }
         return result;
     }

--- a/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/completion/CompleteResult.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.server.completion;
 
 import com.amannmalik.mcp.config.McpConfiguration;
+import com.amannmalik.mcp.util.Immutable;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
@@ -18,8 +19,7 @@ public record CompleteResult(Completion completion, JsonObject _meta) {
 
     public record Completion(List<String> values, Integer total, Boolean hasMore) {
         public Completion(List<String> values, Integer total, Boolean hasMore) {
-            List<String> copy = values == null ? List.of() : List.copyOf(values);
-            copy = copy.stream()
+            List<String> copy = Immutable.list(values).stream()
                     .map(InputSanitizer::requireClean)
                     .toList();
             this.values = copy;

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourceTemplatesResult.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.util.Immutable;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
@@ -9,7 +10,7 @@ public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplat
                                           String nextCursor,
                                           JsonObject _meta) {
     public ListResourceTemplatesResult {
-        resourceTemplates = resourceTemplates == null ? List.of() : List.copyOf(resourceTemplates);
+        resourceTemplates = Immutable.list(resourceTemplates);
         MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ListResourcesResult.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.util.Immutable;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
@@ -9,7 +10,7 @@ public record ListResourcesResult(List<Resource> resources,
                                   String nextCursor,
                                   JsonObject _meta) {
     public ListResourcesResult {
-        resources = resources == null ? List.of() : List.copyOf(resources);
+        resources = Immutable.list(resources);
         MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/resources/ReadResourceResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ReadResourceResult.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.resources;
 
+import com.amannmalik.mcp.util.Immutable;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
@@ -7,7 +8,7 @@ import java.util.List;
 
 public record ReadResourceResult(List<ResourceBlock> contents, JsonObject _meta) {
     public ReadResourceResult {
-        contents = contents == null ? List.of() : List.copyOf(contents);
+        contents = Immutable.list(contents);
         MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/server/tools/ListToolsResult.java
+++ b/src/main/java/com/amannmalik/mcp/server/tools/ListToolsResult.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.server.tools;
 
+import com.amannmalik.mcp.util.Immutable;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
@@ -9,7 +10,7 @@ public record ListToolsResult(List<Tool> tools,
                               String nextCursor,
                               JsonObject _meta) {
     public ListToolsResult {
-        tools = tools == null || tools.isEmpty() ? List.of() : List.copyOf(tools);
+        tools = Immutable.list(tools);
         MetaValidator.requireValid(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/util/Immutable.java
+++ b/src/main/java/com/amannmalik/mcp/util/Immutable.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class Immutable {
+    private Immutable() {
+    }
+
+    public static <T> List<T> list(Collection<? extends T> items) {
+        return List.copyOf(Objects.requireNonNullElseGet(items, List::of));
+    }
+
+    public static <K, V> Map<K, V> map(Map<? extends K, ? extends V> items) {
+        return Map.copyOf(Objects.requireNonNullElseGet(items, Map::of));
+    }
+}


### PR DESCRIPTION
## Summary
- add utility for immutable list and map copies
- use centralized helpers across prompt, resource, tool, and completion records

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e79a444cc832485acf4cb8d90edfe