### PR TITLE
feat: add pre-init request failure scenario

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -10,4 +10,5 @@ module mcp.main {
     exports com.amannmalik.mcp.elicitation;
     exports com.amannmalik.mcp.roots;
     exports com.amannmalik.mcp.sampling;
+    exports com.amannmalik.mcp.jsonrpc;
 }

--- a/src/test/java/com/amannmalik/mcp/lifecycle/McpLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/lifecycle/McpLifecycleSteps.java
@@ -6,9 +6,12 @@ import com.amannmalik.mcp.core.McpClient;
 import com.amannmalik.mcp.core.McpServer;
 import com.amannmalik.mcp.core.StdioTransport;
 import com.amannmalik.mcp.elicitation.InteractiveElicitationProvider;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
 import com.amannmalik.mcp.roots.InMemoryRootsProvider;
 import com.amannmalik.mcp.roots.Root;
 import com.amannmalik.mcp.sampling.InteractiveSamplingProvider;
+import jakarta.json.Json;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.After;
 import io.cucumber.java.en.*;
@@ -26,6 +29,7 @@ public final class McpLifecycleSteps {
     private long connectMillis;
     private final Set<String> expectedServerCaps = new HashSet<>();
     private final Set<ClientCapability> hostCaps = EnumSet.noneOf(ClientCapability.class);
+    private final List<JsonRpcMessage> responses = new ArrayList<>();
 
     @Given("a clean MCP environment")
     public void cleanEnvironment() {
@@ -33,6 +37,7 @@ public final class McpLifecycleSteps {
         connectMillis = 0L;
         expectedServerCaps.clear();
         hostCaps.clear();
+        responses.clear();
     }
 
     @Given("protocol version {string} is supported")
@@ -42,6 +47,11 @@ public final class McpLifecycleSteps {
 
     @Given("both McpHost and McpServer are available")
     public void hostAndServerAvailable() {
+    }
+
+    @Given("an uninitialized connection between McpHost and McpServer")
+    public void uninitializedConnection() throws IOException {
+        hostInitiatesConnection();
     }
 
     @Given("a McpServer with capabilities:")
@@ -60,6 +70,43 @@ public final class McpLifecycleSteps {
                 hostCaps.add(ClientCapability.valueOf(row.get("capability").toUpperCase()));
             }
         });
+    }
+
+    @When("the McpHost sends request:")
+    public void hostSendsRequest(DataTable table) throws IOException {
+        var params = Json.createObjectBuilder().build();
+        for (var row : table.asMaps()) {
+            responses.add(client.request(row.get("method"), params));
+        }
+    }
+
+    @Then("the McpServer should respond with error code {int}")
+    public void serverShouldRespondWithErrorCode(int code) {
+        Assertions.assertFalse(responses.isEmpty());
+        for (var msg : responses) {
+            if (msg instanceof JsonRpcError err) {
+                Assertions.assertEquals(code, err.error().code());
+            } else {
+                Assertions.fail("Expected JsonRpcError");
+            }
+        }
+    }
+
+    @Then("error message should contain {string}")
+    public void errorMessageShouldContain(String expected) {
+        Assertions.assertFalse(responses.isEmpty());
+        for (var msg : responses) {
+            if (msg instanceof JsonRpcError err) {
+                Assertions.assertTrue(err.error().message().contains(expected));
+            } else {
+                Assertions.fail("Expected JsonRpcError");
+            }
+        }
+    }
+
+    @Then("the connection should remain uninitialized")
+    public void connectionShouldRemainUninitialized() {
+        Assertions.assertFalse(client.connected());
     }
 
     @When("the McpHost initiates connection to McpServer")

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -5,4 +5,5 @@ open module mcp.test {
     requires io.cucumber.datatable;
     requires io.cucumber.java;
     requires org.junit.jupiter.api;
+    requires jakarta.json;
 }

--- a/src/test/resources/com/amannmalik/mcp/test/lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/lifecycle.feature
@@ -83,17 +83,17 @@ Feature: MCP Lifecycle Conformance
 #    And error message should contain "Invalid params"
 #    And the connection should remain uninitialized
 #
-#  @sequencing @error-handling
-#  Scenario: Requests before initialization must fail
-#    Given an uninitialized connection between McpHost and McpServer
-#    When the McpHost sends request:
-#      | method         |
-#      | tools/list     |
-#      | prompts/list   |
-#      | resources/list |
-#    Then the McpServer should respond with error code -32002
-#    And error message should contain "Server not initialized"
-#    And the connection should remain uninitialized
+  @sequencing @error-handling
+  Scenario: Requests before initialization must fail
+    Given an uninitialized connection between McpHost and McpServer
+    When the McpHost sends request:
+      | method         |
+      | tools/list     |
+      | prompts/list   |
+      | resources/list |
+    Then the McpServer should respond with error code -32002
+    And error message should contain "Server not initialized"
+    And the connection should remain uninitialized
 #
 #  @capabilities @negotiation
 #  Scenario: Complete server capability negotiation


### PR DESCRIPTION
## Summary
- test that requests are rejected before initialization
- implement step definitions for pre-init request failure
- expose JSON-RPC types for tests

## Testing
- `gradle --console=plain test`

------
https://chatgpt.com/codex/tasks/task_e_6897ea54cc7c8324b25735124c714628