### PR TITLE
Factor common resource metadata

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/Resource.java
@@ -14,7 +14,7 @@ public record Resource(
         Long size,
         Annotations annotations,
         JsonObject _meta
-) implements DisplayNameProvider {
+) implements DisplayNameProvider, ResourceDescriptor {
     public Resource {
         uri = UriValidator.requireAbsolute(uri);
         name = InputSanitizer.requireClean(name);

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceDescriptor.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceDescriptor.java
@@ -1,0 +1,14 @@
+package com.amannmalik.mcp.server.resources;
+
+import com.amannmalik.mcp.annotations.Annotations;
+import jakarta.json.JsonObject;
+
+public sealed interface ResourceDescriptor permits Resource, ResourceTemplate {
+    String name();
+    String title();
+    String description();
+    String mimeType();
+    Annotations annotations();
+    JsonObject _meta();
+}
+

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourceTemplate.java
@@ -13,7 +13,7 @@ public record ResourceTemplate(
         String mimeType,
         Annotations annotations,
         JsonObject _meta
-) implements DisplayNameProvider {
+) implements DisplayNameProvider, ResourceDescriptor {
     public ResourceTemplate {
         uriTemplate = UriTemplateValidator.requireAbsoluteTemplate(uriTemplate);
         name = InputSanitizer.requireClean(name);

--- a/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
+++ b/src/main/java/com/amannmalik/mcp/server/resources/ResourcesCodec.java
@@ -11,18 +11,22 @@ public final class ResourcesCodec {
     private ResourcesCodec() {
     }
 
+    private static void addDescriptorFields(JsonObjectBuilder b, ResourceDescriptor d) {
+        if (d.title() != null) b.add("title", d.title());
+        if (d.description() != null) b.add("description", d.description());
+        if (d.mimeType() != null) b.add("mimeType", d.mimeType());
+        if (d.annotations() != Annotations.EMPTY) {
+            b.add("annotations", AnnotationsCodec.toJsonObject(d.annotations()));
+        }
+        if (d._meta() != null) b.add("_meta", d._meta());
+    }
+
     public static JsonObject toJsonObject(Resource r) {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("uri", r.uri())
                 .add("name", r.name());
-        if (r.title() != null) b.add("title", r.title());
-        if (r.description() != null) b.add("description", r.description());
-        if (r.mimeType() != null) b.add("mimeType", r.mimeType());
+        addDescriptorFields(b, r);
         if (r.size() != null) b.add("size", r.size());
-        if (r.annotations() != Annotations.EMPTY) {
-            b.add("annotations", AnnotationsCodec.toJsonObject(r.annotations()));
-        }
-        if (r._meta() != null) b.add("_meta", r._meta());
         return b.build();
     }
 
@@ -43,13 +47,7 @@ public final class ResourcesCodec {
         JsonObjectBuilder b = Json.createObjectBuilder()
                 .add("uriTemplate", t.uriTemplate())
                 .add("name", t.name());
-        if (t.title() != null) b.add("title", t.title());
-        if (t.description() != null) b.add("description", t.description());
-        if (t.mimeType() != null) b.add("mimeType", t.mimeType());
-        if (t.annotations() != Annotations.EMPTY) {
-            b.add("annotations", AnnotationsCodec.toJsonObject(t.annotations()));
-        }
-        if (t._meta() != null) b.add("_meta", t._meta());
+        addDescriptorFields(b, t);
         return b.build();
     }
 


### PR DESCRIPTION
## Summary
- share metadata access across Resource and ResourceTemplate via new `ResourceDescriptor`
- centralize optional field handling in `ResourcesCodec`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688e7f89e4288324bf674ff1658d180a