### PR TITLE
Provide authorization metadata and progress messages

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/PermissiveTokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/PermissiveTokenValidator.java
@@ -1,0 +1,13 @@
+package com.amannmalik.mcp.auth;
+
+import com.amannmalik.mcp.validation.InputSanitizer;
+
+import java.util.Set;
+
+public final class PermissiveTokenValidator implements TokenValidator {
+    @Override
+    public Principal validate(String token) throws AuthorizationException {
+        if (token == null || token.isBlank()) throw new AuthorizationException("token required");
+        return new Principal(InputSanitizer.requireClean(token), Set.of());
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpTransport.java
@@ -64,17 +64,10 @@ public final class StreamableHttpTransport implements Transport {
         } else {
             this.resourceMetadataUrl = resourceMetadataUrl;
         }
-        int idx = this.resourceMetadataUrl.indexOf("/.well-known/oauth-protected-resource");
-        if (idx >= 0) {
-            this.canonicalResource = this.resourceMetadataUrl.substring(0, idx);
-        } else {
-            this.canonicalResource = "http://127.0.0.1:" + this.port;
-        }
-        if (authorizationServers == null || authorizationServers.isEmpty()) {
-            this.authorizationServers = List.of();
-        } else {
-            this.authorizationServers = List.copyOf(authorizationServers);
-        }
+        this.canonicalResource = "http://127.0.0.1:" + this.port;
+        this.authorizationServers = authorizationServers == null || authorizationServers.isEmpty()
+                ? List.of()
+                : List.copyOf(authorizationServers);
         this.router = new MessageRouter(clients.request, clients.responses, clients.general, clients.lastGeneral, clients::removeRequest);
     }
 

--- a/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
+++ b/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
@@ -100,7 +100,8 @@ public final class JsonRpcRequestProcessor {
 
     private void sendProgress(ProgressToken token, double current) {
         try {
-            progressManager.send(new ProgressNotification(token, current, 1.0, null), sender);
+            String msg = current >= 1.0 ? "complete" : "in progress";
+            progressManager.send(new ProgressNotification(token, current, 1.0, msg), sender);
         } catch (IOException ignore) {
         }
     }

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -12,6 +12,9 @@ import com.amannmalik.mcp.resources.ResourceSubscription;
 import com.amannmalik.mcp.resources.ResourceUpdate;
 import com.amannmalik.mcp.roots.*;
 import com.amannmalik.mcp.sampling.*;
+import com.amannmalik.mcp.auth.AuthorizationManager;
+import com.amannmalik.mcp.auth.BearerTokenAuthorizationStrategy;
+import com.amannmalik.mcp.auth.PermissiveTokenValidator;
 import com.amannmalik.mcp.transport.*;
 import com.amannmalik.mcp.util.ListChangeSubscription;
 import com.amannmalik.mcp.util.ProgressNotification;
@@ -120,6 +123,7 @@ public final class McpConformanceSteps {
             }
         };
         client = createClient(createTransport(transport), testListener);
+        if ("http".equals(transport)) client.setAccessToken("token");
         client.connect();
         System.out.println("DEBUG: Client connected successfully with " + transport + " transport");
     }
@@ -272,7 +276,8 @@ public final class McpConformanceSteps {
         System.out.println("DEBUG: Starting StreamableHttpTransport server...");
         serverTransport = new StreamableHttpTransport(0,
                 new OriginValidator(Set.of("http://localhost", "http://127.0.0.1")),
-                null,
+                new AuthorizationManager(List.of(
+                        new BearerTokenAuthorizationStrategy(new PermissiveTokenValidator()))),
                 "https://example.com/.well-known/oauth-protected-resource",
                 List.of("https://auth.example.com"));
         System.out.println("DEBUG: StreamableHttpTransport server started on port: " + serverTransport.port());


### PR DESCRIPTION
## Summary
- ensure progress notifications include a message and monotonic updates
- anchor OAuth metadata to the server's base URL while advertising external metadata location
- add a permissive token validator and wire HTTP tests through an AuthorizationManager for proper 401 handling

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fcafa907883249cb841ede2a368a6