### PR TITLE
Fix lifecycle step definitions

### DIFF
--- a/src/test/java/com/amannmalik/mcp/lifecycle/McpLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/lifecycle/McpLifecycleSteps.java
@@ -5,7 +5,9 @@ import com.amannmalik.mcp.core.ClientInfo;
 import com.amannmalik.mcp.core.McpClient;
 import com.amannmalik.mcp.core.McpServer;
 import com.amannmalik.mcp.core.StdioTransport;
-import com.amannmalik.mcp.elicitation.InteractiveElicitationProvider;
+import com.amannmalik.mcp.elicitation.ElicitationAction;
+import com.amannmalik.mcp.elicitation.ElicitResult;
+import com.amannmalik.mcp.elicitation.ElicitationProvider;
 import com.amannmalik.mcp.jsonrpc.JsonRpcError;
 import com.amannmalik.mcp.jsonrpc.JsonRpcMessage;
 import com.amannmalik.mcp.roots.InMemoryRootsProvider;
@@ -157,12 +159,14 @@ public final class McpLifecycleSteps {
         PipedInputStream serverIn = new PipedInputStream();
         PipedOutputStream clientOut = new PipedOutputStream(serverIn);
         var sampling = hostCaps.contains(ClientCapability.SAMPLING)
-                ? new InteractiveSamplingProvider(false) : null;
+                ? new InteractiveSamplingProvider(true) : null;
         var roots = hostCaps.contains(ClientCapability.ROOTS)
                 ? new InMemoryRootsProvider(List.of(new Root("file://" + System.getProperty("user.dir"),
                 "Current Directory", null))) : null;
-        var elicitation = hostCaps.contains(ClientCapability.ELICITATION)
-                ? new InteractiveElicitationProvider() : null;
+        ElicitationProvider elicitation = hostCaps.contains(ClientCapability.ELICITATION)
+                ? (req, timeout) -> new ElicitResult(ElicitationAction.ACCEPT,
+                Json.createObjectBuilder().build(), null)
+                : null;
         client = new McpClient(new ClientInfo("TestClient", "Test Client App", "1.0.0"),
                 hostCaps, new StdioTransport(clientIn, clientOut), sampling, roots, elicitation, null);
         server = new McpServer(new StdioTransport(serverIn, serverOut), null);
@@ -256,13 +260,11 @@ public final class McpLifecycleSteps {
 
     @Given("a McpServer supporting protocol version {string}")
     public void serverSupportsVersion(String version) {
-        Assertions.assertEquals("2025-06-18", version);
         serverVersion = version;
     }
 
     @Given("a McpHost requesting protocol version {string}")
     public void hostRequestsVersion(String version) {
-        Assertions.assertEquals("2025-06-18", version);
         hostVersion = version;
     }
 
@@ -272,33 +274,17 @@ public final class McpLifecycleSteps {
         long start = System.currentTimeMillis();
         client.connect();
         connectMillis = System.currentTimeMillis() - start;
-    }
-
-    @Then("both parties should agree on protocol version {string}")
-    public void agreeOnVersion(String version) throws IOException {
-        PipedInputStream clientIn = new PipedInputStream();
-        PipedOutputStream serverOut = new PipedOutputStream(clientIn);
-        PipedInputStream serverIn = new PipedInputStream();
-        PipedOutputStream clientOut = new PipedOutputStream(serverIn);
-        client = new McpClient(new ClientInfo("TestClient", "Test Client App", "1.0.0"),
-                Set.of(), new StdioTransport(clientIn, clientOut), null, null, null, null);
-        server = new McpServer(new StdioTransport(serverIn, serverOut), null);
-        serverThread = new Thread(() -> {
-            try {
-                server.serve();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
-        serverThread.start();
-        client.connect();
-        if (!serverSupportedVersions.isEmpty()) {
+        if (!serverSupportedVersions.isEmpty() && hostVersion != null) {
             negotiatedVersion = serverSupportedVersions.stream()
                     .filter(v -> v.compareTo(hostVersion) <= 0)
                     .max(String::compareTo)
                     .orElse(serverSupportedVersions.get(serverSupportedVersions.size() - 1));
-        } else {
+        } else if (serverVersion != null) {
             negotiatedVersion = serverVersion;
+        } else if (hostVersion != null) {
+            negotiatedVersion = hostVersion;
+        } else {
+            negotiatedVersion = client.protocolVersion();
         }
     }
 


### PR DESCRIPTION
## Summary
- Avoid interactive providers during lifecycle tests
- Remove hardcoded protocol versions and duplicate step definition
- Compute negotiated protocol version based on server and host support

## Testing
- `gradle test --rerun-tasks --console plain` *(fails: process stuck after compiling test classes)*

------
https://chatgpt.com/codex/tasks/task_e_6897f521c4588324a97be28821a20b3b