### PR TITLE
test: add tools conformance scenario

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -79,6 +79,7 @@ public final class McpConformanceSteps {
                 ServerCapability.COMPLETIONS
         );
         assertEquals(expected, client.serverCapabilities());
+        assertTrue(client.toolsListChangedSupported());
         assertDoesNotThrow(() -> client.ping());
     }
 
@@ -230,6 +231,7 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("uri", parameter).build());
             case "list_templates" -> client.request("resources/templates/list", Json.createObjectBuilder().build());
             case "list_tools" -> client.request("tools/list", Json.createObjectBuilder().build());
+            case "list_tools_schema" -> client.request("tools/list", Json.createObjectBuilder().build());
             case "call_tool" -> client.request("tools/call",
                     Json.createObjectBuilder().add("name", parameter).build());
             case "list_prompts" -> client.request("prompts/list", Json.createObjectBuilder().build());
@@ -276,6 +278,13 @@ public final class McpConformanceSteps {
                 var tools = result.getJsonArray("tools");
                 assertEquals(1, tools.size());
                 assertEquals(expected, tools.getJsonObject(0).getString("name"));
+            }
+            case "list_tools_schema" -> {
+                var tools = result.getJsonArray("tools");
+                assertEquals(1, tools.size());
+                var tool = tools.getJsonObject(0);
+                assertEquals(expected, tool.getString("name"));
+                assertEquals("object", tool.getJsonObject("inputSchema").getString("type"));
             }
             case "call_tool" -> {
                 var content = result.getJsonArray("content").getJsonObject(0);

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -23,6 +23,24 @@ Feature: MCP protocol conformance
     When the client disconnects
     Then the server terminates cleanly
 
+      Examples:
+        | transport |
+        | stdio     |
+        | http      |
+
+  Scenario Outline: MCP tools specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When testing core functionality
+      | operation         | parameter | expected_result |
+      | list_tools_schema |           | test_tool       |
+      | call_tool         | test_tool | ok              |
+    And testing error conditions
+      | operation         | parameter | expected_error_code |
+      | call_unknown_tool | nope      | -32602              |
+    When the client disconnects
+    Then the server terminates cleanly
+
     Examples:
       | transport |
       | stdio     |


### PR DESCRIPTION
## Summary
- extend conformance steps to assert tools listChanged support
- add dedicated tools scenario focusing on list and call operations

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e86044ff4832487e1c2e4667ad36b