### PR TITLE
Clear interrupt after sampling rejection

### DIFF
--- a/src/main/java/com/amannmalik/mcp/client/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/client/McpClient.java
@@ -548,7 +548,7 @@ public final class McpClient implements AutoCloseable {
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            Thread.interrupted();
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Sampling interrupted");
         } catch (Exception e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());


### PR DESCRIPTION
## Summary
- keep HTTP client thread active after sampling rejection

## Testing
- `gradle test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_688eaa26bba48324929fadf223aa6892