### PR TITLE
Add capability boundary lifecycle test

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module mcp.main {
     requires org.eclipse.jetty.server;
     exports com.amannmalik.mcp;
     exports com.amannmalik.mcp.core;
+    exports com.amannmalik.mcp.jsonrpc;
     exports com.amannmalik.mcp.elicitation;
     exports com.amannmalik.mcp.roots;
     exports com.amannmalik.mcp.sampling;

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -5,4 +5,5 @@ open module mcp.test {
     requires io.cucumber.datatable;
     requires io.cucumber.java;
     requires org.junit.jupiter.api;
+    requires jakarta.json;
 }

--- a/src/test/resources/com/amannmalik/mcp/test/lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/lifecycle.feature
@@ -275,16 +275,16 @@ Feature: MCP Lifecycle Conformance
 #      | notifications/log    |
 #    And should defer any other operations until initialized notification received
 #
-#  @operation-phase @capability-respect
-#  Scenario: Capability boundaries respected during operations
-#    Given successful initialization with specific negotiated capabilities
-#    And server capabilities include "tools" but not "prompts"
-#    And client capabilities include "sampling" but not "roots"
-#    When McpHost attempts to use non-negotiated server capability "prompts/list"
-#    Then McpServer should respond with error code -32601
-#    And error message should indicate "Method not found"
-#    And connection should remain stable for valid operations
-#
+  @operation-phase @capability-respect
+  Scenario: Capability boundaries respected during operations
+    Given successful initialization with specific negotiated capabilities
+    And server capabilities include "tools" but not "prompts"
+    And client capabilities include "sampling" but not "roots"
+    When McpHost attempts to use non-negotiated server capability "prompts/list"
+    Then McpServer should respond with error code -32601
+    And error message should indicate "Method not found"
+    And connection should remain stable for valid operations
+
   @operation-phase @version-consistency
   Scenario: Protocol version consistency throughout session
     Given successful initialization with protocol version "2025-06-18"


### PR DESCRIPTION
## Summary
- randomly select and enable capability-boundary scenario
- implement Cucumber steps to assert error when using non-negotiated capability
- expose jsonrpc module and configure tests for Json usage

## Testing
- `gradle test` *(fails: Capability boundaries respected during operations)*

------
https://chatgpt.com/codex/tasks/task_e_6897ef7f8b0c8324a6c317fd886ca08d