### PR TITLE
Expand elicitation tests

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -305,6 +305,17 @@ public final class McpConformanceSteps {
                 yield client.request("tools/call",
                         Json.createObjectBuilder().add("name", parameter).build());
             }
+            case "call_tool_elicit_decline" -> {
+                elicitation.respond(new ElicitResult(ElicitationAction.DECLINE, null, null));
+                yield client.request("tools/call",
+                        Json.createObjectBuilder().add("name", parameter).build());
+            }
+            case "call_tool_elicit_invalid" -> {
+                elicitation.respond(new ElicitResult(ElicitationAction.ACCEPT,
+                        Json.createObjectBuilder().add("msg", 1).build(), null));
+                yield client.request("tools/call",
+                        Json.createObjectBuilder().add("name", parameter).build());
+            }
             case "list_prompts" -> client.request("prompts/list", Json.createObjectBuilder().build());
             case "get_prompt" -> client.request("prompts/get",
                     Json.createObjectBuilder().add("name", parameter)

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -141,8 +141,10 @@ Feature: MCP protocol conformance
       | operation        | parameter | expected_result |
       | call_tool_elicit | echo_tool | ping            |
     And testing error conditions
-      | operation               | parameter | expected_error_code |
-      | call_tool_elicit_cancel | echo_tool | -32602              |
+      | operation                      | parameter | expected_error_code |
+      | call_tool_elicit_cancel        | echo_tool | -32602              |
+      | call_tool_elicit_decline       | echo_tool | -32602              |
+      | call_tool_elicit_invalid       | echo_tool | -32602              |
     When the client disconnects
     Then the server terminates cleanly
 


### PR DESCRIPTION
## Summary
- broaden MCP elicitation conformance with decline and invalid response cases
- teach test harness to emit elicitation decline and invalid responses

## Testing
- `gradle test --no-daemon --console plain` *(fails: MCP elicitation specification conformance, MCP notification timing and delivery conformance)*

------
https://chatgpt.com/codex/tasks/task_e_688fc0732740832498d6ccb8dc24e1b8