### PR TITLE
test: add completion conformance coverage

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -363,6 +363,16 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder()
                             .add("ref", Json.createObjectBuilder().add("type", "ref/prompt").add("name", "test_prompt"))
                             .add("argument", Json.createObjectBuilder().add("name", "test_arg").add("value", "")).build());
+            case "request_completion_invalid" -> client.request("completion/complete",
+                    Json.createObjectBuilder()
+                            .add("ref", Json.createObjectBuilder().add("type", "ref/prompt").add("name", "nope"))
+                            .add("argument", Json.createObjectBuilder().add("name", "test_arg").add("value", "")).build());
+            case "request_completion_missing_arg" -> client.request("completion/complete",
+                    Json.createObjectBuilder()
+                            .add("ref", Json.createObjectBuilder().add("type", "ref/prompt").add("name", "test_prompt")).build());
+            case "request_completion_missing_ref" -> client.request("completion/complete",
+                    Json.createObjectBuilder()
+                            .add("argument", Json.createObjectBuilder().add("name", "test_arg").add("value", "")).build());
             case "request_sampling" -> {
                 var req = new CreateMessageRequest(
                         List.of(new SamplingMessage(Role.USER,
@@ -385,6 +395,8 @@ public final class McpConformanceSteps {
                     Json.createObjectBuilder().add("level", parameter).build());
             case "set_log_level_missing" -> client.request("logging/setLevel",
                     Json.createObjectBuilder().build());
+            case "set_log_level_extra" -> client.request("logging/setLevel",
+                    Json.createObjectBuilder().add("level", parameter).add("extra", true).build());
             case "subscribe_resource" -> client.request("resources/subscribe",
                     Json.createObjectBuilder().add("uri", parameter).build());
             case "unsubscribe_resource" -> client.request("resources/unsubscribe",
@@ -755,8 +767,10 @@ public final class McpConformanceSteps {
                 assertEquals(expected, messages.getJsonObject(0).getString("role"));
             }
             case "request_completion" -> {
-                var values = result.getJsonObject("completion").getJsonArray("values");
+                var completion = result.getJsonObject("completion");
+                var values = completion.getJsonArray("values");
                 assertEquals(expected, values.getJsonString(0).getString());
+                assertTrue(completion.containsKey("hasMore"));
             }
 
             case "request_sampling" -> {

--- a/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
+++ b/src/test/resources/com/amannmalik/mcp/mcp_conformance.feature
@@ -134,6 +134,27 @@ Feature: MCP protocol conformance
       | http      |
 
   # Specification Links:
+  # - [Completion](specification/2025-06-18/server/utilities/completion.mdx)
+  Scenario Outline: MCP completion specification conformance
+    Given a running MCP server using <transport> transport
+    Then capabilities should be advertised and ping succeeds
+    When testing core functionality
+      | operation          | parameter | expected_result |
+      | request_completion |           | test_completion |
+    And testing error conditions
+      | operation                      | parameter | expected_error_code |
+      | request_completion_invalid     |           | -32602              |
+      | request_completion_missing_arg |           | -32602              |
+      | request_completion_missing_ref |           | -32602              |
+    When the client disconnects
+    Then the server terminates cleanly
+
+    Examples:
+      | transport |
+      | stdio     |
+      | http      |
+
+  # Specification Links:
   # - [Elicitation](specification/2025-06-18/client/elicitation.mdx)
   Scenario Outline: MCP elicitation specification conformance
     Given a running MCP server using <transport> transport


### PR DESCRIPTION
## Summary
- expand Cucumber tests with completion conformance scenario
- add harness cases for invalid completion requests and extra log level parameter
- assert completion responses include `hasMore`

## Testing
- `gradle --console=plain check` *(fails: 28 tests completed, 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3e3dcf483248452e8c22df44521