### PR TITLE
Refine pagination cursor typing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -256,13 +256,14 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
                 "version", serverInfo.version());
     }
 
-    public ListResourcesResult listResources(String cursor) throws IOException {
+    public ListResourcesResult listResources(Cursor cursor) throws IOException {
+        String token = cursor instanceof Cursor.Token(var value) ? value : null;
         JsonRpcResponse resp = JsonRpc.expectResponse(request(
                 RequestMethod.RESOURCES_LIST,
                 AbstractEntityCodec.paginatedRequest(
                         ListResourcesRequest::cursor,
                         ListResourcesRequest::_meta,
-                        ListResourcesRequest::new).toJson(new ListResourcesRequest(cursor, null)), 0L
+                        ListResourcesRequest::new).toJson(new ListResourcesRequest(token, null)), 0L
         ));
         return AbstractEntityCodec.paginatedResult(
                 "resources",
@@ -273,13 +274,14 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
                 (page, meta) -> new ListResourcesResult(page.items(), page.nextCursor(), meta)).fromJson(resp.result());
     }
 
-    public ListResourceTemplatesResult listResourceTemplates(String cursor) throws IOException {
+    public ListResourceTemplatesResult listResourceTemplates(Cursor cursor) throws IOException {
+        String token = cursor instanceof Cursor.Token(var value) ? value : null;
         JsonRpcResponse resp = JsonRpc.expectResponse(request(
                 RequestMethod.RESOURCES_TEMPLATES_LIST,
                 AbstractEntityCodec.paginatedRequest(
                         ListResourceTemplatesRequest::cursor,
                         ListResourceTemplatesRequest::_meta,
-                        ListResourceTemplatesRequest::new).toJson(new ListResourceTemplatesRequest(cursor, null)), 0L
+                        ListResourceTemplatesRequest::new).toJson(new ListResourceTemplatesRequest(token, null)), 0L
         ));
         return AbstractEntityCodec.paginatedResult(
                 "resourceTemplates",
@@ -499,7 +501,7 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.METHOD_NOT_FOUND, "Roots not supported");
         }
         try {
-            var page = roots.list(null);
+            var page = roots.list(Cursor.Start.INSTANCE);
             return new JsonRpcResponse(req.id(),
                     new ListRootsResultAbstractEntityCodec().toJson(new ListRootsResult(page.items(), null)));
         } catch (Exception e) {

--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.cli;
 
 import com.amannmalik.mcp.api.*;
+import com.amannmalik.mcp.spi.Cursor;
 import com.amannmalik.mcp.spi.Role;
 import com.amannmalik.mcp.spi.SamplingAccessPolicy;
 import jakarta.json.Json;
@@ -179,7 +180,8 @@ public final class HostCommand {
                         if (parts.length < 2) {
                             System.out.println("Usage: list-tools <client-id> [cursor]");
                         } else {
-                            String cursor = parts.length > 2 ? parts[2] : null;
+                            String token = parts.length > 2 ? parts[2] : null;
+                            Cursor cursor = token == null ? Cursor.Start.INSTANCE : new Cursor.Token(token);
                             var page = host.listTools(parts[1], cursor);
                             System.out.println(page);
                         }

--- a/src/main/java/com/amannmalik/mcp/core/InMemoryProvider.java
+++ b/src/main/java/com/amannmalik/mcp/core/InMemoryProvider.java
@@ -5,6 +5,7 @@ import com.amannmalik.mcp.completion.InMemoryCompletionProvider;
 import com.amannmalik.mcp.prompts.InMemoryPromptProvider;
 import com.amannmalik.mcp.resources.InMemoryResourceProvider;
 import com.amannmalik.mcp.roots.InMemoryRootsProvider;
+import com.amannmalik.mcp.spi.Cursor;
 import com.amannmalik.mcp.spi.Pagination;
 import com.amannmalik.mcp.spi.Provider;
 import com.amannmalik.mcp.tools.InMemoryToolProvider;
@@ -33,8 +34,8 @@ public sealed class InMemoryProvider<T> implements Provider<T> permits
     }
 
     @Override
-    public Pagination.Page<T> list(String cursor) {
-        return Pagination.page(items, cursor, Pagination.DEFAULT_PAGE_SIZE);
+    public Pagination.Page<T> list(Cursor cursor) {
+        return Pagination.page(items, cursor == null ? Cursor.Start.INSTANCE : cursor, Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/InMemoryPromptProvider.java
@@ -26,7 +26,7 @@ public final class InMemoryPromptProvider extends InMemoryProvider<Prompt> imple
     }
 
     @Override
-    public Pagination.Page<Prompt> list(String cursor) {
+    public Pagination.Page<Prompt> list(Cursor cursor) {
         items.sort(Comparator.comparing(Prompt::name));
         return super.list(cursor);
     }

--- a/src/main/java/com/amannmalik/mcp/resources/InMemoryResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/resources/InMemoryResourceProvider.java
@@ -27,8 +27,8 @@ public final class InMemoryResourceProvider extends InMemoryProvider<Resource> i
     }
 
     @Override
-    public Pagination.Page<ResourceTemplate> listTemplates(String cursor) {
-        return Pagination.page(templates, cursor, Pagination.DEFAULT_PAGE_SIZE);
+    public Pagination.Page<ResourceTemplate> listTemplates(Cursor cursor) {
+        return Pagination.page(templates, cursor == null ? Cursor.Start.INSTANCE : cursor, Pagination.DEFAULT_PAGE_SIZE);
     }
 
     @Override

--- a/src/main/java/com/amannmalik/mcp/spi/CompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/CompletionProvider.java
@@ -23,7 +23,7 @@ public non-sealed interface CompletionProvider extends ExecutingProvider<Ref, Co
     }
 
     @Override
-    default Pagination.Page<Ref> list(String cursor) {
+    default Pagination.Page<Ref> list(Cursor cursor) {
         return new Pagination.Page<>(List.of(), Cursor.End.INSTANCE);
     }
 

--- a/src/main/java/com/amannmalik/mcp/spi/Cursor.java
+++ b/src/main/java/com/amannmalik/mcp/spi/Cursor.java
@@ -2,9 +2,13 @@ package com.amannmalik.mcp.spi;
 
 import com.amannmalik.mcp.util.ValidationUtil;
 
-public sealed interface Cursor permits Cursor.End, Cursor.Token {
+public sealed interface Cursor permits Cursor.Start, Cursor.End, Cursor.Token {
     static Cursor of(String value) {
         return value == null ? End.INSTANCE : new Token(value);
+    }
+
+    enum Start implements Cursor {
+        INSTANCE
     }
 
     enum End implements Cursor {
@@ -15,6 +19,7 @@ public sealed interface Cursor permits Cursor.End, Cursor.Token {
         public Token {
             if (value == null) throw new IllegalArgumentException("value is required");
             value = ValidationUtil.requireClean(value);
+            Pagination.requireValidCursor(value);
         }
     }
 }

--- a/src/main/java/com/amannmalik/mcp/spi/ElicitationProvider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/ElicitationProvider.java
@@ -15,7 +15,7 @@ public non-sealed interface ElicitationProvider extends ExecutingProvider<Elicit
     }
 
     @Override
-    default Pagination.Page<ElicitRequest> list(String cursor) {
+    default Pagination.Page<ElicitRequest> list(Cursor cursor) {
         return new Pagination.Page<>(List.of(), Cursor.End.INSTANCE);
     }
 

--- a/src/main/java/com/amannmalik/mcp/spi/Provider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/Provider.java
@@ -6,7 +6,7 @@ import com.amannmalik.mcp.core.InMemoryProvider;
 import java.util.function.Consumer;
 
 public sealed interface Provider<T> extends AutoCloseable permits InMemoryProvider, PromptProvider, ResourceProvider, RootsProvider, ToolProvider, ExecutingProvider {
-    Pagination.Page<T> list(String cursor);
+    Pagination.Page<T> list(Cursor cursor);
 
     default AutoCloseable subscribe(Consumer<Change> listener) {
         return () -> {

--- a/src/main/java/com/amannmalik/mcp/spi/ResourceProvider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/ResourceProvider.java
@@ -12,7 +12,7 @@ public non-sealed interface ResourceProvider extends Provider<Resource> {
         return Optional.empty();
     }
 
-    Pagination.Page<ResourceTemplate> listTemplates(String cursor);
+    Pagination.Page<ResourceTemplate> listTemplates(Cursor cursor);
 
     AutoCloseable subscribe(String uri, Consumer<ResourceUpdate> listener);
 

--- a/src/main/java/com/amannmalik/mcp/spi/SamplingProvider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/SamplingProvider.java
@@ -15,7 +15,7 @@ public non-sealed interface SamplingProvider extends ExecutingProvider<SamplingM
     }
 
     @Override
-    default Pagination.Page<SamplingMessage> list(String cursor) {
+    default Pagination.Page<SamplingMessage> list(Cursor cursor) {
         return new Pagination.Page<>(List.of(), Cursor.End.INSTANCE);
     }
 

--- a/src/main/java/com/amannmalik/mcp/spi/ToolProvider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/ToolProvider.java
@@ -11,15 +11,14 @@ public non-sealed interface ToolProvider extends Provider<Tool> {
 
     default Optional<Tool> find(String name) {
         if (name == null) throw new IllegalArgumentException("name required");
-        String cursor = null;
+        Cursor cursor = Cursor.Start.INSTANCE;
         do {
             Pagination.Page<Tool> page = list(cursor);
             for (Tool t : page.items()) {
                 if (t.name().equals(name)) return Optional.of(t);
             }
-            Cursor next = page.nextCursor();
-            cursor = next instanceof Cursor.Token(String value) ? value : null;
-        } while (cursor != null);
+            cursor = page.nextCursor();
+        } while (!(cursor instanceof Cursor.End));
         return Optional.empty();
     }
 }


### PR DESCRIPTION
## Summary
- use strong `Cursor` types for provider pagination
- centralize cursor validation and encoding
- propagate cursor handling through client and server APIs

## Testing
- `gradle check` *(fails: McpConformanceSuite > initializationError: org.junit.platform.suite.engine.NoTestsDiscoveredException)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a2b197c832493ad504507c508a6