### PR TITLE
refactor: unify json codecs

### DIFF
--- a/src/main/java/com/amannmalik/mcp/logging/LoggingMessageNotification.java
+++ b/src/main/java/com/amannmalik/mcp/logging/LoggingMessageNotification.java
@@ -1,14 +1,14 @@
 package com.amannmalik.mcp.logging;
 
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.*;
 
 import java.util.Set;
 
 public record LoggingMessageNotification(LoggingLevel level, String logger, JsonValue data) {
-    public static final JsonCodec<LoggingMessageNotification> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<LoggingMessageNotification> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(LoggingMessageNotification n) {
             JsonObjectBuilder b = Json.createObjectBuilder()
@@ -21,9 +21,8 @@ public record LoggingMessageNotification(LoggingLevel level, String logger, Json
         @Override
         public LoggingMessageNotification fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("level", "logger", "data"));
-            String raw = obj.getString("level", null);
-            if (raw == null) throw new IllegalArgumentException("level required");
+            requireOnlyKeys(obj, Set.of("level", "logger", "data"));
+            String raw = requireString(obj, "level");
             LoggingLevel level = LoggingLevel.fromString(raw);
             JsonValue data = obj.get("data");
             if (data == null) throw new IllegalArgumentException("data required");

--- a/src/main/java/com/amannmalik/mcp/logging/SetLevelRequest.java
+++ b/src/main/java/com/amannmalik/mcp/logging/SetLevelRequest.java
@@ -1,14 +1,14 @@
 package com.amannmalik.mcp.logging;
 
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.*;
 
 import java.util.Set;
 
 public record SetLevelRequest(LoggingLevel level, JsonObject _meta) {
-    public static final JsonCodec<SetLevelRequest> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<SetLevelRequest> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(SetLevelRequest req) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("level", req.level().name().toLowerCase());
@@ -19,9 +19,8 @@ public record SetLevelRequest(LoggingLevel level, JsonObject _meta) {
         @Override
         public SetLevelRequest fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("level", "_meta"));
-            String raw = obj.getString("level", null);
-            if (raw == null) throw new IllegalArgumentException("level required");
+            requireOnlyKeys(obj, Set.of("level", "_meta"));
+            String raw = requireString(obj, "level");
             LoggingLevel level = LoggingLevel.fromString(raw);
             return new SetLevelRequest(level, obj.getJsonObject("_meta"));
         }

--- a/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
@@ -1,7 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.*;
@@ -13,7 +13,7 @@ import java.util.Set;
 public record GetPromptRequest(String name,
                                Map<String, String> arguments,
                                JsonObject _meta) {
-    public static final JsonCodec<GetPromptRequest> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<GetPromptRequest> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(GetPromptRequest req) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("name", req.name());
@@ -29,9 +29,8 @@ public record GetPromptRequest(String name,
         @Override
         public GetPromptRequest fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("params required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("name", "arguments", "_meta"));
-            String name = obj.getString("name", null);
-            if (name == null) throw new IllegalArgumentException("name required");
+            requireOnlyKeys(obj, Set.of("name", "arguments", "_meta"));
+            String name = requireString(obj, "name");
             JsonObject argsObj = obj.getJsonObject("arguments");
             Map<String, String> args = Map.of();
             if (argsObj != null) {

--- a/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/Prompt.java
@@ -1,7 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.util.DisplayNameProvider;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
@@ -18,7 +18,7 @@ public record Prompt(
         List<PromptArgument> arguments,
         JsonObject _meta
 ) implements DisplayNameProvider {
-    public static final JsonCodec<Prompt> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<Prompt> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(Prompt prompt) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("name", prompt.name());
@@ -36,9 +36,8 @@ public record Prompt(
         @Override
         public Prompt fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("name", "title", "description", "arguments", "_meta"));
-            String name = obj.getString("name", null);
-            if (name == null) throw new IllegalArgumentException("name required");
+            requireOnlyKeys(obj, Set.of("name", "title", "description", "arguments", "_meta"));
+            String name = requireString(obj, "name");
             String title = obj.getString("title", null);
             String description = obj.getString("description", null);
             JsonObject meta = obj.getJsonObject("_meta");

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
@@ -1,7 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.util.DisplayNameProvider;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
@@ -16,7 +16,7 @@ public record PromptArgument(
         boolean required,
         JsonObject _meta
 ) implements DisplayNameProvider {
-    public static final JsonCodec<PromptArgument> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<PromptArgument> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(PromptArgument a) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("name", a.name());
@@ -30,9 +30,8 @@ public record PromptArgument(
         @Override
         public PromptArgument fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("name", "title", "description", "required", "_meta"));
-            String name = obj.getString("name", null);
-            if (name == null) throw new IllegalArgumentException("name required");
+            requireOnlyKeys(obj, Set.of("name", "title", "description", "required", "_meta"));
+            String name = requireString(obj, "name");
             String title = obj.getString("title", null);
             String description = obj.getString("description", null);
             boolean required = obj.getBoolean("required", false);

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptInstance.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptInstance.java
@@ -1,7 +1,7 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import jakarta.json.*;
 
 import java.util.ArrayList;
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 public record PromptInstance(String description, List<PromptMessage> messages) {
-    public static final JsonCodec<PromptInstance> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<PromptInstance> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(PromptInstance inst) {
             JsonArrayBuilder msgs = Json.createArrayBuilder();
@@ -22,7 +22,7 @@ public record PromptInstance(String description, List<PromptMessage> messages) {
         @Override
         public PromptInstance fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("messages", "description"));
+            requireOnlyKeys(obj, Set.of("messages", "description"));
             JsonArray arr = obj.getJsonArray("messages");
             if (arr == null) throw new IllegalArgumentException("messages required");
             List<PromptMessage> msgs = new ArrayList<>();

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptMessage.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptMessage.java
@@ -1,14 +1,14 @@
 package com.amannmalik.mcp.prompts;
 
 import com.amannmalik.mcp.content.ContentBlock;
-import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.JsonCodec;
 import jakarta.json.*;
 
 import java.util.Set;
 
 public record PromptMessage(Role role, PromptContent content) {
-    public static final JsonCodec<PromptMessage> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<PromptMessage> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(PromptMessage m) {
             return Json.createObjectBuilder()
@@ -20,11 +20,10 @@ public record PromptMessage(Role role, PromptContent content) {
         @Override
         public PromptMessage fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("role", "content"));
-            String raw = obj.getString("role", null);
-            if (raw == null) throw new IllegalArgumentException("role required");
+            requireOnlyKeys(obj, Set.of("role", "content"));
+            String raw = requireString(obj, "role");
             Role role = Role.valueOf(raw.toUpperCase());
-            JsonObject c = obj.getJsonObject("content");
+            JsonObject c = getObject(obj, "content");
             if (c == null) throw new IllegalArgumentException("content required");
             PromptContent content = (PromptContent) ContentBlock.CODEC.fromJson(c);
             return new PromptMessage(role, content);

--- a/src/main/java/com/amannmalik/mcp/tools/ToolAnnotations.java
+++ b/src/main/java/com/amannmalik/mcp/tools/ToolAnnotations.java
@@ -1,8 +1,11 @@
 package com.amannmalik.mcp.tools;
 
+import com.amannmalik.mcp.core.AbstractEntityCodec;
 import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.*;
+
+import java.util.Set;
 
 public record ToolAnnotations(
         String title,
@@ -11,7 +14,7 @@ public record ToolAnnotations(
         Boolean idempotentHint,
         Boolean openWorldHint
 ) {
-    public static final JsonCodec<ToolAnnotations> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<ToolAnnotations> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(ToolAnnotations ann) {
             JsonObjectBuilder b = Json.createObjectBuilder();
@@ -26,6 +29,7 @@ public record ToolAnnotations(
         @Override
         public ToolAnnotations fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
+            requireOnlyKeys(obj, Set.of("title", "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"));
             String title = obj.getString("title", null);
             Boolean readOnly = obj.containsKey("readOnlyHint") ? obj.getBoolean("readOnlyHint") : null;
             Boolean destructive = obj.containsKey("destructiveHint") ? obj.getBoolean("destructiveHint") : null;

--- a/src/main/java/com/amannmalik/mcp/tools/ToolResult.java
+++ b/src/main/java/com/amannmalik/mcp/tools/ToolResult.java
@@ -1,15 +1,18 @@
 package com.amannmalik.mcp.tools;
 
 import com.amannmalik.mcp.content.ContentBlock;
+import com.amannmalik.mcp.core.AbstractEntityCodec;
 import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.*;
+
+import java.util.Set;
 
 public record ToolResult(JsonArray content,
                          JsonObject structuredContent,
                          Boolean isError,
                          JsonObject _meta) {
-    public static final JsonCodec<ToolResult> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<ToolResult> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(ToolResult r) {
             JsonObjectBuilder b = Json.createObjectBuilder()
@@ -23,6 +26,7 @@ public record ToolResult(JsonArray content,
         @Override
         public ToolResult fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
+            requireOnlyKeys(obj, Set.of("content", "structuredContent", "isError", "_meta"));
             JsonArray content = obj.getJsonArray("content");
             if (content == null) throw new IllegalArgumentException("content required");
             JsonObject structured = obj.getJsonObject("structuredContent");


### PR DESCRIPTION
## Summary
- extend prompts and tools codecs from AbstractEntityCodec for shared field validation
- standardize logging codecs on AbstractEntityCodec

## Testing
- `gradle test --console=plain --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_688ff9475f308324a8c4183a57196bd9