### PR TITLE
test: cover invalid cursor for tools and prompts

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -315,6 +315,7 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("cursor", parameter).build());
             case "list_templates" -> client.request("resources/templates/list", Json.createObjectBuilder().build());
             case "list_tools", "list_tools_schema", "list_tools_output_schema", "list_tools_annotations" -> client.request("tools/list", Json.createObjectBuilder().build());
+            case "list_tools_invalid_cursor" -> client.request("tools/list", Json.createObjectBuilder().add("cursor", parameter).build());
             case "call_tool" -> client.request("tools/call",
                     Json.createObjectBuilder().add("name", parameter).build());
             case "call_tool_structured" -> client.request("tools/call",
@@ -344,6 +345,7 @@ public final class McpConformanceSteps {
                         Json.createObjectBuilder().add("name", parameter).build());
             }
             case "list_prompts" -> client.request("prompts/list", Json.createObjectBuilder().build());
+            case "list_prompts_invalid_cursor" -> client.request("prompts/list", Json.createObjectBuilder().add("cursor", parameter).build());
             case "get_prompt" -> client.request("prompts/get",
                     Json.createObjectBuilder().add("name", parameter)
                             .add("arguments", Json.createObjectBuilder().add("test_arg", "v")).build());

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -48,6 +48,7 @@ Feature: MCP protocol conformance
     And testing error conditions
       | operation         | parameter | expected_error_code |
       | call_unknown_tool | nope      | -32602              |
+      | list_tools_invalid_cursor | notacursor | -32602              |
     When the client disconnects
     Then the server terminates cleanly
 
@@ -71,6 +72,7 @@ Feature: MCP protocol conformance
       | operation              | parameter   | expected_error_code |
       | get_prompt_invalid     | nope        | -32602              |
       | get_prompt_missing_arg | test_prompt | -32602              |
+      | list_prompts_invalid_cursor | notacursor | -32602              |
     When the client disconnects
     Then the server terminates cleanly
 


### PR DESCRIPTION
## Summary
- expand conformance tests for invalid cursor handling in tools and prompts listing

## Testing
- `gradle test` *(fails: MCP elicitation specification conformance)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3621e0c8324b4f64c2c191476ba