### PR TITLE
add sampling conformance scenario

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -81,3 +81,20 @@ Feature: MCP protocol conformance
       | stdio     |
       | http      |
 
+  Scenario Outline: MCP sampling specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When testing core functionality
+      | operation        | parameter | expected_result |
+      | request_sampling |           | ok              |
+    And testing error conditions
+      | operation               | parameter | expected_error_code |
+      | request_sampling_reject |           | -32603             |
+    When the client disconnects
+    Then the server terminates cleanly
+
+    Examples:
+      | transport |
+      | stdio     |
+      | http      |
+


### PR DESCRIPTION
## Summary
- extend Cucumber feature with sampling scenario
- support sampling steps in conformance tests

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688e8b2ba9f0832496de233ee8c56279