### PR TITLE
Expand progress and subscription verification

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -56,6 +56,8 @@ public final class McpConformanceSteps {
     private final Set<String> receivedNotifications = ConcurrentHashMap.newKeySet();
     private final BlockingQueue<ResourceUpdate> resourceUpdates = new LinkedBlockingQueue<>();
     private final BlockingQueue<ProgressNotification> progressUpdates = new LinkedBlockingQueue<>();
+    private ProgressNotification firstProgressUpdate;
+    private ProgressNotification lastProgressUpdate;
     private final List<String> paginatedTools = new ArrayList<>();
 
     private void setupTestConfiguration(String transport) {
@@ -133,9 +135,31 @@ public final class McpConformanceSteps {
 
     @Then("progress updates are received")
     public void verifyProgressUpdates() throws Exception {
-        ProgressNotification note = progressUpdates.poll(2, TimeUnit.SECONDS);
-        assertNotNull(note);
-        assertEquals("tok", note.token().asString());
+        firstProgressUpdate = progressUpdates.poll(2, TimeUnit.SECONDS);
+        assertNotNull(firstProgressUpdate);
+        assertEquals("tok", firstProgressUpdate.token().asString());
+        lastProgressUpdate = firstProgressUpdate;
+    }
+
+    @And("progress completes to {double}")
+    public void progressCompletes(double expected) throws Exception {
+        double last = firstProgressUpdate.progress();
+        boolean complete = last >= expected;
+        lastProgressUpdate = firstProgressUpdate;
+        ProgressNotification note;
+        while ((note = progressUpdates.poll(2, TimeUnit.SECONDS)) != null) {
+            double current = note.progress();
+            assertTrue(current >= last);
+            last = current;
+            lastProgressUpdate = note;
+            if (current >= expected) complete = true;
+        }
+        assertTrue(complete);
+    }
+
+    @And("progress message is provided")
+    public void progressMessageProvided() {
+        assertNotNull(lastProgressUpdate.message());
     }
 
     @When("listing tools with pagination")
@@ -385,6 +409,8 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("level", parameter).build());
             case "set_log_level_missing" -> client.request("logging/setLevel",
                     Json.createObjectBuilder().build());
+            case "set_log_level_extra" -> client.request("logging/setLevel",
+                    Json.createObjectBuilder().add("level", parameter).add("extra", "x").build());
             case "subscribe_resource" -> client.request("resources/subscribe",
                     Json.createObjectBuilder().add("uri", parameter).build());
             case "unsubscribe_resource" -> client.request("resources/unsubscribe",
@@ -543,6 +569,13 @@ public final class McpConformanceSteps {
                         Json.createObjectBuilder().add("uri", parameter).build());
                 case "unsubscribe_nonexistent" -> client.request("resources/unsubscribe",
                         Json.createObjectBuilder().add("uri", parameter).build());
+                case "subscribe_duplicate_resource" -> {
+                    JsonRpcMessage first = client.request("resources/subscribe",
+                            Json.createObjectBuilder().add("uri", parameter).build());
+                    assertInstanceOf(JsonRpcResponse.class, first);
+                    yield client.request("resources/subscribe",
+                            Json.createObjectBuilder().add("uri", parameter).build());
+                }
                 default -> throw new IllegalArgumentException("Unknown notification error operation: " + operation);
             };
             if (response instanceof JsonRpcError error) {

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -180,6 +180,8 @@ Feature: MCP protocol conformance
     Then capabilities should be advertised and ping succeeds
     When requesting resource list with progress tracking
     Then progress updates are received
+    And progress completes to 1.0
+    And progress message is provided
     When the client disconnects
     Then the server terminates cleanly
 
@@ -252,6 +254,7 @@ Feature: MCP protocol conformance
       | operation                  | parameter  | expected_error_code |
       | subscribe_invalid_resource | bad://uri  | -32002              |
       | unsubscribe_nonexistent    | fake://uri | -32602              |
+      | subscribe_duplicate_resource | test://example | -32602 |
     When the client disconnects
     Then the server terminates cleanly
 


### PR DESCRIPTION
## Summary
- tighten progress conformance checks
- validate duplicate subscription errors

## Testing
- `gradle test` *(fails: progress message missing, elicitation cancellations)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3621e0c8324b4f64c2c191476ba