### PR TITLE
Enable tool argument elicitation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/elicitation/BlockingElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/elicitation/BlockingElicitationProvider.java
@@ -4,6 +4,7 @@ import java.util.concurrent.*;
 
 public final class BlockingElicitationProvider implements ElicitationProvider {
     private final BlockingQueue<ElicitResult> responses = new LinkedBlockingQueue<>();
+    private volatile ElicitRequest lastRequest;
 
     public void respond(ElicitResult response) {
         if (response == null) throw new IllegalArgumentException("response is required");
@@ -12,8 +13,13 @@ public final class BlockingElicitationProvider implements ElicitationProvider {
         }
     }
 
+    public ElicitRequest lastRequest() {
+        return lastRequest;
+    }
+
     @Override
     public ElicitResult elicit(ElicitRequest request, long timeoutMillis) throws InterruptedException {
+        lastRequest = request;
         ElicitResult resp = timeoutMillis <= 0
                 ? responses.take()
                 : responses.poll(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/amannmalik/mcp/tools/ToolExecutor.java
+++ b/src/main/java/com/amannmalik/mcp/tools/ToolExecutor.java
@@ -1,19 +1,80 @@
 package com.amannmalik.mcp.tools;
 
-import jakarta.json.JsonObject;
+import com.amannmalik.mcp.elicitation.*;
+import jakarta.json.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public final class ToolExecutor {
     private final ToolProvider provider;
+    private final ElicitationProvider elicitation;
 
-    public ToolExecutor(ToolProvider provider) {
+    public ToolExecutor(ToolProvider provider, ElicitationProvider elicitation) {
         if (provider == null) throw new IllegalArgumentException("provider required");
         this.provider = provider;
+        this.elicitation = elicitation;
+    }
+
+    public ToolExecutor(ToolProvider provider) {
+        this(provider, null);
     }
 
     public ToolResult execute(String name, JsonObject arguments) {
         if (name == null || arguments == null) {
             throw new IllegalArgumentException("name and arguments required");
         }
-        return provider.call(name, arguments);
+        Tool tool = provider.find(name).orElseThrow();
+        JsonObject args = arguments;
+        JsonObject schema = tool.inputSchema();
+        if (schema != null) {
+            JsonArray req = schema.getJsonArray("required");
+            JsonObject props = schema.getJsonObject("properties");
+            if (req != null && props != null && !req.isEmpty()) {
+                List<String> missing = new ArrayList<>();
+                for (JsonValue v : req) {
+                    String f = ((JsonString) v).getString();
+                    if (!args.containsKey(f)) missing.add(f);
+                }
+                if (!missing.isEmpty()) {
+                    if (elicitation == null) {
+                        throw new IllegalArgumentException("missing argument: " + missing.getFirst());
+                    }
+                    JsonObjectBuilder propBuilder = Json.createObjectBuilder();
+                    JsonArrayBuilder reqBuilder = Json.createArrayBuilder();
+                    for (String m : missing) {
+                        propBuilder.add(m, props.get(m));
+                        reqBuilder.add(m);
+                    }
+                    JsonObject reqSchema = Json.createObjectBuilder()
+                            .add("type", "object")
+                            .add("properties", propBuilder.build())
+                            .add("required", reqBuilder.build())
+                            .build();
+                    ElicitResult result;
+                    try {
+                        result = elicitation.elicit(new ElicitRequest("missing required arguments", reqSchema, null), 0);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return error("elicitation interrupted");
+                    }
+                    if (result.action() != ElicitationAction.ACCEPT || result.content() == null) {
+                        return error("elicitation rejected");
+                    }
+                    JsonObjectBuilder merged = Json.createObjectBuilder();
+                    args.forEach(merged::add);
+                    result.content().forEach(merged::add);
+                    args = merged.build();
+                }
+            }
+        }
+        return provider.call(name, args);
+    }
+
+    private static ToolResult error(String message) {
+        JsonArray content = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder().add("type", "text").add("text", message))
+                .build();
+        return new ToolResult(content, null, true, null);
     }
 }


### PR DESCRIPTION
## Summary
- integrate elicitation into ToolExecutor
- capture last elicitation request
- exercise tool elicit flow in Cucumber steps

## Testing
- `./verify.sh` *(fails: UndefinedStepException)*

------
https://chatgpt.com/codex/tasks/task_e_68914ae7af0c83249cf45900b597f520