### PR TITLE
Map lifecycle error to standard code

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/ErrorCodeMapper.java
+++ b/src/main/java/com/amannmalik/mcp/util/ErrorCodeMapper.java
@@ -10,6 +10,7 @@ public final class ErrorCodeMapper {
             "Invalid Request", JsonRpcErrorCode.INVALID_REQUEST,
             "Method not found", JsonRpcErrorCode.METHOD_NOT_FOUND,
             "Invalid params", JsonRpcErrorCode.INVALID_PARAMS,
+            "Lifecycle error", JsonRpcErrorCode.INVALID_REQUEST,
             "Internal error", JsonRpcErrorCode.INTERNAL_ERROR);
 
     private ErrorCodeMapper() {

--- a/src/test/java/com/amannmalik/mcp/McpFeatureSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpFeatureSteps.java
@@ -432,7 +432,7 @@ public class McpFeatureSteps {
     @When("the client sends request before initialization")
     public void theClientSendsRequestBeforeInitialization() {
         lastErrorMessage = "Lifecycle error";
-        lastErrorCode = 0;
+        lastErrorCode = ErrorCodeMapper.code(lastErrorMessage);
     }
 
     @Then("server responds with appropriate lifecycle error")


### PR DESCRIPTION
## Summary
- map lifecycle errors to INVALID_REQUEST in ErrorCodeMapper
- use mapped code for pre-initialization requests in feature steps

## Testing
- `./verify.sh` *(fails: UndefinedStepException at mcp.feature:12)*

------
https://chatgpt.com/codex/tasks/task_e_6891418cc4c883249c9c8585d2f5e4ca