### PR TITLE
refactor: harden transport management

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/ConnectionManager.java
+++ b/src/main/java/com/amannmalik/mcp/transport/ConnectionManager.java
@@ -1,33 +1,36 @@
 package com.amannmalik.mcp.transport;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public final class ConnectionManager {
-    private boolean connected;
-    private int pending;
+    private final AtomicBoolean connected = new AtomicBoolean();
+    private final AtomicInteger pending = new AtomicInteger();
 
     public void connect() {
-        connected = true;
+        connected.set(true);
     }
 
     public void sendRequest() {
-        if (!connected) throw new IllegalStateException("not connected");
-        pending++;
+        if (!connected.get()) throw new IllegalStateException("not connected");
+        pending.incrementAndGet();
     }
 
     public void completeRequest() {
-        if (pending > 0) pending--;
+        pending.getAndUpdate(p -> p > 0 ? p - 1 : 0);
     }
 
     public void interrupt() {
-        connected = false;
-        pending = 0;
+        connected.set(false);
+        pending.set(0);
     }
 
     public boolean connected() {
-        return connected;
+        return connected.get();
     }
 
     public int pending() {
-        return pending;
+        return pending.get();
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/transport/HttpTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/HttpTransport.java
@@ -18,6 +18,7 @@ public final class HttpTransport implements Transport {
 
     @Override
     public void send(JsonObject message) {
+        if (closed) throw new IllegalStateException("closed");
         inbox.add(message);
     }
 


### PR DESCRIPTION
## Summary
- make ConnectionManager thread-safe
- guard HttpTransport against sends after close

## Testing
- `gradle test` *(fails: JsonRpcEndpoint warning, 17 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6891418cc4c883249c9c8585d2f5e4ca