### PR TITLE
test: add authorization conformance checks

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -23,7 +23,11 @@ import jakarta.json.JsonValue;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -402,6 +406,37 @@ public final class McpConformanceSteps {
                     yield JsonRpcError.of(RequestId.NullId.INSTANCE, JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());
                 }
             }
+            case "unauthorized_request" -> {
+                var http = HttpClient.newHttpClient();
+                var req = HttpRequest.newBuilder(
+                                URI.create("http://127.0.0.1:" + serverTransport.port() + "/"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build();
+                var resp = http.send(req, HttpResponse.BodyHandlers.discarding());
+                yield new JsonRpcResponse(RequestId.NullId.INSTANCE,
+                        Json.createObjectBuilder()
+                                .add("status", resp.statusCode())
+                                .add("www_authenticate",
+                                        resp.headers().firstValue("WWW-Authenticate").orElse(""))
+                                .build());
+            }
+            case "resource_metadata_auth_server" -> {
+                var http = HttpClient.newHttpClient();
+                var uri = URI.create("http://127.0.0.1:" + serverTransport.port()
+                        + "/.well-known/oauth-protected-resource");
+                var resp = http.send(HttpRequest.newBuilder(uri).GET().build(),
+                        HttpResponse.BodyHandlers.ofString());
+                try (var reader = Json.createReader(new StringReader(resp.body()))) {
+                    var body = reader.readObject();
+                    yield new JsonRpcResponse(RequestId.NullId.INSTANCE,
+                            Json.createObjectBuilder()
+                                    .add("status", resp.statusCode())
+                                    .add("authorization_server",
+                                            body.getJsonArray("authorization_servers").getString(0))
+                                    .build());
+                }
+            }
             case "roots_listed" -> {
                 for (int i = 0; i < 50 && rootsProvider.listCount() == 0; i++) Thread.sleep(100);
                 yield new JsonRpcResponse(RequestId.NullId.INSTANCE,
@@ -765,6 +800,14 @@ public final class McpConformanceSteps {
                 assertEquals(expected, content.getString("text"));
                 assertEquals("mock-model", result.getString("model"));
                 assertEquals("endTurn", result.getString("stopReason"));
+            }
+            case "unauthorized_request" -> {
+                assertEquals(401, result.getInt("status"));
+                assertEquals(expected, result.getString("www_authenticate"));
+            }
+            case "resource_metadata_auth_server" -> {
+                assertEquals(200, result.getInt("status"));
+                assertEquals(expected, result.getString("authorization_server"));
             }
             case "roots_listed" -> {
                 int c = result.getInt("count");

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -223,6 +223,22 @@ Feature: MCP protocol conformance
       | http      |
 
   # Specification Links:
+  # - [Authorization](specification/2025-06-18/basic/authorization.mdx)
+  Scenario Outline: MCP authorization specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When testing core functionality
+      | operation                    | parameter | expected_result                                                                 |
+      | unauthorized_request        |           | Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource" |
+      | resource_metadata_auth_server |           | https://auth.example.com                                                         |
+    When the client disconnects
+    Then the server terminates cleanly
+
+    Examples:
+      | transport |
+      | http      |
+
+  # Specification Links:
   # - [Subscriptions](specification/2025-06-18/server/subscriptions.mdx)
   # - [Notifications](specification/2025-06-18/server/notifications.mdx)
   Scenario Outline: MCP notification and subscription specification conformance


### PR DESCRIPTION
## Summary
- expand MCP conformance tests with authorization scenario
- exercise unauthorized HTTP requests and metadata retrieval

## Testing
- `gradle check` *(fails: java.lang.IllegalArgumentException at McpConformanceSteps.java:446 and AssertionFailedError at McpConformanceSteps.java:190)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3e3dcf483248452e8c22df44521