### PR TITLE
refactor: unify codecs

### DIFF
--- a/src/main/java/com/amannmalik/mcp/logging/LoggingMessageNotification.java
+++ b/src/main/java/com/amannmalik/mcp/logging/LoggingMessageNotification.java
@@ -1,14 +1,13 @@
 package com.amannmalik.mcp.logging;
 
-import com.amannmalik.mcp.core.JsonCodec;
-import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.*;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.*;
 
 import java.util.Set;
 
 public record LoggingMessageNotification(LoggingLevel level, String logger, JsonValue data) {
-    public static final JsonCodec<LoggingMessageNotification> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<LoggingMessageNotification> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(LoggingMessageNotification n) {
             JsonObjectBuilder b = Json.createObjectBuilder()
@@ -21,7 +20,7 @@ public record LoggingMessageNotification(LoggingLevel level, String logger, Json
         @Override
         public LoggingMessageNotification fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("level", "logger", "data"));
+            requireOnlyKeys(obj, Set.of("level", "logger", "data"));
             String raw = obj.getString("level", null);
             if (raw == null) throw new IllegalArgumentException("level required");
             LoggingLevel level = LoggingLevel.fromString(raw);

--- a/src/main/java/com/amannmalik/mcp/logging/SetLevelRequest.java
+++ b/src/main/java/com/amannmalik/mcp/logging/SetLevelRequest.java
@@ -1,14 +1,13 @@
 package com.amannmalik.mcp.logging;
 
-import com.amannmalik.mcp.core.JsonCodec;
-import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.*;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.*;
 
 import java.util.Set;
 
 public record SetLevelRequest(LoggingLevel level, JsonObject _meta) {
-    public static final JsonCodec<SetLevelRequest> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<SetLevelRequest> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(SetLevelRequest req) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("level", req.level().name().toLowerCase());
@@ -19,7 +18,7 @@ public record SetLevelRequest(LoggingLevel level, JsonObject _meta) {
         @Override
         public SetLevelRequest fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("level", "_meta"));
+            requireOnlyKeys(obj, Set.of("level", "_meta"));
             String raw = obj.getString("level", null);
             if (raw == null) throw new IllegalArgumentException("level required");
             LoggingLevel level = LoggingLevel.fromString(raw);

--- a/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/GetPromptRequest.java
@@ -1,7 +1,6 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.core.JsonCodec;
-import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.*;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.*;
@@ -13,7 +12,7 @@ import java.util.Set;
 public record GetPromptRequest(String name,
                                Map<String, String> arguments,
                                JsonObject _meta) {
-    public static final JsonCodec<GetPromptRequest> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<GetPromptRequest> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(GetPromptRequest req) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("name", req.name());
@@ -29,7 +28,7 @@ public record GetPromptRequest(String name,
         @Override
         public GetPromptRequest fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("params required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("name", "arguments", "_meta"));
+            requireOnlyKeys(obj, Set.of("name", "arguments", "_meta"));
             String name = obj.getString("name", null);
             if (name == null) throw new IllegalArgumentException("name required");
             JsonObject argsObj = obj.getJsonObject("arguments");

--- a/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/PromptArgument.java
@@ -1,7 +1,6 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.core.JsonCodec;
-import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.core.*;
 import com.amannmalik.mcp.util.DisplayNameProvider;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
@@ -16,7 +15,7 @@ public record PromptArgument(
         boolean required,
         JsonObject _meta
 ) implements DisplayNameProvider {
-    public static final JsonCodec<PromptArgument> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<PromptArgument> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(PromptArgument a) {
             JsonObjectBuilder b = Json.createObjectBuilder().add("name", a.name());
@@ -30,7 +29,7 @@ public record PromptArgument(
         @Override
         public PromptArgument fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
-            AbstractEntityCodec.requireOnlyKeys(obj, Set.of("name", "title", "description", "required", "_meta"));
+            requireOnlyKeys(obj, Set.of("name", "title", "description", "required", "_meta"));
             String name = obj.getString("name", null);
             if (name == null) throw new IllegalArgumentException("name required");
             String title = obj.getString("title", null);

--- a/src/main/java/com/amannmalik/mcp/util/CancelledNotification.java
+++ b/src/main/java/com/amannmalik/mcp/util/CancelledNotification.java
@@ -1,16 +1,17 @@
 package com.amannmalik.mcp.util;
 
-import com.amannmalik.mcp.core.JsonCodec;
+import com.amannmalik.mcp.core.*;
 import com.amannmalik.mcp.jsonrpc.RequestId;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import jakarta.json.*;
+import java.util.Set;
 
 public record CancelledNotification(RequestId requestId, String reason) {
-    public static final JsonCodec<CancelledNotification> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<CancelledNotification> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(CancelledNotification note) {
-            JsonObjectBuilder b = Json.createObjectBuilder();
-            b.add("requestId", RequestId.toJsonValue(note.requestId()));
+            JsonObjectBuilder b = Json.createObjectBuilder()
+                    .add("requestId", RequestId.toJsonValue(note.requestId()));
             if (note.reason() != null) b.add("reason", note.reason());
             return b.build();
         }
@@ -18,6 +19,7 @@ public record CancelledNotification(RequestId requestId, String reason) {
         @Override
         public CancelledNotification fromJson(JsonObject obj) {
             if (obj == null) throw new IllegalArgumentException("object required");
+            requireOnlyKeys(obj, Set.of("requestId", "reason"));
             RequestId id = RequestId.from(obj.get("requestId"));
             String reason = obj.getString("reason", null);
             return new CancelledNotification(id, reason);

--- a/src/main/java/com/amannmalik/mcp/util/ProgressNotification.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressNotification.java
@@ -1,11 +1,11 @@
 package com.amannmalik.mcp.util;
 
-import com.amannmalik.mcp.core.JsonCodec;
+import com.amannmalik.mcp.core.*;
 import com.amannmalik.mcp.validation.InputSanitizer;
 import com.amannmalik.mcp.validation.MetaValidator;
 import jakarta.json.*;
 
-import java.util.Optional;
+import java.util.*;
 
 public record ProgressNotification(
         ProgressToken token,
@@ -13,7 +13,7 @@ public record ProgressNotification(
         Double total,
         String message
 ) {
-    public static final JsonCodec<ProgressNotification> CODEC = new JsonCodec<>() {
+    public static final JsonCodec<ProgressNotification> CODEC = new AbstractEntityCodec<>() {
         @Override
         public JsonObject toJson(ProgressNotification note) {
             JsonObjectBuilder b = Json.createObjectBuilder();
@@ -29,6 +29,8 @@ public record ProgressNotification(
 
         @Override
         public ProgressNotification fromJson(JsonObject obj) {
+            if (obj == null) throw new IllegalArgumentException("object required");
+            requireOnlyKeys(obj, Set.of("progressToken", "progress", "total", "message"));
             ProgressToken token = switch (obj.get("progressToken").getValueType()) {
                 case STRING -> new ProgressToken.StringToken(InputSanitizer.requireClean(obj.getString("progressToken")));
                 case NUMBER -> new ProgressToken.NumericToken(obj.getJsonNumber("progressToken").longValue());


### PR DESCRIPTION
## Summary
- use AbstractEntityCodec for logging, prompts, and utility codecs to streamline validation
- centralize key checking via requireOnlyKeys across converted records

## Testing
- `gradle test --stacktrace`


------
https://chatgpt.com/codex/tasks/task_e_688ff9475f308324a8c4183a57196bd9