### PR TITLE
Queue HTTP transport messages until client SSE connected

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
@@ -77,6 +77,7 @@ final class McpServlet extends HttpServlet {
             transport.clients.lastGeneral.set(null);
         }
         transport.clients.general.add(client);
+        transport.flushBacklog();
         ac.addListener(transport.clients.generalListener(client));
     }
 


### PR DESCRIPTION
## Summary
- ensure StreamableHttpTransport queues outbound messages when no SSE clients are active
- deliver queued messages once an SSE client connects and MessageRouter tracks delivery

## Testing
- `gradle test --tests "McpConformanceFeatureTest"`

------
https://chatgpt.com/codex/tasks/task_e_688e94bbfaac8324bd112882b7fda809