### PR TITLE
test: verify invalid resource cursor handling

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -263,6 +263,8 @@ public final class McpConformanceSteps {
             case "resource_metadata", "list_resources_annotations" -> client.request("resources/list", Json.createObjectBuilder().build());
             case "read_resource" -> client.request("resources/read",
                     Json.createObjectBuilder().add("uri", parameter).build());
+            case "list_resources_invalid_cursor" -> client.request("resources/list",
+                    Json.createObjectBuilder().add("cursor", parameter).build());
             case "list_templates" -> client.request("resources/templates/list", Json.createObjectBuilder().build());
             case "list_tools", "list_tools_schema", "list_tools_output_schema", "list_tools_annotations" -> client.request("tools/list", Json.createObjectBuilder().build());
             case "call_tool" -> client.request("tools/call",

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -22,6 +22,7 @@ Feature: MCP protocol conformance
     And testing error conditions
       | operation         | parameter | expected_error_code |
       | read_invalid_uri  | bad://uri | -32002              |
+      | list_resources_invalid_cursor | notacursor | -32602              |
       | call_unknown_tool | nope      | -32602              |
       | cancel_tool_call  | slow_tool | -32603              |
     And a cancellation log message is received


### PR DESCRIPTION
## Summary
- add conformance test for invalid pagination cursor on `resources/list`
- support executing the new test operation in step definitions

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_688fbd1925848324af8c454beb3288f3