### PR TITLE
refactor: unify json-rpc codec

### DIFF
--- a/src/main/java/com/amannmalik/mcp/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/McpClient.java
@@ -176,14 +176,14 @@ public final class McpClient implements AutoCloseable {
         RequestId reqId = new RequestId.NumericId(id.getAndIncrement());
         JsonRpcRequest request = new JsonRpcRequest(reqId, RequestMethod.INITIALIZE.method(), initJson);
         try {
-            transport.send(JsonRpcCodec.toJsonObject(request));
+            transport.send(JsonRpcCodec.CODEC.toJson(request));
         } catch (UnauthorizedException e) {
             handleUnauthorized(e);
             throw e;
         }
         CompletableFuture<JsonRpcMessage> future = CompletableFuture.supplyAsync(() -> {
             try {
-                return JsonRpcCodec.fromJsonObject(transport.receive());
+                return JsonRpcCodec.CODEC.fromJson(transport.receive());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -237,7 +237,7 @@ public final class McpClient implements AutoCloseable {
 
     private void notifyInitialized() throws IOException {
         JsonRpcNotification note = new JsonRpcNotification(NotificationMethod.INITIALIZED.method(), null);
-        transport.send(JsonRpcCodec.toJsonObject(note));
+        transport.send(JsonRpcCodec.CODEC.toJson(note));
     }
 
     private void subscribeRootsIfNeeded() throws IOException {
@@ -356,7 +356,7 @@ public final class McpClient implements AutoCloseable {
         var future = new CompletableFuture<JsonRpcMessage>();
         pending.put(reqId, future);
         try {
-            transport.send(JsonRpcCodec.toJsonObject(new JsonRpcRequest(reqId, method, params)));
+            transport.send(JsonRpcCodec.CODEC.toJson(new JsonRpcRequest(reqId, method, params)));
             return awaitResponse(reqId, future, timeoutMillis);
         } catch (UnauthorizedException e) {
             handleUnauthorized(e);
@@ -392,7 +392,7 @@ public final class McpClient implements AutoCloseable {
     public void notify(String method, JsonObject params) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
         JsonRpcNotification notification = new JsonRpcNotification(method, params);
-        transport.send(JsonRpcCodec.toJsonObject(notification));
+        transport.send(JsonRpcCodec.CODEC.toJson(notification));
     }
 
     public void notify(NotificationMethod method, JsonObject params) throws IOException {
@@ -500,7 +500,7 @@ public final class McpClient implements AutoCloseable {
         while (connected) {
             JsonRpcMessage msg;
             try {
-                msg = JsonRpcCodec.fromJsonObject(transport.receive());
+                msg = JsonRpcCodec.CODEC.fromJson(transport.receive());
             } catch (IOException e) {
                 pending.values().forEach(f -> f.completeExceptionally(e));
                 break;
@@ -612,7 +612,7 @@ public final class McpClient implements AutoCloseable {
     }
 
     private void send(JsonRpcMessage msg) throws IOException {
-        transport.send(JsonRpcCodec.toJsonObject(msg));
+        transport.send(JsonRpcCodec.CODEC.toJson(msg));
     }
 
     private void requireCapability(RequestMethod method) {

--- a/src/main/java/com/amannmalik/mcp/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/McpServer.java
@@ -188,7 +188,7 @@ public final class McpServer implements AutoCloseable {
             var obj = receiveMessage();
             if (obj.isEmpty()) continue;
             try {
-                processMessage(JsonRpcCodec.fromJsonObject(obj.get()));
+                processMessage(JsonRpcCodec.CODEC.fromJson(obj.get()));
             } catch (IllegalArgumentException e) {
                 handleInvalidRequest(e);
             } catch (IOException e) {
@@ -311,7 +311,7 @@ public final class McpServer implements AutoCloseable {
     }
 
     private synchronized void send(JsonRpcMessage msg) throws IOException {
-        transport.send(JsonRpcCodec.toJsonObject(msg));
+        transport.send(JsonRpcCodec.CODEC.toJson(msg));
     }
 
     private void requireClientCapability(ClientCapability cap) {
@@ -553,7 +553,7 @@ public final class McpServer implements AutoCloseable {
             var obj = receiveMessage();
             if (obj.isEmpty()) continue;
             try {
-                processMessage(JsonRpcCodec.fromJsonObject(obj.get()));
+                processMessage(JsonRpcCodec.CODEC.fromJson(obj.get()));
             } catch (IllegalArgumentException ex) {
                 handleInvalidRequest(ex);
             }

--- a/src/main/java/com/amannmalik/mcp/transport/SseClients.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseClients.java
@@ -80,7 +80,7 @@ final class SseClients {
         responses.forEach((id, q) -> {
             RequestId reqId = RequestId.parse(id);
             JsonRpcError err = JsonRpcError.of(reqId, JsonRpcErrorCode.INTERNAL_ERROR, "Transport closed");
-            if (!q.offer(JsonRpcCodec.toJsonObject(err))) {
+            if (!q.offer(JsonRpcCodec.CODEC.toJson(err))) {
                 throw new IllegalStateException("queue full");
             }
         });


### PR DESCRIPTION
## Summary
- expose JsonRpcCodec as a JsonCodec<JsonRpcMessage>
- route client, server, and SSE helpers through the unified codec

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ff9475f308324a8c4183a57196bd9