### PR TITLE
Use JUnit Platform suite for Cucumber tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,8 @@ dependencies {
     implementation("org.snakeyaml:snakeyaml-engine:$snakeyamlVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("io.cucumber:cucumber-java:7.23.0")
-    testImplementation("io.cucumber:cucumber-junit:7.23.0")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:7.23.0")
+    testImplementation("org.junit.platform:junit-platform-suite:1.13.3")
     jmh("org.openjdk.jmh:jmh-core:$jmhVersion")
     jmh("org.openjdk.jmh:jmh-generator-annprocess:$jmhVersion")
 }

--- a/src/test/java/com/amannmalik/mcp/McpConformanceFeatureTest.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceFeatureTest.java
@@ -1,7 +1,16 @@
 package com.amannmalik.mcp;
 
-import io.cucumber.junit.platform.engine.Cucumber;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
 
-@Cucumber
-public class McpConformanceFeatureTest {
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("com/amannmalik/mcp")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.amannmalik.mcp")
+final class McpConformanceFeatureTest {
 }
+


### PR DESCRIPTION
## Summary
- switch to JUnit Platform suite for running Cucumber features
- drop old cucumber-junit dependency

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_688fcf8c6fdc832492e7d9a38126a0d3