### PR TITLE
Centralize capability names

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ClientCapability.java
+++ b/src/main/java/com/amannmalik/mcp/api/ClientCapability.java
@@ -1,8 +1,31 @@
 package com.amannmalik.mcp.api;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 public enum ClientCapability {
-    ROOTS,
-    SAMPLING,
-    ELICITATION,
-    EXPERIMENTAL
+    ROOTS("roots"),
+    SAMPLING("sampling"),
+    ELICITATION("elicitation"),
+    EXPERIMENTAL("experimental");
+
+    private static final Map<String, ClientCapability> BY_CODE = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(ClientCapability::code, c -> c));
+
+    private final String code;
+
+    ClientCapability(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public static Optional<ClientCapability> from(String raw) {
+        if (raw == null) return Optional.empty();
+        return Optional.ofNullable(BY_CODE.get(raw));
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/api/ServerCapability.java
+++ b/src/main/java/com/amannmalik/mcp/api/ServerCapability.java
@@ -1,10 +1,33 @@
 package com.amannmalik.mcp.api;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 public enum ServerCapability {
-    PROMPTS,
-    RESOURCES,
-    TOOLS,
-    LOGGING,
-    COMPLETIONS,
-    EXPERIMENTAL
+    PROMPTS("prompts"),
+    RESOURCES("resources"),
+    TOOLS("tools"),
+    LOGGING("logging"),
+    COMPLETIONS("completions"),
+    EXPERIMENTAL("experimental");
+
+    private static final Map<String, ServerCapability> BY_CODE = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(ServerCapability::code, c -> c));
+
+    private final String code;
+
+    ServerCapability(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public static Optional<ServerCapability> from(String raw) {
+        if (raw == null) return Optional.empty();
+        return Optional.ofNullable(BY_CODE.get(raw));
+    }
 }

--- a/src/main/java/com/amannmalik/mcp/codec/InitializeRequestAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/InitializeRequestAbstractEntityCodec.java
@@ -21,7 +21,7 @@ public final class InitializeRequestAbstractEntityCodec extends AbstractEntityCo
             if (c == ClientCapability.ROOTS && req.features().rootsListChanged()) {
                 b.add("listChanged", true);
             }
-            caps.add(c.name().toLowerCase(), b.build());
+            caps.add(c.code(), b.build());
         }
         req.capabilities().clientExperimental().forEach(caps::add);
         return Json.createObjectBuilder()
@@ -42,14 +42,15 @@ public final class InitializeRequestAbstractEntityCodec extends AbstractEntityCo
             for (var entry : capsObj.entrySet()) {
                 String k = entry.getKey();
                 JsonObject v = entry.getValue().asJsonObject();
-                switch (k) {
-                    case "roots" -> {
-                        client.add(ClientCapability.ROOTS);
+                Optional<ClientCapability> cap = ClientCapability.from(k);
+                if (cap.isPresent()) {
+                    ClientCapability c = cap.get();
+                    client.add(c);
+                    if (c == ClientCapability.ROOTS) {
                         rootsList = v.getBoolean("listChanged", false);
                     }
-                    case "sampling" -> client.add(ClientCapability.SAMPLING);
-                    case "elicitation" -> client.add(ClientCapability.ELICITATION);
-                    default -> experimental.put(k, v);
+                } else {
+                    experimental.put(k, v);
                 }
             }
         }

--- a/src/main/java/com/amannmalik/mcp/codec/InitializeResponseAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/InitializeResponseAbstractEntityCodec.java
@@ -31,7 +31,7 @@ public final class InitializeResponseAbstractEntityCodec extends AbstractEntityC
                 default -> {
                 }
             }
-            server.add(c.name().toLowerCase(), b.build());
+            server.add(c.code(), b.build());
         }
         resp.capabilities().serverExperimental().forEach(server::add);
         JsonObjectBuilder b = Json.createObjectBuilder()
@@ -49,26 +49,21 @@ public final class InitializeResponseAbstractEntityCodec extends AbstractEntityC
         Set<ServerCapability> server = EnumSet.noneOf(ServerCapability.class);
         Map<String, JsonObject> experimental = new HashMap<>();
         if (capsObj != null) {
-            capsObj.forEach((k, v) -> {
-                try {
-                    server.add(ServerCapability.valueOf(k.toUpperCase()));
-                } catch (IllegalArgumentException ignore) {
-                    experimental.put(k, v.asJsonObject());
-                }
-            });
+            capsObj.forEach((k, v) -> ServerCapability.from(k)
+                    .ifPresentOrElse(server::add, () -> experimental.put(k, v.asJsonObject())));
         }
         EnumSet<ServerFeature> features = EnumSet.noneOf(ServerFeature.class);
         if (capsObj != null) {
-            JsonObject res = capsObj.getJsonObject("resources");
+            JsonObject res = capsObj.getJsonObject(ServerCapability.RESOURCES.code());
             if (res != null) {
                 if (res.getBoolean("subscribe", false)) features.add(ServerFeature.RESOURCES_SUBSCRIBE);
                 if (res.getBoolean("listChanged", false)) features.add(ServerFeature.RESOURCES_LIST_CHANGED);
             }
-            JsonObject tools = capsObj.getJsonObject("tools");
+            JsonObject tools = capsObj.getJsonObject(ServerCapability.TOOLS.code());
             if (tools != null && tools.getBoolean("listChanged", false)) {
                 features.add(ServerFeature.TOOLS_LIST_CHANGED);
             }
-            JsonObject prompts = capsObj.getJsonObject("prompts");
+            JsonObject prompts = capsObj.getJsonObject(ServerCapability.PROMPTS.code());
             if (prompts != null && prompts.getBoolean("listChanged", false)) {
                 features.add(ServerFeature.PROMPTS_LIST_CHANGED);
             }


### PR DESCRIPTION
## Summary
- centralize capability string codes for client and server capabilities
- reference those codes in initialize request/response codecs

## Testing
- `./verify.sh` *(fails: NoTestsDiscoveredException)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a320e8083249a86e6efc480fd30