### PR TITLE
Centralize JsonRpc response handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpc.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpc.java
@@ -1,8 +1,16 @@
 package com.amannmalik.mcp.jsonrpc;
 
+import java.io.IOException;
+
 public final class JsonRpc {
     private JsonRpc() {
     }
 
     public static final String VERSION = "2.0";
+
+    public static JsonRpcResponse expectResponse(JsonRpcMessage msg) throws IOException {
+        if (msg instanceof JsonRpcResponse resp) return resp;
+        if (msg instanceof JsonRpcError err) throw new IOException(err.error().message());
+        throw new IOException("Unexpected message type: " + msg.getClass().getSimpleName());
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/security/HostProcess.java
+++ b/src/main/java/com/amannmalik/mcp/security/HostProcess.java
@@ -146,13 +146,11 @@ public final class HostProcess implements AutoCloseable {
         McpClient client = clients.get(clientId);
         if (client == null) throw new IllegalArgumentException("Unknown client: " + clientId);
         requireCapability(client, ServerCapability.TOOLS);
-        JsonRpcMessage resp = client.request(
+        JsonRpcResponse resp = JsonRpc.expectResponse(client.request(
                 RequestMethod.TOOLS_LIST,
                 ToolCodec.toJsonObject(new ListToolsRequest(cursor, null))
-        );
-        if (resp instanceof JsonRpcResponse r) return ToolCodec.toListToolsResult(r.result());
-        if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
-        throw new IOException("Unexpected response");
+        ));
+        return ToolCodec.toListToolsResult(resp.result());
     }
 
     public ToolResult callTool(String clientId, String name, JsonObject args) throws IOException {
@@ -161,13 +159,11 @@ public final class HostProcess implements AutoCloseable {
         requireCapability(client, ServerCapability.TOOLS);
         consents.requireConsent(principal, "tool:" + name);
         toolAccess.requireAllowed(principal, name);
-        JsonRpcMessage resp = client.request(
+        JsonRpcResponse resp = JsonRpc.expectResponse(client.request(
                 RequestMethod.TOOLS_CALL,
                 ToolCodec.toJsonObject(new CallToolRequest(name, args, null))
-        );
-        if (resp instanceof JsonRpcResponse r) return ToolCodec.toToolResult(r.result());
-        if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
-        throw new IOException("Unexpected response");
+        ));
+        return ToolCodec.toToolResult(resp.result());
     }
 
     public JsonObject createMessage(String clientId, JsonObject params) throws IOException {
@@ -177,10 +173,8 @@ public final class HostProcess implements AutoCloseable {
         requireCapability(client, ClientCapability.SAMPLING);
         consents.requireConsent(principal, "sampling");
         samplingAccess.requireAllowed(principal);
-        JsonRpcMessage resp = client.request(RequestMethod.SAMPLING_CREATE_MESSAGE, params);
-        if (resp instanceof JsonRpcResponse r) return r.result();
-        if (resp instanceof JsonRpcError err) throw new IOException(err.error().message());
-        throw new IOException("Unexpected response");
+        JsonRpcResponse resp = JsonRpc.expectResponse(client.request(RequestMethod.SAMPLING_CREATE_MESSAGE, params));
+        return resp.result();
     }
 
     public JsonRpcMessage request(String id, String method, JsonObject params) throws IOException {


### PR DESCRIPTION
## Summary
- centralize JsonRpc response validation
- refactor client and host helpers to use shared check

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e7cc1c41c8324ad3d3795bf4b83b6