### PR TITLE
Refactor JsonRpcMessage version constant

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/JsonRpcMessage.java
+++ b/src/main/java/com/amannmalik/mcp/api/JsonRpcMessage.java
@@ -1,7 +1,13 @@
 package com.amannmalik.mcp.api;
 
-import com.amannmalik.mcp.jsonrpc.*;
+import com.amannmalik.mcp.jsonrpc.JsonRpc;
+import com.amannmalik.mcp.jsonrpc.JsonRpcError;
+import com.amannmalik.mcp.jsonrpc.JsonRpcNotification;
+import com.amannmalik.mcp.jsonrpc.JsonRpcRequest;
+import com.amannmalik.mcp.jsonrpc.JsonRpcResponse;
 
 public sealed interface JsonRpcMessage permits JsonRpcRequest, JsonRpcNotification, JsonRpcResponse, JsonRpcError {
-    String jsonrpc();
+    default String jsonrpc() {
+        return JsonRpc.VERSION;
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcError.java
@@ -27,11 +27,6 @@ public record JsonRpcError(RequestId id, ErrorDetail error) implements JsonRpcMe
         return new JsonRpcError(id, new ErrorDetail(code, message, data));
     }
 
-    @Override
-    public String jsonrpc() {
-        return JsonRpc.VERSION;
-    }
-
     public record ErrorDetail(int code, String message, JsonValue data) {
     }
 }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcNotification.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcNotification.java
@@ -9,9 +9,4 @@ public record JsonRpcNotification(String method, JsonObject params) implements J
             throw new IllegalArgumentException("method is required");
         }
     }
-
-    @Override
-    public String jsonrpc() {
-        return JsonRpc.VERSION;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcRequest.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcRequest.java
@@ -10,9 +10,4 @@ public record JsonRpcRequest(RequestId id, String method, JsonObject params) imp
             throw new IllegalArgumentException("id and method are required");
         }
     }
-
-    @Override
-    public String jsonrpc() {
-        return JsonRpc.VERSION;
-    }
 }

--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcResponse.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcResponse.java
@@ -13,9 +13,4 @@ public record JsonRpcResponse(RequestId id, JsonObject result) implements JsonRp
             throw new IllegalArgumentException("result is required");
         }
     }
-
-    @Override
-    public String jsonrpc() {
-        return JsonRpc.VERSION;
-    }
 }


### PR DESCRIPTION
## Summary
- centralize JsonRpc version constant in JsonRpcMessage default method
- drop redundant jsonrpc() overrides in message records

## Testing
- `./verify.sh` *(fails: McpConformanceSuite initializationError)*

------
https://chatgpt.com/codex/tasks/task_e_689a3fed272c832495d1d1020fc98573