### PR TITLE
refactor: rename notify to sendNotification

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/JsonRpcEndpoint.java
+++ b/src/main/java/com/amannmalik/mcp/api/JsonRpcEndpoint.java
@@ -54,15 +54,15 @@ sealed class JsonRpcEndpoint implements AutoCloseable permits McpClient, McpServ
             throw new IOException(cause);
         } catch (TimeoutException e) {
             try {
-                notify(NotificationMethod.CANCELLED.method(),
+                sendNotification(NotificationMethod.CANCELLED.method(),
                         CANCEL_CODEC.toJson(new CancelledNotification(id, "timeout")));
             } catch (IOException ignore) {
             }
-            throw new IOException(McpServerConfiguration.defaultConfiguration().errorTimeout() + " after " + timeoutMillis + " ms", e);
+            throw new IOException("timeout after " + timeoutMillis + " ms", e);
         }
     }
 
-    protected final void notify(String method, JsonObject params) throws IOException {
+    protected final void sendNotification(String method, JsonObject params) throws IOException {
         send(new JsonRpcNotification(method, params));
     }
 

--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -223,9 +223,9 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         }
     }
 
-    public void notify(NotificationMethod method, JsonObject params) throws IOException {
+    public void sendNotification(NotificationMethod method, JsonObject params) throws IOException {
         if (!connected) throw new IllegalStateException("not connected");
-        notify(method.method(), params);
+        super.sendNotification(method.method(), params);
     }
 
     @Override
@@ -419,7 +419,7 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         try {
             rootsSubscription = roots.subscribe(ignored -> {
                 try {
-                    notify(NotificationMethod.ROOTS_LIST_CHANGED,
+                    sendNotification(NotificationMethod.ROOTS_LIST_CHANGED,
                             AbstractEntityCodec.empty(RootsListChangedNotification::new).toJson(new RootsListChangedNotification()));
                 } catch (IOException ignore) {
                 }

--- a/src/main/java/com/amannmalik/mcp/api/McpHost.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpHost.java
@@ -191,8 +191,8 @@ public final class McpHost implements AutoCloseable {
         return requireClientForMethod(id, method).request(method, params, 0L);
     }
 
-    public void notify(String id, NotificationMethod method, JsonObject params) throws IOException {
-        requireClientForMethod(id, method).notify(method, params);
+    public void sendNotification(String id, NotificationMethod method, JsonObject params) throws IOException {
+        requireClientForMethod(id, method).sendNotification(method, params);
     }
 
     public void grantConsent(String scope) {

--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -246,7 +246,7 @@ public final class HostCommand {
                             var params = parts.length > 3 ?
                                     Json.createReader(new StringReader(parts[3])).readObject() :
                                     JsonValue.EMPTY_JSON_OBJECT;
-                            host.notify(parts[1], NotificationMethod.from(parts[2]).orElseThrow(), params);
+                            host.sendNotification(parts[1], NotificationMethod.from(parts[2]).orElseThrow(), params);
                             System.out.println("Notification sent");
                         }
                     }


### PR DESCRIPTION
## Summary
- clarify JSON-RPC notification handling by renaming ambiguous `notify` method to `sendNotification`
- simplify timeout error message and remove server configuration dependency

## Testing
- `gradle test` *(fails: McpConformanceSuite > initializationError NoTestsDiscoveredException)*

------
https://chatgpt.com/codex/tasks/task_e_689a4558c700832480b7d5969759d671