### PR TITLE
Implement protocol version negotiation

### DIFF
--- a/src/test/java/com/amannmalik/mcp/McpLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/McpLifecycleSteps.java
@@ -286,8 +286,12 @@ public class McpLifecycleSteps {
 
     @Given("a McpServer supporting protocol version {string}")
     public void serverSupportsVersion(String version) {
-        lifecycle = new ProtocolLifecycle(EnumSet.noneOf(ServerCapability.class), new ServerInfo("TestServer", "Test Server App", "1.0.0"), null);
         serverSupportedVersions = Set.of(version);
+        lifecycle = new ProtocolLifecycle(
+                EnumSet.noneOf(ServerCapability.class),
+                new ServerInfo("TestServer", "Test Server App", "1.0.0"),
+                null,
+                serverSupportedVersions);
     }
 
     @Given("a McpServer supporting protocol versions:")
@@ -297,7 +301,11 @@ public class McpLifecycleSteps {
             v.add(row.get("version"));
         }
         serverSupportedVersions = Set.copyOf(v);
-        lifecycle = new ProtocolLifecycle(EnumSet.noneOf(ServerCapability.class), new ServerInfo("TestServer", "Test Server App", "1.0.0"), null);
+        lifecycle = new ProtocolLifecycle(
+                EnumSet.noneOf(ServerCapability.class),
+                new ServerInfo("TestServer", "Test Server App", "1.0.0"),
+                null,
+                serverSupportedVersions);
     }
 
     @Given("a McpServer supporting only protocol version {string}")
@@ -376,6 +384,13 @@ public class McpLifecycleSteps {
         );
         try {
             initializeResponse = lifecycle.initialize(req);
+            if (clientSupportedVersions != null &&
+                    !clientSupportedVersions.contains(initializeResponse.protocolVersion())) {
+                initializationException = new UnsupportedProtocolVersionException(
+                        initializeResponse.protocolVersion(),
+                        String.join(", ", clientSupportedVersions));
+                initializeResponse = null;
+            }
         } catch (Exception e) {
             initializationException = e;
         }

--- a/src/test/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycleTest.java
+++ b/src/test/java/com/amannmalik/mcp/lifecycle/ProtocolLifecycleTest.java
@@ -1,0 +1,28 @@
+package com.amannmalik.mcp.lifecycle;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProtocolLifecycleTest {
+    @Test
+    void selectsLatestSupportedVersionWhenRequestedUnsupported() {
+        ProtocolLifecycle lifecycle = new ProtocolLifecycle(
+                EnumSet.noneOf(ServerCapability.class),
+                new ServerInfo("S", "Server", "1"),
+                "",
+                Set.of("2024-11-05", "2025-06-18"));
+        InitializeRequest req = new InitializeRequest(
+                "2026-01-01",
+                new Capabilities(Set.of(), Set.of(), Map.of(), Map.of()),
+                new ClientInfo("c", "Client", "1"),
+                ClientFeatures.EMPTY
+        );
+        InitializeResponse res = lifecycle.initialize(req);
+        assertEquals("2025-06-18", res.protocolVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- add server-side protocol version list and negotiate against client requests
- simulate client disconnection when server replies with unsupported version
- cover downgrade path with ProtocolLifecycleTest

## Testing
- `gradle test --tests ProtocolLifecycleTest`
- `gradle test` *(fails: Undefined step in tools.feature)*

------
https://chatgpt.com/codex/tasks/task_e_6897b31072a88324953a3392b8cb33cd