### PR TITLE
Implement full roots protocol flow

### DIFF
--- a/src/main/java/com/amannmalik/mcp/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/McpServer.java
@@ -507,6 +507,10 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
         return rootsManager.roots();
     }
 
+    public ProtocolLifecycle lifecycle() {
+        return lifecycle;
+    }
+
     public ElicitResult elicit(ElicitRequest req) throws IOException {
         requireClientCapability(ClientCapability.ELICITATION);
         JsonRpcMessage msg = request(RequestMethod.ELICITATION_CREATE, ElicitRequest.CODEC.toJson(req));

--- a/src/main/java/com/amannmalik/mcp/roots/JsonRpcRequestSender.java
+++ b/src/main/java/com/amannmalik/mcp/roots/JsonRpcRequestSender.java
@@ -1,0 +1,83 @@
+package com.amannmalik.mcp.roots;
+
+import com.amannmalik.mcp.config.McpConfiguration;
+import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.transport.Transport;
+import com.amannmalik.mcp.util.JsonRpcRequestProcessor;
+import com.amannmalik.mcp.util.ProgressManager;
+import com.amannmalik.mcp.util.RateLimiter;
+import com.amannmalik.mcp.wire.RequestMethod;
+import jakarta.json.JsonObject;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.*;
+
+public final class JsonRpcRequestSender implements RequestSender {
+    private final Transport transport;
+    private final JsonRpcRequestProcessor processor;
+    private final Map<RequestId, CompletableFuture<JsonRpcMessage>> pending = new ConcurrentHashMap<>();
+    private long counter;
+
+    public JsonRpcRequestSender(Transport transport) {
+        this(transport, new JsonRpcRequestProcessor(new ProgressManager(new RateLimiter(
+                McpConfiguration.current().progressPerSecond(),
+                McpConfiguration.current().rateLimiterWindowMs())), m -> {
+            try {
+                transport.send(JsonRpcCodec.CODEC.toJson(m));
+            } catch (IOException ignore) {
+            }
+        }));
+    }
+
+    public JsonRpcRequestSender(Transport transport, JsonRpcRequestProcessor processor) {
+        if (transport == null || processor == null) throw new IllegalArgumentException("transport and processor required");
+        this.transport = transport;
+        this.processor = processor;
+    }
+
+    @Override
+    public JsonRpcMessage send(RequestMethod method, JsonObject params) throws IOException {
+        RequestId id = new RequestId.NumericId(counter++);
+        CompletableFuture<JsonRpcMessage> future = new CompletableFuture<>();
+        pending.put(id, future);
+        transport.send(JsonRpcCodec.CODEC.toJson(new JsonRpcRequest(id, method.method(), params)));
+        long end = System.currentTimeMillis() + McpConfiguration.current().defaultMs();
+        while (true) {
+            if (future.isDone()) {
+                try {
+                    return future.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                } catch (ExecutionException e) {
+                    var cause = e.getCause();
+                    if (cause instanceof IOException io) throw io;
+                    throw new IOException(cause);
+                }
+            }
+            if (System.currentTimeMillis() >= end) {
+                throw new IOException(McpConfiguration.current().errorTimeout());
+            }
+            JsonRpcMessage msg = JsonRpcCodec.CODEC.fromJson(transport.receive());
+            switch (msg) {
+                case JsonRpcRequest req -> processor.handle(req, true).ifPresent(r -> {
+                    try {
+                        transport.send(JsonRpcCodec.CODEC.toJson(r));
+                    } catch (IOException ignore) {
+                    }
+                });
+                case JsonRpcNotification note -> processor.handle(note);
+                case JsonRpcResponse resp -> complete(resp.id(), resp);
+                case JsonRpcError err -> complete(err.id(), err);
+                default -> { }
+            }
+        }
+    }
+
+    private void complete(RequestId id, JsonRpcMessage msg) {
+        var f = pending.remove(id);
+        if (f != null) f.complete(msg);
+    }
+}
+

--- a/src/main/java/com/amannmalik/mcp/util/RootChecker.java
+++ b/src/main/java/com/amannmalik/mcp/util/RootChecker.java
@@ -24,27 +24,35 @@ public final class RootChecker {
 
         final Path targetPath;
         try {
-            targetPath = Paths.get(target).toRealPath();
+            Path p = Paths.get(target);
+            targetPath = normalize(p);
         } catch (Exception e) {
             return false;
         }
 
         return roots.stream()
                 .map(Root::uri)
-                .map(RootChecker::toRealPath)
+                .map(RootChecker::toPath)
                 .flatMap(Optional::stream)
                 .anyMatch(targetPath::startsWith);
     }
 
-    private static Optional<Path> toRealPath(String uri) {
+    private static Optional<Path> toPath(String uri) {
         try {
             URI base = URI.create(uri);
             if ("file".equalsIgnoreCase(base.getScheme())) {
-                return Optional.of(Paths.get(base).toRealPath());
+                return Optional.of(normalize(Paths.get(base)));
             }
         } catch (Exception ignore) {
-            // ignore invalid root entries
         }
         return Optional.empty();
+    }
+
+    private static Path normalize(Path p) {
+        try {
+            return p.toRealPath();
+        } catch (Exception e) {
+            return p.toAbsolutePath().normalize();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add JsonRpcRequestSender for server-initiated roots/list requests
- expose McpServer.lifecycle for protocol component access
- normalize virtual paths in RootChecker and exercise real message flow in RootsFeatureSteps

## Testing
- `gradle check --no-daemon --console plain`

------
https://chatgpt.com/codex/tasks/task_e_689755416c488324a2262696e6dbafc5