### PR TITLE
refactor transport message handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -148,18 +148,11 @@ public final class StreamableHttpTransport implements Transport {
             return false;
         }
         String norm = accept.toLowerCase(Locale.ROOT);
-        if (post) {
-            if (!(norm.contains("application/json") && norm.contains("text/event-stream"))) {
-                resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
-                return false;
-            }
-        } else {
-            if (!norm.contains("text/event-stream")) {
-                resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
-                return false;
-            }
-        }
-        return true;
+        boolean ok = post
+                ? norm.contains("application/json") && norm.contains("text/event-stream")
+                : norm.contains("text/event-stream");
+        if (!ok) resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+        return ok;
     }
 
     boolean validateSession(HttpServletRequest req,


### PR DESCRIPTION
## Summary
- simplify HTTP client transport to centralize SSE reader setup and auth handling
- streamline Accept header validation on server side

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688e82f2d1148324aa3e0b406fe4536c