### PR TITLE
verify server initialization details

### DIFF
--- a/src/main/java/com/amannmalik/mcp/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/McpClient.java
@@ -50,6 +50,8 @@ public final class McpClient implements AutoCloseable {
     private Set<ServerCapability> serverCapabilities = Set.of();
     private String instructions;
     private ServerFeatures serverFeatures = new ServerFeatures(false, false, false, false);
+    private String protocolVersion;
+    private ServerInfo serverInfo;
     private final McpClientListener listener;
     private volatile ResourceMetadata resourceMetadata;
     private final Map<String, ResourceListener> resourceListeners = new ConcurrentHashMap<>();
@@ -134,6 +136,14 @@ public final class McpClient implements AutoCloseable {
         return info;
     }
 
+    public String protocolVersion() {
+        return protocolVersion;
+    }
+
+    public ServerInfo serverInfo() {
+        return serverInfo;
+    }
+
     public synchronized void connect() throws IOException {
         if (connected) return;
         JsonRpcMessage msg = sendInitialization();
@@ -212,6 +222,8 @@ public final class McpClient implements AutoCloseable {
         if (transport instanceof StreamableHttpClientTransport http) {
             http.setProtocolVersion(serverVersion);
         }
+        protocolVersion = serverVersion;
+        serverInfo = ir.serverInfo();
         serverCapabilities = ir.capabilities().server();
         instructions = ir.instructions();
         ServerFeatures f = ir.features();

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -122,6 +122,11 @@ public final class McpConformanceSteps {
         assertEquals(expected, client.serverCapabilities());
         assertTrue(client.toolsListChangedSupported());
         assertDoesNotThrow(() -> client.ping());
+        assertTrue(Set.of(Protocol.LATEST_VERSION, Protocol.PREVIOUS_VERSION)
+                .contains(client.protocolVersion()));
+        var info = client.serverInfo();
+        assertFalse(info.name().isBlank());
+        assertFalse(info.version().isBlank());
     }
 
     @When("requesting resource list with progress tracking")
@@ -385,6 +390,8 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("level", parameter).build());
             case "set_log_level_missing" -> client.request("logging/setLevel",
                     Json.createObjectBuilder().build());
+            case "set_log_level_extra" -> client.request("logging/setLevel",
+                    Json.createObjectBuilder().add("level", parameter).add("extra", 1).build());
             case "subscribe_resource" -> client.request("resources/subscribe",
                     Json.createObjectBuilder().add("uri", parameter).build());
             case "unsubscribe_resource" -> client.request("resources/unsubscribe",


### PR DESCRIPTION
## Summary
- record server protocol version and info during initialization
- assert initialization metadata and add log level error coverage

## Testing
- `./verify.sh` *(fails: Elicitation examples 1.1, 1.2)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3621e0c8324b4f64c2c191476ba