### PR TITLE
Refactor pending JSON‑RPC request tracking

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/PendingRequests.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/PendingRequests.java
@@ -1,0 +1,40 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class PendingRequests {
+    private final AtomicLong counter = new AtomicLong(1);
+    private final Map<RequestId, CompletableFuture<JsonRpcMessage>> pending = new ConcurrentHashMap<>();
+
+    public record Context(RequestId id, CompletableFuture<JsonRpcMessage> future) {}
+
+    public RequestId nextId() {
+        return new RequestId.NumericId(counter.getAndIncrement());
+    }
+
+    public Context register() {
+        var id = nextId();
+        var future = new CompletableFuture<JsonRpcMessage>();
+        pending.put(id, future);
+        return new Context(id, future);
+    }
+
+    public void complete(RequestId id, JsonRpcMessage msg) {
+        var f = pending.remove(id);
+        if (f != null) f.complete(msg);
+    }
+
+    public void remove(RequestId id) {
+        pending.remove(id);
+    }
+
+    public void failAll(IOException e) {
+        pending.values().forEach(f -> f.completeExceptionally(e));
+        pending.clear();
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize JSON-RPC request ID and future management in PendingRequests
- wire McpClient and McpServer through PendingRequests and clear outstanding requests on shutdown

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e8dd9dcd88324bbf681cdb54b80e8