### PR TITLE
test: add authorization metadata conformance

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -286,3 +286,18 @@ Feature: MCP protocol conformance
       | stdio     |
       | http      |
 
+  # Specification Links:
+  # - [Authorization](specification/2025-06-18/basic/authorization.mdx)
+  Scenario Outline: MCP authorization metadata specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When fetching authorization metadata
+    Then authorization metadata uses server base URL
+    And authorization servers are advertised
+    When the client disconnects
+    Then the server terminates cleanly
+
+    Examples:
+      | transport |
+      | http      |
+


### PR DESCRIPTION
## Summary
- add scenario verifying authorization metadata
- exercise canonical resource and advertised authorization servers

## Testing
- `gradle test` *(fails: MCP logging specification conformance, MCP elicitation specification conformance, MCP authorization metadata specification conformance)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3621e0c8324b4f64c2c191476ba