### PR TITLE
refactor list change notifications

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     private static final InitializeRequestAbstractEntityCodec INITIALIZE_REQUEST_CODEC = new InitializeRequestAbstractEntityCodec();
     private static final JsonCodec<ResourceUpdatedNotification> RESOURCE_UPDATED_NOTIFICATION_JSON_CODEC = new ResourceUpdatedNotificationAbstractEntityCodec();
+    private static final JsonCodec<ResourceListChangedNotification> RESOURCE_LIST_CHANGED_NOTIFICATION_JSON_CODEC = new ResourceListChangedNotificationJsonCodec();
+    private static final JsonCodec<ToolListChangedNotification> TOOL_LIST_CHANGED_NOTIFICATION_JSON_CODEC = new ToolListChangedNotificationJsonCodec();
     private static final JsonCodec<SubscribeRequest> SUBSCRIBE_REQUEST_JSON_CODEC = new SubscribeRequestAbstractEntityCodec();
     private static final JsonCodec<UnsubscribeRequest> UNSUBSCRIBE_REQUEST_JSON_CODEC = new UnsubscribeRequestAbstractEntityCodec();
     private static final JsonCodec<SetLevelRequest> SET_LEVEL_REQUEST_JSON_CODEC = new SetLevelRequestAbstractEntityCodec();
@@ -552,8 +554,7 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
 
     private void handleResourcesListChanged(JsonRpcNotification note) {
         try {
-            // TODO: understand and refactor this
-            AbstractEntityCodec.empty(ResourceListChangedNotification::new).fromJson(note.params());
+            RESOURCE_LIST_CHANGED_NOTIFICATION_JSON_CODEC.fromJson(note.params());
             listener.onResourceListChanged();
         } catch (IllegalArgumentException ignore) {
         }
@@ -573,8 +574,7 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
 
     private void handleToolsListChanged(JsonRpcNotification note) {
         try {
-            // TODO: understand and refactor this
-            AbstractEntityCodec.empty(ToolListChangedNotification::new).fromJson(note.params());
+            TOOL_LIST_CHANGED_NOTIFICATION_JSON_CODEC.fromJson(note.params());
             listener.onToolListChanged();
         } catch (IllegalArgumentException ignore) {
         }

--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -27,6 +27,7 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
     private static final CompleteRequestJsonCodec COMPLETE_REQUEST_JSON_CODEC = new CompleteRequestJsonCodec();
     private static final JsonCodec<SetLevelRequest> SET_LEVEL_REQUEST_JSON_CODEC = new SetLevelRequestAbstractEntityCodec();
     private static final CancelledNotificationJsonCodec CANCELLED_NOTIFICATION_JSON_CODEC = new CancelledNotificationJsonCodec();
+    private static final JsonCodec<ToolListChangedNotification> TOOL_LIST_CHANGED_NOTIFICATION_JSON_CODEC = new ToolListChangedNotificationJsonCodec();
     private static final JsonCodec<ListToolsResult> LIST_TOOLS_RESULT_JSON_CODEC =
             AbstractEntityCodec.paginatedResult(
                     "tools",
@@ -131,7 +132,7 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
             toolListSubscription = subscribeListChanges(
                     tools::subscribe,
                     NotificationMethod.TOOLS_LIST_CHANGED,
-                    AbstractEntityCodec.empty(ToolListChangedNotification::new).toJson(new ToolListChangedNotification()));
+                    TOOL_LIST_CHANGED_NOTIFICATION_JSON_CODEC.toJson(new ToolListChangedNotification()));
         }
 
         if (prompts != null && prompts.supportsListChanged()) {

--- a/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
+++ b/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
@@ -18,6 +18,7 @@ import java.util.function.*;
 
 final class ResourceOrchestrator implements AutoCloseable {
     private static final JsonCodec<ResourceUpdatedNotification> RESOURCE_UPDATED_NOTIFICATION_JSON_CODEC = new ResourceUpdatedNotificationAbstractEntityCodec();
+    private static final JsonCodec<ResourceListChangedNotification> RESOURCE_LIST_CHANGED_NOTIFICATION_JSON_CODEC = new ResourceListChangedNotificationJsonCodec();
     private final ResourceProvider resources;
     private final ResourceAccessPolicy access;
     private final Principal principal;
@@ -47,7 +48,7 @@ final class ResourceOrchestrator implements AutoCloseable {
                 subscribeListChanges(
                         resources::subscribe,
                         NotificationMethod.RESOURCES_LIST_CHANGED,
-                        AbstractEntityCodec.empty(ResourceListChangedNotification::new).toJson(new ResourceListChangedNotification())) : null;
+                        RESOURCE_LIST_CHANGED_NOTIFICATION_JSON_CODEC.toJson(new ResourceListChangedNotification())) : null;
     }
 
     public void register(JsonRpcEndpoint endpoint) {

--- a/src/main/java/com/amannmalik/mcp/codec/ResourceListChangedNotificationJsonCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/ResourceListChangedNotificationJsonCodec.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.codec;
+
+import com.amannmalik.mcp.resources.ResourceListChangedNotification;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+public final class ResourceListChangedNotificationJsonCodec implements JsonCodec<ResourceListChangedNotification> {
+    @Override
+    public JsonObject toJson(ResourceListChangedNotification notification) {
+        return JsonValue.EMPTY_JSON_OBJECT;
+    }
+
+    @Override
+    public ResourceListChangedNotification fromJson(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) throw new IllegalArgumentException("unexpected fields");
+        return new ResourceListChangedNotification();
+    }
+}
+

--- a/src/main/java/com/amannmalik/mcp/codec/ToolListChangedNotificationJsonCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/ToolListChangedNotificationJsonCodec.java
@@ -1,0 +1,19 @@
+package com.amannmalik.mcp.codec;
+
+import com.amannmalik.mcp.api.ToolListChangedNotification;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+public final class ToolListChangedNotificationJsonCodec implements JsonCodec<ToolListChangedNotification> {
+    @Override
+    public JsonObject toJson(ToolListChangedNotification notification) {
+        return JsonValue.EMPTY_JSON_OBJECT;
+    }
+
+    @Override
+    public ToolListChangedNotification fromJson(JsonObject obj) {
+        if (obj != null && !obj.isEmpty()) throw new IllegalArgumentException("unexpected fields");
+        return new ToolListChangedNotification();
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace generic empty codecs with explicit resource and tool list change codecs
- route client, server, and resource orchestrator notifications through dedicated codecs

## Testing
- `./verify.sh` *(fails: McpConformanceSuite initializationError NoTestsDiscoveredException)*

------
https://chatgpt.com/codex/tasks/task_e_689a4321b0d88324af3de4ffe4157dd9