### PR TITLE
refactor: unify pagination codecs

### DIFF
--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
@@ -7,18 +7,10 @@ import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
 public record ListPromptsRequest(String cursor, JsonObject _meta) {
-    public static final JsonCodec<ListPromptsRequest> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListPromptsRequest req) {
-            return AbstractEntityCodec.toJson(new PaginatedRequest(req.cursor(), req._meta()));
-        }
-
-        @Override
-        public ListPromptsRequest fromJson(JsonObject obj) {
-            PaginatedRequest pr = AbstractEntityCodec.fromPaginatedRequest(obj);
-            return new ListPromptsRequest(pr.cursor(), pr._meta());
-        }
-    };
+    public static final JsonCodec<ListPromptsRequest> CODEC =
+            AbstractEntityCodec.paginatedRequest(
+                    r -> new PaginatedRequest(r.cursor(), r._meta()),
+                    pr -> new ListPromptsRequest(pr.cursor(), pr._meta()));
 
     public ListPromptsRequest {
         MetaValidator.requireValid(_meta);

--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsResult.java
@@ -11,32 +11,14 @@ import java.util.*;
 public record ListPromptsResult(List<Prompt> prompts,
                                 String nextCursor,
                                 JsonObject _meta) {
-    public static final JsonCodec<ListPromptsResult> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListPromptsResult r) {
-            return AbstractEntityCodec.paginated(
+    public static final JsonCodec<ListPromptsResult> CODEC =
+            AbstractEntityCodec.paginatedResult(
                     "prompts",
-                    new Pagination.Page<>(r.prompts(), r.nextCursor()),
-                    Prompt.CODEC::toJson,
-                    r._meta());
-        }
-
-        @Override
-        public ListPromptsResult fromJson(JsonObject obj) {
-            if (obj == null) throw new IllegalArgumentException("object required");
-            JsonArray arr = obj.getJsonArray("prompts");
-            if (arr == null) throw new IllegalArgumentException("prompts required");
-            List<Prompt> prompts = new ArrayList<>();
-            for (JsonValue v : arr) {
-                if (v.getValueType() != JsonValue.ValueType.OBJECT) {
-                    throw new IllegalArgumentException("prompt must be object");
-                }
-                prompts.add(Prompt.CODEC.fromJson(v.asJsonObject()));
-            }
-            PaginatedResult pr = AbstractEntityCodec.fromPaginatedResult(obj);
-            return new ListPromptsResult(prompts, pr.nextCursor(), pr._meta());
-        }
-    };
+                    "prompt",
+                    r -> new Pagination.Page<>(r.prompts(), r.nextCursor()),
+                    ListPromptsResult::_meta,
+                    Prompt.CODEC,
+                    (items, pr) -> new ListPromptsResult(items, pr.nextCursor(), pr._meta()));
 
     public ListPromptsResult {
         prompts = Immutable.list(prompts);

--- a/src/main/java/com/amannmalik/mcp/resources/ListResourceTemplatesRequest.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ListResourceTemplatesRequest.java
@@ -7,18 +7,10 @@ import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
 public record ListResourceTemplatesRequest(String cursor, JsonObject _meta) {
-    public static final JsonCodec<ListResourceTemplatesRequest> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListResourceTemplatesRequest req) {
-            return AbstractEntityCodec.toJson(new PaginatedRequest(req.cursor(), req._meta()));
-        }
-
-        @Override
-        public ListResourceTemplatesRequest fromJson(JsonObject obj) {
-            PaginatedRequest pr = AbstractEntityCodec.fromPaginatedRequest(obj);
-            return new ListResourceTemplatesRequest(pr.cursor(), pr._meta());
-        }
-    };
+    public static final JsonCodec<ListResourceTemplatesRequest> CODEC =
+            AbstractEntityCodec.paginatedRequest(
+                    r -> new PaginatedRequest(r.cursor(), r._meta()),
+                    pr -> new ListResourceTemplatesRequest(pr.cursor(), pr._meta()));
 
     public ListResourceTemplatesRequest {
         MetaValidator.requireValid(_meta);

--- a/src/main/java/com/amannmalik/mcp/resources/ListResourceTemplatesResult.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ListResourceTemplatesResult.java
@@ -11,32 +11,14 @@ import java.util.*;
 public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates,
                                           String nextCursor,
                                           JsonObject _meta) {
-    public static final JsonCodec<ListResourceTemplatesResult> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListResourceTemplatesResult r) {
-            return AbstractEntityCodec.paginated(
+    public static final JsonCodec<ListResourceTemplatesResult> CODEC =
+            AbstractEntityCodec.paginatedResult(
                     "resourceTemplates",
-                    new Pagination.Page<>(r.resourceTemplates(), r.nextCursor()),
-                    ResourceTemplate.CODEC::toJson,
-                    r._meta());
-        }
-
-        @Override
-        public ListResourceTemplatesResult fromJson(JsonObject obj) {
-            if (obj == null) throw new IllegalArgumentException("object required");
-            JsonArray arr = obj.getJsonArray("resourceTemplates");
-            if (arr == null) throw new IllegalArgumentException("resourceTemplates required");
-            List<ResourceTemplate> templates = new ArrayList<>();
-            for (JsonValue v : arr) {
-                if (v.getValueType() != JsonValue.ValueType.OBJECT) {
-                    throw new IllegalArgumentException("resourceTemplate must be object");
-                }
-                templates.add(ResourceTemplate.CODEC.fromJson(v.asJsonObject()));
-            }
-            PaginatedResult pr = AbstractEntityCodec.fromPaginatedResult(obj);
-            return new ListResourceTemplatesResult(templates, pr.nextCursor(), pr._meta());
-        }
-    };
+                    "resourceTemplate",
+                    r -> new Pagination.Page<>(r.resourceTemplates(), r.nextCursor()),
+                    ListResourceTemplatesResult::_meta,
+                    ResourceTemplate.CODEC,
+                    (items, pr) -> new ListResourceTemplatesResult(items, pr.nextCursor(), pr._meta()));
 
     public ListResourceTemplatesResult {
         resourceTemplates = Immutable.list(resourceTemplates);

--- a/src/main/java/com/amannmalik/mcp/resources/ListResourcesRequest.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ListResourcesRequest.java
@@ -7,18 +7,10 @@ import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
 public record ListResourcesRequest(String cursor, JsonObject _meta) {
-    public static final JsonCodec<ListResourcesRequest> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListResourcesRequest req) {
-            return AbstractEntityCodec.toJson(new PaginatedRequest(req.cursor(), req._meta()));
-        }
-
-        @Override
-        public ListResourcesRequest fromJson(JsonObject obj) {
-            PaginatedRequest pr = AbstractEntityCodec.fromPaginatedRequest(obj);
-            return new ListResourcesRequest(pr.cursor(), pr._meta());
-        }
-    };
+    public static final JsonCodec<ListResourcesRequest> CODEC =
+            AbstractEntityCodec.paginatedRequest(
+                    r -> new PaginatedRequest(r.cursor(), r._meta()),
+                    pr -> new ListResourcesRequest(pr.cursor(), pr._meta()));
 
     public ListResourcesRequest {
         MetaValidator.requireValid(_meta);

--- a/src/main/java/com/amannmalik/mcp/resources/ListResourcesResult.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ListResourcesResult.java
@@ -11,32 +11,14 @@ import java.util.*;
 public record ListResourcesResult(List<Resource> resources,
                                   String nextCursor,
                                   JsonObject _meta) {
-    public static final JsonCodec<ListResourcesResult> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListResourcesResult r) {
-            return AbstractEntityCodec.paginated(
+    public static final JsonCodec<ListResourcesResult> CODEC =
+            AbstractEntityCodec.paginatedResult(
                     "resources",
-                    new Pagination.Page<>(r.resources(), r.nextCursor()),
-                    Resource.CODEC::toJson,
-                    r._meta());
-        }
-
-        @Override
-        public ListResourcesResult fromJson(JsonObject obj) {
-            if (obj == null) throw new IllegalArgumentException("object required");
-            JsonArray arr = obj.getJsonArray("resources");
-            if (arr == null) throw new IllegalArgumentException("resources required");
-            List<Resource> resources = new ArrayList<>();
-            for (JsonValue v : arr) {
-                if (v.getValueType() != JsonValue.ValueType.OBJECT) {
-                    throw new IllegalArgumentException("resource must be object");
-                }
-                resources.add(Resource.CODEC.fromJson(v.asJsonObject()));
-            }
-            PaginatedResult pr = AbstractEntityCodec.fromPaginatedResult(obj);
-            return new ListResourcesResult(resources, pr.nextCursor(), pr._meta());
-        }
-    };
+                    "resource",
+                    r -> new Pagination.Page<>(r.resources(), r.nextCursor()),
+                    ListResourcesResult::_meta,
+                    Resource.CODEC,
+                    (items, pr) -> new ListResourcesResult(items, pr.nextCursor(), pr._meta()));
 
     public ListResourcesResult {
         resources = Immutable.list(resources);

--- a/src/main/java/com/amannmalik/mcp/tools/ListToolsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/tools/ListToolsRequest.java
@@ -7,18 +7,10 @@ import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.JsonObject;
 
 public record ListToolsRequest(String cursor, JsonObject _meta) {
-    public static final JsonCodec<ListToolsRequest> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListToolsRequest req) {
-            return AbstractEntityCodec.toJson(new PaginatedRequest(req.cursor(), req._meta()));
-        }
-
-        @Override
-        public ListToolsRequest fromJson(JsonObject obj) {
-            PaginatedRequest pr = AbstractEntityCodec.fromPaginatedRequest(obj);
-            return new ListToolsRequest(pr.cursor(), pr._meta());
-        }
-    };
+    public static final JsonCodec<ListToolsRequest> CODEC =
+            AbstractEntityCodec.paginatedRequest(
+                    r -> new PaginatedRequest(r.cursor(), r._meta()),
+                    pr -> new ListToolsRequest(pr.cursor(), pr._meta()));
 
     public ListToolsRequest {
         MetaValidator.requireValid(_meta);

--- a/src/main/java/com/amannmalik/mcp/tools/ListToolsResult.java
+++ b/src/main/java/com/amannmalik/mcp/tools/ListToolsResult.java
@@ -11,32 +11,14 @@ import java.util.*;
 public record ListToolsResult(List<Tool> tools,
                               String nextCursor,
                               JsonObject _meta) {
-    public static final JsonCodec<ListToolsResult> CODEC = new JsonCodec<>() {
-        @Override
-        public JsonObject toJson(ListToolsResult r) {
-            return AbstractEntityCodec.paginated(
+    public static final JsonCodec<ListToolsResult> CODEC =
+            AbstractEntityCodec.paginatedResult(
                     "tools",
-                    new Pagination.Page<>(r.tools(), r.nextCursor()),
-                    Tool.CODEC::toJson,
-                    r._meta());
-        }
-
-        @Override
-        public ListToolsResult fromJson(JsonObject obj) {
-            if (obj == null) throw new IllegalArgumentException("object required");
-            JsonArray arr = obj.getJsonArray("tools");
-            if (arr == null) throw new IllegalArgumentException("tools required");
-            List<Tool> tools = new ArrayList<>();
-            for (JsonValue v : arr) {
-                if (v.getValueType() != JsonValue.ValueType.OBJECT) {
-                    throw new IllegalArgumentException("tool must be object");
-                }
-                tools.add(Tool.CODEC.fromJson(v.asJsonObject()));
-            }
-            PaginatedResult pr = AbstractEntityCodec.fromPaginatedResult(obj);
-            return new ListToolsResult(tools, pr.nextCursor(), pr._meta());
-        }
-    };
+                    "tool",
+                    r -> new Pagination.Page<>(r.tools(), r.nextCursor()),
+                    ListToolsResult::_meta,
+                    Tool.CODEC,
+                    (items, pr) -> new ListToolsResult(items, pr.nextCursor(), pr._meta()));
 
     public ListToolsResult {
         tools = Immutable.list(tools);


### PR DESCRIPTION
## Summary
- centralize generic pagination codecs
- trim boilerplate in list request/response models

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fed50d8d08324b42753064c59bb83