### PR TITLE
Use typed security violation logging

### DIFF
--- a/src/main/java/com/amannmalik/mcp/security/SecurityViolationLogger.java
+++ b/src/main/java/com/amannmalik/mcp/security/SecurityViolationLogger.java
@@ -1,12 +1,14 @@
 package com.amannmalik.mcp.security;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class SecurityViolationLogger {
-    private final List<Entry> entries = new ArrayList<>();
+    public enum Level { INFO, WARNING, ERROR }
 
-    public void log(String level, String message) {
+    private final List<Entry> entries = new CopyOnWriteArrayList<>();
+
+    public void log(Level level, String message) {
         entries.add(new Entry(level, message));
     }
 
@@ -14,5 +16,5 @@ public final class SecurityViolationLogger {
         return List.copyOf(entries);
     }
 
-    public record Entry(String level, String message) {}
+    public record Entry(Level level, String message) {}
 }

--- a/src/test/java/com/amannmalik/mcp/McpFeatureSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpFeatureSteps.java
@@ -508,7 +508,7 @@ public class McpFeatureSteps {
 
     @And("logs security violation with level {string}")
     public void logsSecurityViolationWithLevel(String level) {
-        boolean found = violationLogger.entries().stream().anyMatch(e -> e.level().equals(level));
+        boolean found = violationLogger.entries().stream().anyMatch(e -> e.level().name().equals(level));
         assertTrue(found);
     }
 

--- a/src/test/java/com/amannmalik/mcp/security/MockTokenValidator.java
+++ b/src/test/java/com/amannmalik/mcp/security/MockTokenValidator.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.security;
 import com.amannmalik.mcp.auth.AuthorizationException;
 import com.amannmalik.mcp.auth.Principal;
 import com.amannmalik.mcp.auth.TokenValidator;
+import com.amannmalik.mcp.security.SecurityViolationLogger.Level;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -28,21 +29,21 @@ public final class MockTokenValidator implements TokenValidator {
                 .collect(Collectors.toMap(p -> p[0], p -> p[1]));
         String audience = claims.get("aud");
         if (audience == null || !audience.equals(expectedAudience)) {
-            log("WARNING", "invalid_audience");
+            log(Level.WARNING, "invalid_audience");
             throw new AuthorizationException("invalid_audience");
         }
         if (!"valid".equals(claims.get("exp"))) {
-            log("WARNING", "expired");
+            log(Level.WARNING, "expired");
             throw new AuthorizationException("expired");
         }
         if (!"true".equals(claims.get("sig"))) {
-            log("WARNING", "invalid_signature");
+            log(Level.WARNING, "invalid_signature");
             throw new AuthorizationException("invalid_signature");
         }
         return new Principal("user", Set.of("read"));
     }
 
-    private void log(String level, String message) {
+    private void log(Level level, String message) {
         if (logger != null) {
             logger.log(level, message);
         }


### PR DESCRIPTION
## Summary
- model security violation levels with an enum for type safety
- adapt mock token validation and steps to new enum

## Testing
- `./verify.sh` *(fails: UndefinedStepException in pending scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_689140999f888324b5e36bdaaae726c6