### PR TITLE
Fix logging set level null request handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/logging/LoggingCodec.java
+++ b/src/main/java/com/amannmalik/mcp/logging/LoggingCodec.java
@@ -53,7 +53,7 @@ public final class LoggingCodec {
     }
 
     public static SetLevelRequest toSetLevelRequest(JsonObject obj) {
-        if (obj == null) throw new IllegalArgumentException("level required");
+        if (obj == null) throw new IllegalArgumentException("object required");
         JsonUtil.requireOnlyKeys(obj, Set.of("level", "_meta"));
         String raw;
         try {

--- a/src/test/java/com/amannmalik/mcp/LoggingCodecTest.java
+++ b/src/test/java/com/amannmalik/mcp/LoggingCodecTest.java
@@ -1,0 +1,12 @@
+package com.amannmalik.mcp.logging;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggingCodecTest {
+    @Test
+    void rejectsNullObject() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> LoggingCodec.toSetLevelRequest(null));
+        assertEquals("object required", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- clarify error when `logging/setLevel` receives a null object
- cover `LoggingCodec.toSetLevelRequest` null handling with a unit test

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fcf8c6fdc832492e7d9a38126a0d3