### PR TITLE
Centralize capability requirements

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpHost.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpHost.java
@@ -84,22 +84,11 @@ public final class McpHost implements AutoCloseable {
     }
 
     private static Optional<ServerCapability> serverCapabilityForMethod(RequestMethod requestMethod) {
-        return CapabilityRequirements.forMethod(requestMethod)
-                .or(() -> {
-                    if (requestMethod.method().startsWith("tools/")) return Optional.of(ServerCapability.TOOLS);
-                    if (requestMethod.method().startsWith("resources/")) return Optional.of(ServerCapability.RESOURCES);
-                    if (requestMethod.method().startsWith("prompts/")) return Optional.of(ServerCapability.PROMPTS);
-                    if (requestMethod.method().startsWith("completion/")) return Optional.of(ServerCapability.COMPLETIONS);
-                    if (requestMethod.method().startsWith("logging/")) return Optional.of(ServerCapability.LOGGING);
-                    return Optional.empty();
-                });
+        return CapabilityRequirements.forMethod(requestMethod);
     }
 
     private static Optional<ClientCapability> clientCapabilityForMethod(JsonRpcMethod method) {
-        if (method.method().startsWith("roots/")) return Optional.of(ClientCapability.ROOTS);
-        if (method.method().startsWith("sampling/")) return Optional.of(ClientCapability.SAMPLING);
-        if (method.method().startsWith("elicitation/")) return Optional.of(ClientCapability.ELICITATION);
-        return Optional.empty();
+        return CapabilityRequirements.forClient(method);
     }
 
     private static void requireCapability(McpClient client, ServerCapability cap) {

--- a/src/main/java/com/amannmalik/mcp/core/CapabilityRequirements.java
+++ b/src/main/java/com/amannmalik/mcp/core/CapabilityRequirements.java
@@ -1,5 +1,8 @@
 package com.amannmalik.mcp.core;
 
+import com.amannmalik.mcp.api.ClientCapability;
+import com.amannmalik.mcp.api.JsonRpcMethod;
+import com.amannmalik.mcp.api.NotificationMethod;
 import com.amannmalik.mcp.api.RequestMethod;
 import com.amannmalik.mcp.api.ServerCapability;
 
@@ -7,7 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public final class CapabilityRequirements {
-    private static final Map<RequestMethod, ServerCapability> MAP = Map.ofEntries(
+    private static final Map<RequestMethod, ServerCapability> SERVER_MAP = Map.ofEntries(
             Map.entry(RequestMethod.RESOURCES_LIST, ServerCapability.RESOURCES),
             Map.entry(RequestMethod.RESOURCES_TEMPLATES_LIST, ServerCapability.RESOURCES),
             Map.entry(RequestMethod.RESOURCES_READ, ServerCapability.RESOURCES),
@@ -21,10 +24,21 @@ public final class CapabilityRequirements {
             Map.entry(RequestMethod.COMPLETION_COMPLETE, ServerCapability.COMPLETIONS)
     );
 
+    private static final Map<JsonRpcMethod, ClientCapability> CLIENT_MAP = Map.ofEntries(
+            Map.entry(RequestMethod.ROOTS_LIST, ClientCapability.ROOTS),
+            Map.entry(NotificationMethod.ROOTS_LIST_CHANGED, ClientCapability.ROOTS),
+            Map.entry(RequestMethod.SAMPLING_CREATE_MESSAGE, ClientCapability.SAMPLING),
+            Map.entry(RequestMethod.ELICITATION_CREATE, ClientCapability.ELICITATION)
+    );
+
     private CapabilityRequirements() {
     }
 
     public static Optional<ServerCapability> forMethod(RequestMethod method) {
-        return Optional.ofNullable(MAP.get(method));
+        return Optional.ofNullable(SERVER_MAP.get(method));
+    }
+
+    public static Optional<ClientCapability> forClient(JsonRpcMethod method) {
+        return Optional.ofNullable(CLIENT_MAP.get(method));
     }
 }


### PR DESCRIPTION
## Summary
- centralize server and client capability lookups in CapabilityRequirements
- simplify McpHost to use unified capability mapping

## Testing
- `./verify.sh` *(fails: McpConformanceSuite initializationError)*


------
https://chatgpt.com/codex/tasks/task_e_689a4321b0d88324af3de4ffe4157dd9