### PR TITLE
fix test hang by reaping server process

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -58,13 +58,11 @@ public final class McpConformanceSteps {
     @After
     public void cleanup() throws Exception {
         if (client != null) client.disconnect();
-        if (serverProcess != null && serverProcess.isAlive()) {
-            serverProcess.destroyForcibly();
+        if (serverProcess != null) {
+            if (serverProcess.isAlive()) serverProcess.destroyForcibly();
             serverProcess.waitFor(2, TimeUnit.SECONDS);
         }
-        if (serverTask != null && !serverTask.isDone()) {
-            serverTask.cancel(true);
-        }
+        if (serverTask != null && !serverTask.isDone()) serverTask.cancel(true);
         if (serverTransport != null) serverTransport.close();
     }
 


### PR DESCRIPTION
## Summary
- ensure test cleanup always waits for server process termination to avoid lingering zombies

## Testing
- `gradle check --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_688ecb7c8c708324836abfa073f1627f