### PR TITLE
feat: enforce pkce in oauth server

### DIFF
--- a/src/test/java/com/amannmalik/mcp/security/OAuthServer.java
+++ b/src/test/java/com/amannmalik/mcp/security/OAuthServer.java
@@ -1,5 +1,7 @@
 package com.amannmalik.mcp.security;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Map;
@@ -7,12 +9,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class OAuthServer {
     private static final SecureRandom RANDOM = new SecureRandom();
-    private final Map<String, Client> clients = new ConcurrentHashMap<>();
-    private final Map<String, String> codes = new ConcurrentHashMap<>();
-    private final String url;
+    private record Grant(String challenge, String resource) {}
 
+    private final Map<String, Client> clients = new ConcurrentHashMap<>();
+    private final Map<String, Grant> codes = new ConcurrentHashMap<>();
     public OAuthServer(String url) {
-        this.url = url;
     }
 
     public record Client(String id, String secret) {}
@@ -24,14 +25,19 @@ public final class OAuthServer {
         return clients.get(id);
     }
 
-    public String authorize(Client client, String challenge, String resource) {
+    public String authorize(Client client, String verifier, String resource) {
+        if (!clients.containsKey(client.id())) throw new IllegalArgumentException();
         String code = random();
-        codes.put(code, client.id());
+        codes.put(code, new Grant(challenge(verifier), resource));
         return code;
     }
 
     public String token(String code, String verifier, String resource) {
-        if (!codes.containsKey(code)) throw new IllegalArgumentException();
+        Grant grant = codes.remove(code);
+        if (grant == null) throw new IllegalArgumentException();
+        if (!grant.challenge().equals(challenge(verifier)) || !grant.resource().equals(resource)) {
+            throw new IllegalArgumentException();
+        }
         return "aud=" + resource + ";exp=valid;sig=true";
     }
 
@@ -41,6 +47,16 @@ public final class OAuthServer {
 
     public String verifier() {
         return random();
+    }
+
+    private String challenge(String verifier) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private String random() {


### PR DESCRIPTION
## Summary
- verify OAuth PKCE code challenge and resource binding in OAuthServer mock

## Testing
- `gradle test` *(fails: 17 tests, 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689140999f888324b5e36bdaaae726c6