### PR TITLE
Unify provider change notifications

### DIFF
--- a/src/main/java/com/amannmalik/mcp/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/McpClient.java
@@ -56,7 +56,7 @@ public final class McpClient implements AutoCloseable {
     private ServerInfo serverInfo;
     private final McpClientListener listener;
     private volatile ResourceMetadata resourceMetadata;
-    private final Map<String, ResourceListener> resourceListeners = new ConcurrentHashMap<>();
+    private final Map<String, ChangeListener<ResourceUpdate>> resourceListeners = new ConcurrentHashMap<>();
 
     private final JsonRpcRequestProcessor processor;
 
@@ -241,7 +241,7 @@ public final class McpClient implements AutoCloseable {
     private void subscribeRootsIfNeeded() throws IOException {
         if (roots == null || !capabilities.contains(ClientCapability.ROOTS) || !rootsListChangedSupported) return;
         try {
-            rootsSubscription = roots.subscribe(() -> {
+            rootsSubscription = roots.subscribe(c -> {
                 try {
                     notify(NotificationMethod.ROOTS_LIST_CHANGED,
                             RootsListChangedNotification.CODEC.toJson(new RootsListChangedNotification()));
@@ -442,7 +442,7 @@ public final class McpClient implements AutoCloseable {
         return ListResourceTemplatesResult.CODEC.fromJson(resp.result());
     }
 
-    public ResourceSubscription subscribeResource(String uri, ResourceListener listener) throws IOException {
+    public ResourceSubscription subscribeResource(String uri, ChangeListener<ResourceUpdate> listener) throws IOException {
         if (!serverFeatures.resourcesSubscribe()) {
             throw new IllegalStateException("resource subscribe not supported");
         }
@@ -651,9 +651,9 @@ public final class McpClient implements AutoCloseable {
         if (note.params() == null) return;
         try {
             ResourceUpdatedNotification run = ResourceUpdatedNotification.CODEC.fromJson(note.params());
-            ResourceListener listener = resourceListeners.get(run.uri());
+            ChangeListener<ResourceUpdate> listener = resourceListeners.get(run.uri());
             if (listener != null) {
-                listener.updated(new ResourceUpdate(run.uri(), run.title()));
+                listener.changed(new ResourceUpdate(run.uri(), run.title()));
             }
         } catch (IllegalArgumentException ignore) {
         }

--- a/src/main/java/com/amannmalik/mcp/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/McpServer.java
@@ -117,14 +117,14 @@ public final class McpServer implements AutoCloseable {
 
         if (tools != null && tools.supportsListChanged()) {
             toolListSubscription = subscribeListChanges(
-                    (ChangeListener<Tool> l) -> tools.subscribe(l),
+                    tools::subscribe,
                     NotificationMethod.TOOLS_LIST_CHANGED,
                     ToolListChangedNotification.CODEC.toJson(new ToolListChangedNotification()));
         }
 
         if (prompts != null && prompts.supportsListChanged()) {
             promptsSubscription = subscribeListChanges(
-                    (ChangeListener<Prompt> l) -> prompts.subscribe(l),
+                    prompts::subscribe,
                     NotificationMethod.PROMPTS_LIST_CHANGED,
                     PromptListChangedNotification.CODEC.toJson(new PromptListChangedNotification()));
         }
@@ -158,12 +158,12 @@ public final class McpServer implements AutoCloseable {
         processor.registerRequest(RequestMethod.SAMPLING_CREATE_MESSAGE.method(), this::handleCreateMessage);
     }
 
-    private <S extends ChangeSubscription, T> S subscribeListChanges(
-            SubscriptionFactory<S, T> factory,
+    private <S extends ChangeSubscription> S subscribeListChanges(
+            SubscriptionFactory<S> factory,
             NotificationMethod method,
             JsonObject payload) {
         try {
-            return factory.subscribe(() -> {
+            return factory.subscribe(c -> {
                 if (lifecycle.state() != LifecycleState.OPERATION) return;
                 try {
                     send(new JsonRpcNotification(method.method(), payload));
@@ -176,8 +176,8 @@ public final class McpServer implements AutoCloseable {
     }
 
     @FunctionalInterface
-    private interface SubscriptionFactory<S extends ChangeSubscription, T> {
-        S subscribe(ChangeListener<T> listener);
+    private interface SubscriptionFactory<S extends ChangeSubscription> {
+        S subscribe(ChangeListener<Change> listener);
     }
 
     public void serve() throws IOException {
@@ -553,7 +553,7 @@ public final class McpServer implements AutoCloseable {
         return rootsManager.listRoots();
     }
 
-    public ChangeSubscription subscribeRoots(ChangeListener<Root> listener) {
+    public ChangeSubscription subscribeRoots(ChangeListener<Change> listener) {
         return rootsManager.subscribe(listener);
     }
 

--- a/src/main/java/com/amannmalik/mcp/core/Provider.java
+++ b/src/main/java/com/amannmalik/mcp/core/Provider.java
@@ -1,5 +1,6 @@
 package com.amannmalik.mcp.core;
 
+import com.amannmalik.mcp.util.Change;
 import com.amannmalik.mcp.util.ChangeListener;
 import com.amannmalik.mcp.util.ChangeSubscription;
 import com.amannmalik.mcp.util.Pagination;
@@ -7,7 +8,7 @@ import com.amannmalik.mcp.util.Pagination;
 public interface Provider<T> extends AutoCloseable {
     Pagination.Page<T> list(String cursor);
 
-    default ChangeSubscription subscribe(ChangeListener<T> listener) {
+    default ChangeSubscription subscribe(ChangeListener<Change> listener) {
         return () -> {};
     }
 

--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class InMemoryPromptProvider implements PromptProvider {
     private final Map<String, PromptTemplate> templates = new ConcurrentHashMap<>();
-    private final ChangeSupport<Prompt> listChangeSupport = new ChangeSupport<>();
+    private final ChangeSupport<Change> listChangeSupport = new ChangeSupport<>();
 
     public void add(PromptTemplate template) {
         String name = template.prompt().name();
@@ -40,7 +40,7 @@ public final class InMemoryPromptProvider implements PromptProvider {
     }
 
     @Override
-    public ChangeSubscription subscribe(ChangeListener<Prompt> listener) {
+    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
         return listChangeSupport.subscribe(listener);
     }
 
@@ -50,6 +50,6 @@ public final class InMemoryPromptProvider implements PromptProvider {
     }
 
     private void notifyListeners() {
-        listChangeSupport.notifyListeners();
+        listChangeSupport.notifyListeners(Change.INSTANCE);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/resources/ResourceListener.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ResourceListener.java
@@ -1,6 +1,0 @@
-package com.amannmalik.mcp.resources;
-
-@FunctionalInterface
-public interface ResourceListener {
-    void updated(ResourceUpdate update);
-}

--- a/src/main/java/com/amannmalik/mcp/resources/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/resources/ResourceProvider.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.resources;
 
 import com.amannmalik.mcp.core.Provider;
+import com.amannmalik.mcp.util.ChangeListener;
 import com.amannmalik.mcp.util.Pagination;
 
 import java.util.Optional;
@@ -16,7 +17,7 @@ public interface ResourceProvider extends Provider<Resource> {
 
     Pagination.Page<ResourceTemplate> listTemplates(String cursor);
 
-    ResourceSubscription subscribe(String uri, ResourceListener listener);
+    ResourceSubscription subscribe(String uri, ChangeListener<ResourceUpdate> listener);
 
     default boolean supportsSubscribe() {
         return false;

--- a/src/main/java/com/amannmalik/mcp/roots/InMemoryRootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/roots/InMemoryRootsProvider.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class InMemoryRootsProvider implements RootsProvider {
     private final List<Root> roots = new CopyOnWriteArrayList<>();
-    private final ChangeSupport<Root> listChangeSupport = new ChangeSupport<>();
+    private final ChangeSupport<Change> listChangeSupport = new ChangeSupport<>();
 
     public InMemoryRootsProvider(List<Root> initial) {
         if (initial != null) roots.addAll(initial);
@@ -19,7 +19,7 @@ public final class InMemoryRootsProvider implements RootsProvider {
     }
 
     @Override
-    public ChangeSubscription subscribe(ChangeListener<Root> listener) {
+    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
         return listChangeSupport.subscribe(listener);
     }
 
@@ -39,6 +39,6 @@ public final class InMemoryRootsProvider implements RootsProvider {
     }
 
     private void notifyListeners() {
-        listChangeSupport.notifyListeners();
+        listChangeSupport.notifyListeners(Change.INSTANCE);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/roots/RootsManager.java
+++ b/src/main/java/com/amannmalik/mcp/roots/RootsManager.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public final class RootsManager {
     private final ProtocolLifecycle lifecycle;
     private final RequestSender requester;
-    private final ChangeSupport<Root> listChangeSupport = new ChangeSupport<>();
+    private final ChangeSupport<Change> listChangeSupport = new ChangeSupport<>();
     private final List<Root> roots = new CopyOnWriteArrayList<>();
 
     public RootsManager(ProtocolLifecycle lifecycle, RequestSender requester) {
@@ -28,11 +28,11 @@ public final class RootsManager {
         boolean changed = !roots.equals(fetched);
         roots.clear();
         roots.addAll(fetched);
-        if (changed) listChangeSupport.notifyListeners();
+        if (changed) listChangeSupport.notifyListeners(Change.INSTANCE);
         return List.copyOf(fetched);
     }
 
-    public ChangeSubscription subscribe(ChangeListener<Root> listener) {
+    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
         return listChangeSupport.subscribe(listener);
     }
 
@@ -72,4 +72,3 @@ public final class RootsManager {
         }
     }
 }
-

--- a/src/main/java/com/amannmalik/mcp/tools/InMemoryToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/tools/InMemoryToolProvider.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
 public final class InMemoryToolProvider implements ToolProvider {
     private final List<Tool> tools;
     private final Map<String, Function<JsonObject, ToolResult>> handlers;
-    private final ChangeSupport<Tool> listChangeSupport = new ChangeSupport<>();
+    private final ChangeSupport<Change> listChangeSupport = new ChangeSupport<>();
 
     public InMemoryToolProvider(List<Tool> tools, Map<String, Function<JsonObject, ToolResult>> handlers) {
         this.tools = tools == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(tools);
@@ -55,7 +55,7 @@ public final class InMemoryToolProvider implements ToolProvider {
     }
 
     @Override
-    public ChangeSubscription subscribe(ChangeListener<Tool> listener) {
+    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
         return listChangeSupport.subscribe(listener);
     }
 
@@ -81,7 +81,7 @@ public final class InMemoryToolProvider implements ToolProvider {
     }
 
     private void notifyListeners() {
-        listChangeSupport.notifyListeners();
+        listChangeSupport.notifyListeners(Change.INSTANCE);
     }
 
     private static ToolResult withStructuredText(ToolResult result) {

--- a/src/main/java/com/amannmalik/mcp/util/Change.java
+++ b/src/main/java/com/amannmalik/mcp/util/Change.java
@@ -1,0 +1,5 @@
+package com.amannmalik.mcp.util;
+
+public enum Change {
+    INSTANCE
+}

--- a/src/main/java/com/amannmalik/mcp/util/ChangeListener.java
+++ b/src/main/java/com/amannmalik/mcp/util/ChangeListener.java
@@ -2,5 +2,5 @@ package com.amannmalik.mcp.util;
 
 @FunctionalInterface
 public interface ChangeListener<T> {
-    void changed();
+    void changed(T change);
 }

--- a/src/main/java/com/amannmalik/mcp/util/ChangeSupport.java
+++ b/src/main/java/com/amannmalik/mcp/util/ChangeSupport.java
@@ -11,7 +11,7 @@ public final class ChangeSupport<T> {
         return () -> listeners.remove(listener);
     }
 
-    public void notifyListeners() {
-        for (var l : listeners) l.changed();
+    public void notifyListeners(T change) {
+        for (var l : listeners) l.changed(change);
     }
 }

--- a/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpConformanceSteps.java
@@ -748,7 +748,7 @@ public final class McpConformanceSteps {
         }
 
         @Override
-        public ChangeSubscription subscribe(ChangeListener<Root> listener) {
+        public ChangeSubscription subscribe(ChangeListener<Change> listener) {
             return delegate.subscribe(listener);
         }
 


### PR DESCRIPTION
## Summary
- Introduced a generic Change event with parameterized ChangeListener and ChangeSupport for unified change notifications.
- Updated Provider and domain providers to use Change notifications, removing the old ResourceListener interface.
- Refactored server and client components to propagate Change events across prompts, tools, resources, and roots.

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68904cea3b64832485e0094115442477