### PR TITLE
Fix elicitation error handling and logging test coverage

### DIFF
--- a/src/main/java/com/amannmalik/mcp/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/McpClient.java
@@ -578,13 +578,6 @@ public final class McpClient implements AutoCloseable {
         try {
             ElicitRequest er = ElicitCodec.toRequest(params);
             ElicitResult resp = elicitation.elicit(er);
-            if (resp.action() == ElicitationAction.ACCEPT) {
-                try {
-                    SchemaValidator.validate(er.requestedSchema(), resp.content());
-                } catch (IllegalArgumentException ve) {
-                    return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, ve.getMessage());
-                }
-            }
             return new JsonRpcResponse(req.id(), ElicitCodec.toJsonObject(resp));
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());

--- a/src/main/java/com/amannmalik/mcp/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/McpServer.java
@@ -425,10 +425,16 @@ public final class McpServer implements AutoCloseable {
                         null);
                 ElicitResult res = elicit(er);
                 if (res.action() == ElicitationAction.ACCEPT) {
-                    ToolResult result = tools.call(callRequest.name(), res.content());
-                    return new JsonRpcResponse(req.id(), ToolCodec.toJsonObject(result));
+                    try {
+                        ToolResult result = tools.call(callRequest.name(), res.content());
+                        return new JsonRpcResponse(req.id(), ToolCodec.toJsonObject(result));
+                    } catch (IllegalArgumentException ex) {
+                        return invalidParams(req, ex);
+                    }
                 }
                 return invalidParams(req, "Tool invocation cancelled");
+            } catch (IllegalArgumentException ex) {
+                return invalidParams(req, ex);
             } catch (Exception ex) {
                 return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, ex.getMessage());
             }

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -385,6 +385,8 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("level", parameter).build());
             case "set_log_level_missing" -> client.request("logging/setLevel",
                     Json.createObjectBuilder().build());
+            case "set_log_level_extra" -> client.request("logging/setLevel",
+                    Json.createObjectBuilder().add("level", parameter).add("extra", true).build());
             case "subscribe_resource" -> client.request("resources/subscribe",
                     Json.createObjectBuilder().add("uri", parameter).build());
             case "unsubscribe_resource" -> client.request("resources/unsubscribe",


### PR DESCRIPTION
## Summary
- ensure elicitation responses with invalid or cancelled input return invalid-params instead of internal error
- let clients forward elicitation payloads without local validation
- extend conformance tests for extra logging parameter

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fc343ef70832493056b37b24d867b