### PR TITLE
Centralize validation utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/annotations/Annotations.java
+++ b/src/main/java/com/amannmalik/mcp/annotations/Annotations.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.annotations;
 
 import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.prompts.Role;
+import com.amannmalik.mcp.validation.ValidationUtil;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -57,9 +58,7 @@ public record Annotations(Set<Role> audience, Double priority, Instant lastModif
 
     public Annotations {
         audience = audience == null || audience.isEmpty() ? Set.of() : EnumSet.copyOf(audience);
-        if (priority != null && (priority < 0.0 || priority > 1.0)) {
-            throw new IllegalArgumentException("priority must be between 0.0 and 1.0");
-        }
+        if (priority != null) priority = ValidationUtil.requireFraction(priority, "priority");
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/completion/CompleteResult.java
+++ b/src/main/java/com/amannmalik/mcp/completion/CompleteResult.java
@@ -67,16 +67,13 @@ public record CompleteResult(Completion completion, JsonObject _meta) {
                     .map(InputSanitizer::requireClean)
                     .toList();
             this.values = copy;
-            this.total = total;
+            this.total = total == null ? null : ValidationUtil.requireNonNegative(total, "total");
             this.hasMore = hasMore;
             if (this.values.size() > MAX_VALUES) {
                 throw new IllegalArgumentException("values must not exceed " + MAX_VALUES + " items");
             }
-            if (this.total != null) {
-                if (this.total < 0) throw new IllegalArgumentException("total must be non-negative");
-                if (this.total < this.values.size()) {
-                    throw new IllegalArgumentException("total must be >= values length");
-                }
+            if (this.total != null && this.total < this.values.size()) {
+                throw new IllegalArgumentException("total must be >= values length");
             }
         }
     }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
@@ -22,10 +22,6 @@ public record JsonRpcError(RequestId id, ErrorDetail error) implements JsonRpcMe
         return new JsonRpcError(id, new ErrorDetail(code, message, data));
     }
 
-    public static JsonRpcError invalidParams(RequestId id, String message) {
-        return of(id, JsonRpcErrorCode.INVALID_PARAMS, message);
-    }
-
     public JsonRpcError {
         if (id == null || error == null) {
             throw new IllegalArgumentException("id and error are required");

--- a/src/main/java/com/amannmalik/mcp/ping/PingScheduler.java
+++ b/src/main/java/com/amannmalik/mcp/ping/PingScheduler.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.ping;
 
 import com.amannmalik.mcp.McpClient;
+import com.amannmalik.mcp.validation.ValidationUtil;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -25,13 +26,11 @@ public final class PingScheduler implements AutoCloseable {
                          int maxFailures) {
         Objects.requireNonNull(client, "client");
         Objects.requireNonNull(onFailure, "onFailure");
-        if (intervalMillis <= 0 || timeoutMillis <= 0) throw new IllegalArgumentException("invalid timing");
-        if (maxFailures <= 0) throw new IllegalArgumentException("maxFailures must be > 0");
         this.client = client;
-        this.interval = intervalMillis;
-        this.timeout = timeoutMillis;
+        this.interval = ValidationUtil.requirePositive(intervalMillis, "intervalMillis");
+        this.timeout = ValidationUtil.requirePositive(timeoutMillis, "timeoutMillis");
         this.onFailure = onFailure;
-        this.maxFailures = maxFailures;
+        this.maxFailures = ValidationUtil.requirePositive(maxFailures, "maxFailures");
     }
 
     public void start() {

--- a/src/main/java/com/amannmalik/mcp/resources/Resource.java
+++ b/src/main/java/com/amannmalik/mcp/resources/Resource.java
@@ -57,9 +57,7 @@ public record Resource(
         title = InputSanitizer.cleanNullable(title);
         description = InputSanitizer.cleanNullable(description);
         mimeType = InputSanitizer.cleanNullable(mimeType);
-        if (size != null && size < 0) {
-            throw new IllegalArgumentException("size must be >= 0");
-        }
+        if (size != null) size = ValidationUtil.requireNonNegative(size, "size");
         annotations = annotations == null ? Annotations.EMPTY : annotations;
         ValidationUtil.requireMeta(_meta);
     }

--- a/src/main/java/com/amannmalik/mcp/resources/ResourceFeature.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ResourceFeature.java
@@ -106,7 +106,7 @@ public final class ResourceFeature implements AutoCloseable {
             ListResourcesResult result = new ListResourcesResult(filtered, list.nextCursor(), null);
             return new JsonRpcResponse(req.id(), ListResourcesResult.CODEC.toJson(result));
         } catch (IllegalArgumentException e) {
-            return invalidParams(req, e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         }
     }
 
@@ -115,7 +115,7 @@ public final class ResourceFeature implements AutoCloseable {
         try {
             rrr = ReadResourceRequest.CODEC.fromJson(req.params());
         } catch (IllegalArgumentException e) {
-            return invalidParams(req, e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         }
         String uri = rrr.uri();
         if (!canAccessResource(uri)) {
@@ -142,7 +142,7 @@ public final class ResourceFeature implements AutoCloseable {
             ListResourceTemplatesResult result = new ListResourceTemplatesResult(filtered, page.nextCursor(), null);
             return new JsonRpcResponse(req.id(), ListResourceTemplatesResult.CODEC.toJson(result));
         } catch (IllegalArgumentException e) {
-            return invalidParams(req, e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         }
     }
 
@@ -151,7 +151,7 @@ public final class ResourceFeature implements AutoCloseable {
         try {
             sr = SubscribeRequest.CODEC.fromJson(req.params());
         } catch (IllegalArgumentException e) {
-            return invalidParams(req, e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         }
         String uri = sr.uri();
         if (!canAccessResource(uri)) {
@@ -188,7 +188,7 @@ public final class ResourceFeature implements AutoCloseable {
         try {
             ur = UnsubscribeRequest.CODEC.fromJson(req.params());
         } catch (IllegalArgumentException e) {
-            return invalidParams(req, e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         }
         String uri = ur.uri();
         if (!canAccessResource(uri)) {
@@ -226,10 +226,6 @@ public final class ResourceFeature implements AutoCloseable {
 
     private String sanitizeCursor(String cursor) {
         return cursor == null ? null : Pagination.sanitize(InputSanitizer.cleanNullable(cursor));
-    }
-
-    private JsonRpcError invalidParams(JsonRpcRequest req, String message) {
-        return JsonRpcError.invalidParams(req.id(), message);
     }
 
     private <S extends ListChangeSubscription> S subscribeListChanges(

--- a/src/main/java/com/amannmalik/mcp/sampling/CreateMessageRequest.java
+++ b/src/main/java/com/amannmalik/mcp/sampling/CreateMessageRequest.java
@@ -87,7 +87,7 @@ public record CreateMessageRequest(
         } else {
             stopSequences = stopSequences.stream().map(InputSanitizer::requireClean).toList();
         }
-        if (maxTokens <= 0) throw new IllegalArgumentException("maxTokens must be > 0");
+        maxTokens = ValidationUtil.requirePositive(maxTokens, "maxTokens");
         ValidationUtil.requireMeta(_meta);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/sampling/ModelPreferences.java
+++ b/src/main/java/com/amannmalik/mcp/sampling/ModelPreferences.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.sampling;
 
 import com.amannmalik.mcp.core.JsonCodec;
 import com.amannmalik.mcp.core.AbstractEntityCodec;
+import com.amannmalik.mcp.validation.ValidationUtil;
 import jakarta.json.*;
 
 import java.util.List;
@@ -46,14 +47,14 @@ public record ModelPreferences(
 
     public ModelPreferences {
         hints = hints == null || hints.isEmpty() ? List.of() : List.copyOf(hints);
-        if (costPriority != null && (costPriority < 0.0 || costPriority > 1.0)) {
-            throw new IllegalArgumentException("costPriority must be between 0.0 and 1.0");
+        if (costPriority != null) {
+            costPriority = ValidationUtil.requireFraction(costPriority, "costPriority");
         }
-        if (speedPriority != null && (speedPriority < 0.0 || speedPriority > 1.0)) {
-            throw new IllegalArgumentException("speedPriority must be between 0.0 and 1.0");
+        if (speedPriority != null) {
+            speedPriority = ValidationUtil.requireFraction(speedPriority, "speedPriority");
         }
-        if (intelligencePriority != null && (intelligencePriority < 0.0 || intelligencePriority > 1.0)) {
-            throw new IllegalArgumentException("intelligencePriority must be between 0.0 and 1.0");
+        if (intelligencePriority != null) {
+            intelligencePriority = ValidationUtil.requireFraction(intelligencePriority, "intelligencePriority");
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
+++ b/src/main/java/com/amannmalik/mcp/util/JsonRpcRequestProcessor.java
@@ -46,7 +46,7 @@ public final class JsonRpcRequestProcessor {
             token = progress.register(req.id(), req.params());
         } catch (IllegalArgumentException e) {
             cleanup(req.id());
-            return Optional.of(JsonRpcError.invalidParams(req.id(), e.getMessage()));
+            return Optional.of(JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage()));
         }
 
         try {
@@ -81,7 +81,7 @@ public final class JsonRpcRequestProcessor {
             if (resp == null) throw new IllegalStateException("handler returned null");
             return resp;
         } catch (IllegalArgumentException e) {
-            return JsonRpcError.invalidParams(req.id(), e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         } catch (Exception e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());
         }

--- a/src/main/java/com/amannmalik/mcp/util/Pagination.java
+++ b/src/main/java/com/amannmalik/mcp/util/Pagination.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.util;
 
 import com.amannmalik.mcp.config.McpConfiguration;
+import com.amannmalik.mcp.validation.ValidationUtil;
 
 import java.util.List;
 
@@ -13,8 +14,8 @@ public final class Pagination {
             McpConfiguration.current().performance().pagination().defaultPageSize();
 
     public static <T> Page<T> page(List<T> items, String cursor, int size) {
-        int start = decode(cursor);
-        if (start < 0 || start > items.size()) throw new IllegalArgumentException("Invalid cursor");
+        int start = ValidationUtil.requireNonNegative(decode(cursor), "cursor");
+        if (start > items.size()) throw new IllegalArgumentException("Invalid cursor");
         int end = Math.min(items.size(), start + size);
         List<T> slice = items.subList(start, end);
         String next = end < items.size() ? encode(end) : null;

--- a/src/main/java/com/amannmalik/mcp/util/ProgressNotification.java
+++ b/src/main/java/com/amannmalik/mcp/util/ProgressNotification.java
@@ -57,13 +57,9 @@ public record ProgressNotification(
 
     public ProgressNotification {
         if (token == null) throw new IllegalArgumentException("token is required");
-        if (Double.isNaN(progress) || Double.isInfinite(progress) || progress < 0.0) {
-            throw new IllegalArgumentException("progress must be >= 0 and finite");
-        }
+        progress = ValidationUtil.requireNonNegative(progress, "progress");
         if (total != null) {
-            if (Double.isNaN(total) || Double.isInfinite(total) || total <= 0.0) {
-                throw new IllegalArgumentException("total must be > 0 and finite");
-            }
+            total = ValidationUtil.requirePositive(total, "total");
             if (progress > total) {
                 throw new IllegalArgumentException("progress must not exceed total");
             }

--- a/src/main/java/com/amannmalik/mcp/util/RateLimiter.java
+++ b/src/main/java/com/amannmalik/mcp/util/RateLimiter.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.util;
 
+import com.amannmalik.mcp.validation.ValidationUtil;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -9,10 +10,8 @@ public final class RateLimiter {
     private final long windowMs;
 
     public RateLimiter(int limit, long windowMs) {
-        if (limit <= 0) throw new IllegalArgumentException("limit must be positive");
-        if (windowMs <= 0) throw new IllegalArgumentException("windowMs must be positive");
-        this.limit = limit;
-        this.windowMs = windowMs;
+        this.limit = ValidationUtil.requirePositive(limit, "limit");
+        this.windowMs = ValidationUtil.requirePositive(windowMs, "windowMs");
     }
 
     public void requireAllowance(String key) {

--- a/src/main/java/com/amannmalik/mcp/validation/ValidationUtil.java
+++ b/src/main/java/com/amannmalik/mcp/validation/ValidationUtil.java
@@ -108,6 +108,47 @@ public final class ValidationUtil {
         if (depth != 0) throw new IllegalArgumentException("Unmatched braces in URI template: " + template);
     }
 
+    public static int requirePositive(int value, String field) {
+        if (value <= 0) throw new IllegalArgumentException(field + " must be > 0");
+        return value;
+    }
+
+    public static long requirePositive(long value, String field) {
+        if (value <= 0) throw new IllegalArgumentException(field + " must be > 0");
+        return value;
+    }
+
+    public static double requirePositive(double value, String field) {
+        if (Double.isNaN(value) || Double.isInfinite(value) || value <= 0.0) {
+            throw new IllegalArgumentException(field + " must be > 0 and finite");
+        }
+        return value;
+    }
+
+    public static int requireNonNegative(int value, String field) {
+        if (value < 0) throw new IllegalArgumentException(field + " must be >= 0");
+        return value;
+    }
+
+    public static long requireNonNegative(long value, String field) {
+        if (value < 0) throw new IllegalArgumentException(field + " must be >= 0");
+        return value;
+    }
+
+    public static double requireNonNegative(double value, String field) {
+        if (Double.isNaN(value) || Double.isInfinite(value) || value < 0.0) {
+            throw new IllegalArgumentException(field + " must be >= 0 and finite");
+        }
+        return value;
+    }
+
+    public static double requireFraction(double value, String field) {
+        if (Double.isNaN(value) || Double.isInfinite(value) || value < 0.0 || value > 1.0) {
+            throw new IllegalArgumentException(field + " must be between 0.0 and 1.0");
+        }
+        return value;
+    }
+
     public static void validateSchema(JsonObject schema, JsonObject value) {
         if (schema == null) return;
         if (!"object".equals(schema.getString("type", null))) return;


### PR DESCRIPTION
## Summary
- centralize numeric validation in a shared `ValidationUtil`
- streamline domain models to use common validation helpers
- drop `JsonRpcError.invalidParams` wrapper in favor of direct error construction

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_689035fd92808324a5c10ef2b99621bb