### PR TITLE
Simplify JSON-RPC processing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/ProgressManager.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressManager.java
@@ -11,14 +11,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-public final class ProgressTracker {
+public final class ProgressManager {
     private final Map<ProgressToken, Double> progress = new ConcurrentHashMap<>();
     private final Map<RequestId, ProgressToken> tokens = new ConcurrentHashMap<>();
     private final Set<RequestId> active = ConcurrentHashMap.newKeySet();
     private final Map<RequestId, String> cancelled = new ConcurrentHashMap<>();
     private final RateLimiter limiter;
 
-    public ProgressTracker(RateLimiter limiter) {
+    public ProgressManager(RateLimiter limiter) {
         if (limiter == null) throw new IllegalArgumentException("limiter required");
         this.limiter = limiter;
     }


### PR DESCRIPTION
## Summary
- streamline request processor registration with direct method mapping
- merge progress and cancellation into unified manager

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_689009a8b858832481931981371146bf