### PR TITLE
test: add pagination conformance

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -186,6 +186,21 @@ Feature: MCP protocol conformance
       | http      |
 
   # Specification Links:
+  # - [Pagination](specification/2025-06-18/server/utilities/pagination.mdx)
+  Scenario Outline: MCP pagination specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When listing tools with pagination
+    Then pagination covers all tools
+    When the client disconnects
+    Then the server terminates cleanly
+
+    Examples:
+      | transport |
+      | stdio     |
+      | http      |
+
+  # Specification Links:
   # - [Roots](specification/2025-06-18/client/roots.mdx)
   Scenario Outline: MCP roots specification conformance
     Given a running MCP server using <transport> transport

--- a/src/test/resources/mcp-test-config-http.yaml
+++ b/src/test/resources/mcp-test-config-http.yaml
@@ -14,7 +14,7 @@ performance:
     logs_per_second: 100
     progress_per_second: 100
   pagination:
-    default_page_size: 10
+    default_page_size: 2
     max_completion_values: 10
     sse_history_limit: 10
     response_queue_capacity: 10

--- a/src/test/resources/mcp-test-config.yaml
+++ b/src/test/resources/mcp-test-config.yaml
@@ -14,7 +14,7 @@ performance:
     logs_per_second: 100
     progress_per_second: 100
   pagination:
-    default_page_size: 10
+    default_page_size: 2
     max_completion_values: 10
     sse_history_limit: 10
     response_queue_capacity: 10


### PR DESCRIPTION
## Summary
- exercise pagination by listing tools over multiple pages
- lower default page size in tests to trigger pagination

## Testing
- `./verify.sh` *(fails: MCP notification timing and delivery conformance)*

------
https://chatgpt.com/codex/tasks/task_e_688fc0732740832498d6ccb8dc24e1b8