### PR TITLE
test: cover request cancellation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/server/ServerDefaults.java
+++ b/src/main/java/com/amannmalik/mcp/server/ServerDefaults.java
@@ -39,8 +39,9 @@ public final class ServerDefaults {
                 .add("required", Json.createArrayBuilder().add("msg"))
                 .build();
         Tool eliciting = new Tool("echo_tool", "Echo Tool", null, eschema, null, null, null);
+        Tool slow = new Tool("slow_tool", "Slow Tool", null, schema, null, null, null);
         return new InMemoryToolProvider(
-                List.of(tool, errorTool, eliciting),
+                List.of(tool, errorTool, eliciting, slow),
                 Map.of(
                         "test_tool", a -> new ToolResult(
                                 Json.createArrayBuilder()
@@ -64,7 +65,23 @@ public final class ServerDefaults {
                                                 .add("type", "text")
                                                 .add("text", a.getString("msg"))
                                                 .build())
-                                        .build(), null, false, null)));
+                                        .build(), null, false, null),
+                        "slow_tool", a -> {
+                                try {
+                                    Thread.sleep(1000);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                return new ToolResult(
+                                        Json.createArrayBuilder()
+                                                .add(Json.createObjectBuilder()
+                                                        .add("type", "text")
+                                                        .add("text", "ok")
+                                                        .build())
+                                                .build(),
+                                        null, false, null);
+                        }
+                ));
     }
 
     public static PromptProvider prompts() {

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -26,6 +26,7 @@ import io.cucumber.java.en.*;
 import jakarta.json.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.*;
@@ -307,6 +308,15 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("uri", parameter).build());
             case "call_unknown_tool" -> client.request("tools/call",
                     Json.createObjectBuilder().add("name", parameter).build());
+            case "cancel_tool_call" -> {
+                try {
+                    client.request("tools/call",
+                            Json.createObjectBuilder().add("name", parameter).build(), 100);
+                    yield new JsonRpcResponse(RequestId.NullId.INSTANCE, Json.createObjectBuilder().build());
+                } catch (IOException e) {
+                    yield JsonRpcError.of(RequestId.NullId.INSTANCE, JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());
+                }
+            }
             case "roots_listed" -> {
                 for (int i = 0; i < 50 && rootsProvider.listCount() == 0; i++) Thread.sleep(100);
                 yield new JsonRpcResponse(RequestId.NullId.INSTANCE,

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -20,6 +20,7 @@ Feature: MCP protocol conformance
       | operation         | parameter | expected_error_code |
       | read_invalid_uri  | bad://uri | -32002              |
       | call_unknown_tool | nope      | -32602              |
+      | cancel_tool_call  | slow_tool | -32603              |
     When the client disconnects
     Then the server terminates cleanly
 


### PR DESCRIPTION
## Summary
- add slow tool to exercise server cancellation logic
- cover cancellation via new conformance feature

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_688ea92d704c832499670bed657e1f51