### PR TITLE
Refactor transport routing and authorization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/AuthorizationUtil.java
+++ b/src/main/java/com/amannmalik/mcp/transport/AuthorizationUtil.java
@@ -1,0 +1,42 @@
+package com.amannmalik.mcp.transport;
+
+import com.amannmalik.mcp.auth.AuthorizationException;
+import com.amannmalik.mcp.auth.AuthorizationManager;
+import com.amannmalik.mcp.auth.Principal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+final class AuthorizationUtil {
+    private AuthorizationUtil() {
+    }
+
+    static Optional<Principal> authorize(AuthorizationManager manager,
+                                         HttpServletRequest req,
+                                         HttpServletResponse resp,
+                                         String resourceMetadataUrl,
+                                         Principal defaultPrincipal) throws IOException {
+        if (manager == null) return Optional.of(defaultPrincipal);
+        try {
+            return Optional.of(manager.authorize(req.getHeader("Authorization")));
+        } catch (AuthorizationException e) {
+            if (resourceMetadataUrl != null) {
+                resp.setHeader("WWW-Authenticate", "Bearer resource_metadata=\"" + resourceMetadataUrl + "\"");
+            }
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return Optional.empty();
+        }
+    }
+
+    static void checkUnauthorized(HttpResponse<InputStream> response) throws IOException {
+        if (response.statusCode() == 401) {
+            String header = response.headers().firstValue("WWW-Authenticate").orElse("");
+            response.body().close();
+            throw new UnauthorizedException(header);
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/MessageDispatcher.java
+++ b/src/main/java/com/amannmalik/mcp/transport/MessageDispatcher.java
@@ -1,0 +1,35 @@
+package com.amannmalik.mcp.transport;
+
+import jakarta.json.JsonObject;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+final class MessageDispatcher {
+    private final MessageRouter router;
+    private final Queue<JsonObject> backlog = new ConcurrentLinkedQueue<>();
+
+    MessageDispatcher(MessageRouter router) {
+        this.router = router;
+    }
+
+    void dispatch(JsonObject message) {
+        if (router.route(message)) {
+            flush();
+        } else {
+            backlog.add(message);
+        }
+    }
+
+    void flush() {
+        while (true) {
+            JsonObject msg = backlog.peek();
+            if (msg == null) return;
+            if (router.route(msg)) {
+                backlog.poll();
+            } else {
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -45,7 +45,7 @@ public final class StreamableHttpClientTransport implements Transport {
                 .GET()
                 .build();
         var response = exchange(request);
-        checkUnauthorized(response);
+        AuthorizationUtil.checkUnauthorized(response);
         int status = response.statusCode();
         String ct = response.headers().firstValue("Content-Type").orElse("");
         if (status != 200 || !ct.startsWith("text/event-stream")) {
@@ -63,7 +63,7 @@ public final class StreamableHttpClientTransport implements Transport {
                 .POST(HttpRequest.BodyPublishers.ofString(message.toString()))
                 .build();
         var response = exchange(request);
-        checkUnauthorized(response);
+        AuthorizationUtil.checkUnauthorized(response);
         int status = response.statusCode();
         String ct = response.headers().firstValue("Content-Type").orElse("");
         if (status == 202) {
@@ -116,13 +116,6 @@ public final class StreamableHttpClientTransport implements Transport {
         t.start();
     }
 
-    private void checkUnauthorized(HttpResponse<InputStream> response) throws IOException {
-        if (response.statusCode() == 401) {
-            String header = response.headers().firstValue("WWW-Authenticate").orElse("");
-            response.body().close();
-            throw new UnauthorizedException(header);
-        }
-    }
 
     private HttpRequest.Builder builder() {
         var b = HttpRequest.newBuilder(endpoint)


### PR DESCRIPTION
## Summary
- centralize authorization logic in AuthorizationUtil
- extract message dispatching from StreamableHttpTransport
- reuse auth check in StreamableHttpClientTransport

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6890b89028b48324831ae0ea44ca06dc