### PR TITLE
Support both process and stdio modes

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/TransportFactory.java
+++ b/src/main/java/com/amannmalik/mcp/api/TransportFactory.java
@@ -40,7 +40,9 @@ public final class TransportFactory {
     }
 
     public static Transport createStdioTransport(String[] commands, boolean verbose) throws IOException {
-        return new StdioTransport(commands, System.in, System.out, verbose ? System.err::println : _ -> {
+        return commands.length == 0
+                ? new StdioTransport(System.in, System.out)
+                : new StdioTransport(commands, verbose ? System.err::println : _ -> {
         });
     }
 }


### PR DESCRIPTION
## Summary
- Add dual constructors to `StdioTransport` for subprocess and direct stdio usage
- Choose appropriate transport creation in `TransportFactory`

## Testing
- `gradle test` *(fails: PendingException at IntegrationSteps.java:31)*

------
https://chatgpt.com/codex/tasks/task_e_6899f80680cc8324bdee30f65a337f66