### PR TITLE
test: add prompt conformance scenario

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -236,6 +236,18 @@ public final class McpConformanceSteps {
             case "get_prompt" -> client.request("prompts/get",
                     Json.createObjectBuilder().add("name", parameter)
                             .add("arguments", Json.createObjectBuilder().add("test_arg", "v")).build());
+            case "list_prompt_name" -> client.request("prompts/list", Json.createObjectBuilder().build());
+            case "list_prompt_arg_required" -> client.request("prompts/list", Json.createObjectBuilder().build());
+            case "get_prompt_text" -> client.request("prompts/get",
+                    Json.createObjectBuilder().add("name", parameter)
+                            .add("arguments", Json.createObjectBuilder().add("test_arg", "v")).build());
+            case "get_prompt_role" -> client.request("prompts/get",
+                    Json.createObjectBuilder().add("name", parameter)
+                            .add("arguments", Json.createObjectBuilder().add("test_arg", "v")).build());
+            case "get_prompt_invalid" -> client.request("prompts/get",
+                    Json.createObjectBuilder().add("name", parameter).build());
+            case "get_prompt_missing_arg" -> client.request("prompts/get",
+                    Json.createObjectBuilder().add("name", parameter).build());
             case "request_completion" -> client.request("completion/complete",
                     Json.createObjectBuilder()
                             .add("ref", Json.createObjectBuilder().add("type", "ref/prompt").add("name", "test_prompt"))
@@ -288,6 +300,23 @@ public final class McpConformanceSteps {
             case "get_prompt" -> {
                 var messages = result.getJsonArray("messages");
                 assertEquals(expected, messages.getJsonObject(0).getJsonObject("content").getString("text"));
+            }
+            case "list_prompt_name" -> {
+                var prompts = result.getJsonArray("prompts");
+                assertEquals(expected, prompts.getJsonObject(0).getString("name"));
+            }
+            case "list_prompt_arg_required" -> {
+                var prompts = result.getJsonArray("prompts");
+                var args = prompts.getJsonObject(0).getJsonArray("arguments");
+                assertEquals(Boolean.parseBoolean(expected), args.getJsonObject(0).getBoolean("required"));
+            }
+            case "get_prompt_text" -> {
+                var messages = result.getJsonArray("messages");
+                assertEquals(expected, messages.getJsonObject(0).getJsonObject("content").getString("text"));
+            }
+            case "get_prompt_role" -> {
+                var messages = result.getJsonArray("messages");
+                assertEquals(expected, messages.getJsonObject(0).getString("role"));
             }
             case "request_completion" -> {
                 var values = result.getJsonObject("completion").getJsonArray("values");

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -27,3 +27,24 @@ Feature: MCP protocol conformance
       | transport |
       | stdio     |
       | http      |
+
+  Scenario Outline: MCP prompts specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When testing core functionality
+      | operation                | parameter      | expected_result |
+      | list_prompt_name         |                | test_prompt     |
+      | list_prompt_arg_required |                | true            |
+      | get_prompt_text          | test_prompt    | hello           |
+      | get_prompt_role          | test_prompt    | user            |
+    And testing error conditions
+      | operation              | parameter   | expected_error_code |
+      | get_prompt_invalid     | nope        | -32602              |
+      | get_prompt_missing_arg | test_prompt | -32602              |
+    When the client disconnects
+    Then the server terminates cleanly
+
+    Examples:
+      | transport |
+      | stdio     |
+      | http      |


### PR DESCRIPTION
## Summary
- add dedicated Cucumber scenario for prompts
- extend test steps for prompt fields and errors

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e863b13848324938fab25328f74a3