### PR TITLE
Provide progress messages and correct OAuth metadata

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -59,17 +59,12 @@ public final class StreamableHttpTransport implements Transport {
         this.originValidator = validator;
         this.authManager = auth;
         if (resourceMetadataUrl == null || resourceMetadataUrl.isBlank()) {
-            this.resourceMetadataUrl = "http://127.0.0.1:" + this.port +
-                    "/.well-known/oauth-protected-resource";
+            this.resourceMetadataUrl = "http://127.0.0.1:" + this.port
+                    + "/.well-known/oauth-protected-resource";
         } else {
             this.resourceMetadataUrl = resourceMetadataUrl;
         }
-        int idx = this.resourceMetadataUrl.indexOf("/.well-known/oauth-protected-resource");
-        if (idx >= 0) {
-            this.canonicalResource = this.resourceMetadataUrl.substring(0, idx);
-        } else {
-            this.canonicalResource = "http://127.0.0.1:" + this.port;
-        }
+        this.canonicalResource = "http://127.0.0.1:" + this.port;
         if (authorizationServers == null || authorizationServers.isEmpty()) {
             this.authorizationServers = List.of();
         } else {

--- a/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
+++ b/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
@@ -99,8 +99,9 @@ public final class JsonRpcRequestProcessor {
     }
 
     private void sendProgress(ProgressToken token, double current) {
+        String msg = current >= 1.0 ? "completed" : "in progress";
         try {
-            progressManager.send(new ProgressNotification(token, current, 1.0, null), sender);
+            progressManager.send(new ProgressNotification(token, current, 1.0, msg), sender);
         } catch (IOException ignore) {
         }
     }


### PR DESCRIPTION
## Summary
- ensure progress notifications include a message
- always advertise server base URL in OAuth resource metadata

## Testing
- `gradle --console=plain test`

------
https://chatgpt.com/codex/tasks/task_e_688fc9f72b84832491ec36a9ae3c409d