### PR TITLE
Unify provider pattern

### DIFF
--- a/src/main/java/com/amannmalik/mcp/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/McpServer.java
@@ -500,6 +500,9 @@ public final class McpServer implements AutoCloseable {
             return new JsonRpcResponse(req.id(), CompleteResult.CODEC.toJson(result));
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());
         } catch (Exception e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());
         }

--- a/src/main/java/com/amannmalik/mcp/completion/CompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/completion/CompletionProvider.java
@@ -1,10 +1,40 @@
 package com.amannmalik.mcp.completion;
 
-/// - [Completion](specification/2025-06-18/server/utilities/completion.mdx)
-public interface CompletionProvider extends AutoCloseable {
-    CompleteResult complete(CompleteRequest request);
+import com.amannmalik.mcp.core.ExecutingProvider;
+import com.amannmalik.mcp.util.Pagination;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 
+import java.util.List;
+
+/// - [Completion](specification/2025-06-18/server/utilities/completion.mdx)
+public interface CompletionProvider extends ExecutingProvider<CompleteRequest.Ref, CompleteResult> {
     @Override
-    default void close() {
+    default Pagination.Page<CompleteRequest.Ref> list(String cursor) {
+        return new Pagination.Page<>(List.of(), null);
+    }
+
+    default CompleteResult complete(CompleteRequest request) throws InterruptedException {
+        JsonObject ctx = request.context() == null
+                ? Json.createObjectBuilder().build()
+                : CompleteRequest.Context.CODEC.toJson(request.context());
+        JsonObject args = Json.createObjectBuilder()
+                .add("argument", CompleteRequest.Argument.CODEC.toJson(request.argument()))
+                .add("context", ctx)
+                .build();
+        return execute(encode(request.ref()), args);
+    }
+
+    static String encode(CompleteRequest.Ref ref) {
+        return switch (ref) {
+            case CompleteRequest.Ref.PromptRef(var name, var _, var _) -> "prompt:" + name;
+            case CompleteRequest.Ref.ResourceRef(var uri) -> "resource:" + uri;
+        };
+    }
+
+    static CompleteRequest.Ref decode(String name) {
+        if (name.startsWith("prompt:")) return new CompleteRequest.Ref.PromptRef(name.substring(7), null, null);
+        if (name.startsWith("resource:")) return new CompleteRequest.Ref.ResourceRef(name.substring(9));
+        throw new IllegalArgumentException("invalid ref");
     }
 }

--- a/src/main/java/com/amannmalik/mcp/core/ExecutingProvider.java
+++ b/src/main/java/com/amannmalik/mcp/core/ExecutingProvider.java
@@ -1,0 +1,7 @@
+package com.amannmalik.mcp.core;
+
+import jakarta.json.JsonObject;
+
+public interface ExecutingProvider<T, R> extends Provider<T> {
+    R execute(String name, JsonObject args) throws InterruptedException;
+}

--- a/src/main/java/com/amannmalik/mcp/core/InMemoryProvider.java
+++ b/src/main/java/com/amannmalik/mcp/core/InMemoryProvider.java
@@ -1,0 +1,38 @@
+package com.amannmalik.mcp.core;
+
+import com.amannmalik.mcp.util.*;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class InMemoryProvider<T> implements Provider<T> {
+    protected final List<T> items;
+    private final ChangeSupport<Change> changeSupport = new ChangeSupport<>();
+
+    public InMemoryProvider() {
+        this(null);
+    }
+
+    public InMemoryProvider(Collection<T> initial) {
+        items = initial == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(initial);
+    }
+
+    @Override
+    public Pagination.Page<T> list(String cursor) {
+        return Pagination.page(items, cursor, Pagination.DEFAULT_PAGE_SIZE);
+    }
+
+    @Override
+    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
+        return changeSupport.subscribe(listener);
+    }
+
+    @Override
+    public boolean supportsListChanged() {
+        return true;
+    }
+
+    protected void notifyListeners() {
+        changeSupport.notifyListeners(Change.INSTANCE);
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/elicitation/ElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/elicitation/ElicitationProvider.java
@@ -1,12 +1,27 @@
 package com.amannmalik.mcp.elicitation;
 
+import com.amannmalik.mcp.core.ExecutingProvider;
+import com.amannmalik.mcp.util.Pagination;
+import jakarta.json.JsonObject;
+
+import java.util.List;
+
 /// - [Elicitation](specification/2025-06-18/client/elicitation.mdx)
 /// - [MCP elicitation specification conformance](src/test/resources/com/amannmalik/mcp/mcp_conformance.feature:116-131)
-public interface ElicitationProvider {
-
+public interface ElicitationProvider extends ExecutingProvider<ElicitRequest, ElicitResult> {
     ElicitResult elicit(ElicitRequest request, long timeoutMillis) throws InterruptedException;
 
     default ElicitResult elicit(ElicitRequest request) throws InterruptedException {
         return elicit(request, 0);
+    }
+
+    @Override
+    default Pagination.Page<ElicitRequest> list(String cursor) {
+        return new Pagination.Page<>(List.of(), null);
+    }
+
+    @Override
+    default ElicitResult execute(String name, JsonObject args) throws InterruptedException {
+        return elicit(ElicitRequest.CODEC.fromJson(args), 0);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -1,35 +1,33 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.util.*;
+import com.amannmalik.mcp.core.InMemoryProvider;
+import com.amannmalik.mcp.util.Pagination;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public final class InMemoryPromptProvider implements PromptProvider {
+public final class InMemoryPromptProvider extends InMemoryProvider<Prompt> implements PromptProvider {
     private final Map<String, PromptTemplate> templates = new ConcurrentHashMap<>();
-    private final ChangeSupport<Change> listChangeSupport = new ChangeSupport<>();
 
     public void add(PromptTemplate template) {
         String name = template.prompt().name();
         if (templates.putIfAbsent(name, template) != null) {
             throw new IllegalArgumentException("duplicate prompt name: " + name);
         }
+        items.add(template.prompt());
         notifyListeners();
     }
 
     public void remove(String name) {
         templates.remove(name);
+        items.removeIf(p -> p.name().equals(name));
         notifyListeners();
     }
 
     @Override
     public Pagination.Page<Prompt> list(String cursor) {
-        List<Prompt> all = new ArrayList<>();
-        for (PromptTemplate t : templates.values()) {
-            all.add(t.prompt());
-        }
-        all.sort(Comparator.comparing(Prompt::name));
-        return Pagination.page(all, cursor, Pagination.DEFAULT_PAGE_SIZE);
+        items.sort(Comparator.comparing(Prompt::name));
+        return super.list(cursor);
     }
 
     @Override
@@ -37,19 +35,5 @@ public final class InMemoryPromptProvider implements PromptProvider {
         PromptTemplate tmpl = templates.get(name);
         if (tmpl == null) throw new IllegalArgumentException("unknown prompt: " + name);
         return tmpl.instantiate(arguments);
-    }
-
-    @Override
-    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
-        return listChangeSupport.subscribe(listener);
-    }
-
-    @Override
-    public boolean supportsListChanged() {
-        return true;
-    }
-
-    private void notifyListeners() {
-        listChangeSupport.notifyListeners(Change.INSTANCE);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/roots/InMemoryRootsProvider.java
+++ b/src/main/java/com/amannmalik/mcp/roots/InMemoryRootsProvider.java
@@ -1,44 +1,21 @@
 package com.amannmalik.mcp.roots;
 
-import com.amannmalik.mcp.util.*;
+import com.amannmalik.mcp.core.InMemoryProvider;
 
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
-public final class InMemoryRootsProvider implements RootsProvider {
-    private final List<Root> roots = new CopyOnWriteArrayList<>();
-    private final ChangeSupport<Change> listChangeSupport = new ChangeSupport<>();
-
+public final class InMemoryRootsProvider extends InMemoryProvider<Root> implements RootsProvider {
     public InMemoryRootsProvider(List<Root> initial) {
-        if (initial != null) roots.addAll(initial);
-    }
-
-    @Override
-    public Pagination.Page<Root> list(String cursor) {
-        return Pagination.page(roots, cursor, Pagination.DEFAULT_PAGE_SIZE);
-    }
-
-    @Override
-    public ChangeSubscription subscribe(ChangeListener<Change> listener) {
-        return listChangeSupport.subscribe(listener);
-    }
-
-    @Override
-    public boolean supportsListChanged() {
-        return true;
+        super(initial);
     }
 
     public void add(Root root) {
-        roots.add(root);
+        items.add(root);
         notifyListeners();
     }
 
     public void remove(String uri) {
-        roots.removeIf(r -> r.uri().equals(uri));
+        items.removeIf(r -> r.uri().equals(uri));
         notifyListeners();
-    }
-
-    private void notifyListeners() {
-        listChangeSupport.notifyListeners(Change.INSTANCE);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/sampling/SamplingProvider.java
+++ b/src/main/java/com/amannmalik/mcp/sampling/SamplingProvider.java
@@ -1,8 +1,14 @@
 package com.amannmalik.mcp.sampling;
 
+import com.amannmalik.mcp.core.ExecutingProvider;
+import com.amannmalik.mcp.util.Pagination;
+import jakarta.json.JsonObject;
+
+import java.util.List;
+
 /// - [Sampling](specification/2025-06-18/client/sampling.mdx)
 /// - [MCP sampling specification conformance](src/test/resources/com/amannmalik/mcp/mcp_conformance.feature:135-150)
-public interface SamplingProvider extends AutoCloseable {
+public interface SamplingProvider extends ExecutingProvider<SamplingMessage, CreateMessageResponse> {
     CreateMessageResponse createMessage(CreateMessageRequest request, long timeoutMillis) throws InterruptedException;
 
     default CreateMessageResponse createMessage(CreateMessageRequest request) throws InterruptedException {
@@ -10,6 +16,12 @@ public interface SamplingProvider extends AutoCloseable {
     }
 
     @Override
-    default void close() {
+    default Pagination.Page<SamplingMessage> list(String cursor) {
+        return new Pagination.Page<>(List.of(), null);
+    }
+
+    @Override
+    default CreateMessageResponse execute(String name, JsonObject args) throws InterruptedException {
+        return createMessage(CreateMessageRequest.CODEC.fromJson(args), 0);
     }
 }


### PR DESCRIPTION
## Summary
- introduce ExecutingProvider to standardize execution-based capabilities
- refactor in-memory providers onto a shared InMemoryProvider base
- migrate completion, sampling, and elicitation providers to the unified hierarchy

## Testing
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_6890ac2e7b548324853eb840b25e88e4