### PR TITLE
centralize request capability requirements

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -632,7 +632,7 @@ public final class McpClient implements AutoCloseable {
     }
 
     private void requireCapability(RequestMethod method) {
-        method.requiredCapability()
+        CapabilityRequirements.forMethod(method)
                 .filter(c -> !serverCapabilities.contains(c))
                 .ifPresent(c -> {
                     throw new IllegalStateException("Server capability not negotiated: " + c);

--- a/src/main/java/com/amannmalik/mcp/lifecycle/CapabilityRequirements.java
+++ b/src/main/java/com/amannmalik/mcp/lifecycle/CapabilityRequirements.java
@@ -1,0 +1,29 @@
+package com.amannmalik.mcp.lifecycle;
+
+import com.amannmalik.mcp.wire.RequestMethod;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class CapabilityRequirements {
+    private static final Map<RequestMethod, ServerCapability> MAP = Map.ofEntries(
+            Map.entry(RequestMethod.RESOURCES_LIST, ServerCapability.RESOURCES),
+            Map.entry(RequestMethod.RESOURCES_TEMPLATES_LIST, ServerCapability.RESOURCES),
+            Map.entry(RequestMethod.RESOURCES_READ, ServerCapability.RESOURCES),
+            Map.entry(RequestMethod.RESOURCES_SUBSCRIBE, ServerCapability.RESOURCES),
+            Map.entry(RequestMethod.RESOURCES_UNSUBSCRIBE, ServerCapability.RESOURCES),
+            Map.entry(RequestMethod.TOOLS_LIST, ServerCapability.TOOLS),
+            Map.entry(RequestMethod.TOOLS_CALL, ServerCapability.TOOLS),
+            Map.entry(RequestMethod.PROMPTS_LIST, ServerCapability.PROMPTS),
+            Map.entry(RequestMethod.PROMPTS_GET, ServerCapability.PROMPTS),
+            Map.entry(RequestMethod.LOGGING_SET_LEVEL, ServerCapability.LOGGING),
+            Map.entry(RequestMethod.COMPLETION_COMPLETE, ServerCapability.COMPLETIONS)
+    );
+
+    private CapabilityRequirements() {
+    }
+
+    public static Optional<ServerCapability> forMethod(RequestMethod method) {
+        return Optional.ofNullable(MAP.get(method));
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
+++ b/src/main/java/com/amannmalik/mcp/wire/RequestMethod.java
@@ -1,39 +1,29 @@
 package com.amannmalik.mcp.wire;
 
-import com.amannmalik.mcp.lifecycle.ServerCapability;
-
-import java.util.EnumSet;
 import java.util.Optional;
 
 public enum RequestMethod implements WireMethod {
     INITIALIZE("initialize"),
     PING("ping"),
-    RESOURCES_LIST("resources/list", ServerCapability.RESOURCES),
-    RESOURCES_TEMPLATES_LIST("resources/templates/list", ServerCapability.RESOURCES),
-    RESOURCES_READ("resources/read", ServerCapability.RESOURCES),
-    RESOURCES_SUBSCRIBE("resources/subscribe", ServerCapability.RESOURCES),
-    RESOURCES_UNSUBSCRIBE("resources/unsubscribe", ServerCapability.RESOURCES),
-    TOOLS_LIST("tools/list", ServerCapability.TOOLS),
-    TOOLS_CALL("tools/call", ServerCapability.TOOLS),
-    PROMPTS_LIST("prompts/list", ServerCapability.PROMPTS),
-    PROMPTS_GET("prompts/get", ServerCapability.PROMPTS),
-    LOGGING_SET_LEVEL("logging/setLevel", ServerCapability.LOGGING),
-    COMPLETION_COMPLETE("completion/complete", ServerCapability.COMPLETIONS),
+    RESOURCES_LIST("resources/list"),
+    RESOURCES_TEMPLATES_LIST("resources/templates/list"),
+    RESOURCES_READ("resources/read"),
+    RESOURCES_SUBSCRIBE("resources/subscribe"),
+    RESOURCES_UNSUBSCRIBE("resources/unsubscribe"),
+    TOOLS_LIST("tools/list"),
+    TOOLS_CALL("tools/call"),
+    PROMPTS_LIST("prompts/list"),
+    PROMPTS_GET("prompts/get"),
+    LOGGING_SET_LEVEL("logging/setLevel"),
+    COMPLETION_COMPLETE("completion/complete"),
     SAMPLING_CREATE_MESSAGE("sampling/createMessage"),
     ROOTS_LIST("roots/list"),
     ELICITATION_CREATE("elicitation/create");
 
     private final String method;
-    private final EnumSet<ServerCapability> capabilities;
 
     RequestMethod(String method) {
         this.method = method;
-        this.capabilities = EnumSet.noneOf(ServerCapability.class);
-    }
-
-    RequestMethod(String method, ServerCapability capability) {
-        this.method = method;
-        this.capabilities = EnumSet.of(capability);
     }
 
     public String method() {
@@ -42,9 +32,5 @@ public enum RequestMethod implements WireMethod {
 
     public static Optional<RequestMethod> from(String method) {
         return WireMethod.from(RequestMethod.class, method);
-    }
-
-    public Optional<ServerCapability> requiredCapability() {
-        return capabilities.stream().findFirst();
     }
 }


### PR DESCRIPTION
## Summary
- remove lifecycle dependency from RequestMethod
- map request methods to required server capabilities in CapabilityRequirements
- consult centralized mapping in McpClient and HostProcess

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e79a444cc832485acf4cb8d90edfe