### PR TITLE
Add lifecycle error mapping

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcErrorCode.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcErrorCode.java
@@ -8,7 +8,8 @@ public enum JsonRpcErrorCode {
     INVALID_REQUEST(-32600),
     METHOD_NOT_FOUND(-32601),
     INVALID_PARAMS(-32602),
-    INTERNAL_ERROR(-32603);
+    INTERNAL_ERROR(-32603),
+    LIFECYCLE_ERROR(0);
 
     private static final Map<Integer, JsonRpcErrorCode> BY_CODE;
     private final int code;

--- a/src/main/java/com/amannmalik/mcp/util/ErrorCodeMapper.java
+++ b/src/main/java/com/amannmalik/mcp/util/ErrorCodeMapper.java
@@ -10,13 +10,16 @@ public final class ErrorCodeMapper {
             "Invalid Request", JsonRpcErrorCode.INVALID_REQUEST,
             "Method not found", JsonRpcErrorCode.METHOD_NOT_FOUND,
             "Invalid params", JsonRpcErrorCode.INVALID_PARAMS,
-            "Internal error", JsonRpcErrorCode.INTERNAL_ERROR);
+            "Internal error", JsonRpcErrorCode.INTERNAL_ERROR,
+            "Lifecycle error", JsonRpcErrorCode.LIFECYCLE_ERROR);
 
     private ErrorCodeMapper() {
     }
 
     public static int code(String message) {
-        return MAP.getOrDefault(message, JsonRpcErrorCode.INVALID_REQUEST).code();
+        JsonRpcErrorCode code = MAP.get(message);
+        if (code == null) throw new IllegalArgumentException(message);
+        return code.code();
     }
 }
 

--- a/src/test/java/com/amannmalik/mcp/McpFeatureSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpFeatureSteps.java
@@ -432,7 +432,7 @@ public class McpFeatureSteps {
     @When("the client sends request before initialization")
     public void theClientSendsRequestBeforeInitialization() {
         lastErrorMessage = "Lifecycle error";
-        lastErrorCode = 0;
+        lastErrorCode = ErrorCodeMapper.code(lastErrorMessage);
     }
 
     @Then("server responds with appropriate lifecycle error")


### PR DESCRIPTION
## Summary
- map lifecycle errors to a dedicated JSON-RPC code
- require explicit error-code mappings
- use lifecycle code in step definitions

## Testing
- `gradle test` (fails: UndefinedStepException)

------
https://chatgpt.com/codex/tasks/task_e_6891418cc4c883249c9c8585d2f5e4ca