### PR TITLE
Seal sampling message content types

### DIFF
--- a/src/main/java/com/amannmalik/mcp/spi/MessageContent.java
+++ b/src/main/java/com/amannmalik/mcp/spi/MessageContent.java
@@ -1,4 +1,15 @@
 package com.amannmalik.mcp.spi;
 
-public interface MessageContent {
+/**
+ * Represents content that can appear in a {@link SamplingMessage}.
+ *
+ * <p>Only text, image, and audio blocks are valid message content as defined by the
+ * <a href="specification/2025-06-18/index.mdx">MCP specification</a>.
+ * Resource links and embedded resources are intentionally excluded to ensure message
+ * payloads remain self-contained and serializable without additional context.</p>
+ */
+public sealed interface MessageContent permits
+        ContentBlock.Text,
+        ContentBlock.Image,
+        ContentBlock.Audio {
 }


### PR DESCRIPTION
## Summary
- restrict MessageContent to text, image, and audio blocks per spec

## Testing
- `./verify.sh` *(fails: 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a3b30ae54832486e35378363a9e4c