### PR TITLE
Fix roots race by starting client read loop earlier

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -138,7 +138,7 @@ public final class McpClient implements AutoCloseable {
         if (connected) return;
         JsonRpcMessage msg = sendInitialization();
         handleInitialization(msg);
-        notifyInitialized();
+        connected = true;
         if (transport instanceof StreamableHttpClientTransport http) {
             try {
                 http.listen();
@@ -147,9 +147,9 @@ public final class McpClient implements AutoCloseable {
                 throw e;
             }
         }
-        connected = true;
-        subscribeRootsIfNeeded();
         startBackgroundTasks();
+        subscribeRootsIfNeeded();
+        notifyInitialized();
     }
 
     private JsonRpcMessage sendInitialization() throws IOException {


### PR DESCRIPTION
## Summary
- begin receiving before notifying initialization to handle immediate server requests

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_688e94d452dc83249fa1dd029f30a8d6