### PR TITLE
refactor: flatten client configuration

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -74,8 +74,8 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
               McpClientListener listener) throws IOException {
         super(createTransport(config, globalVerbose),
                 new ProgressManager(new RateLimiter(
-                        config.transport().progressPerSecond(),
-                        config.transport().rateLimiterWindow().toMillis())),
+                        config.progressPerSecond(),
+                        config.rateLimiterWindow().toMillis())),
                 1);
         this.info = new ClientInfo(config.serverName(), config.serverDisplayName(), config.serverVersion());
         this.capabilities = config.clientCapabilities().isEmpty() ? Set.of() : EnumSet.copyOf(config.clientCapabilities());
@@ -93,11 +93,11 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         }
         this.elicitation = elicitation == null ? NO_ELICITATION_PROVIDER : elicitation;
         this.listener = listener == null ? NOOP_LISTENER : listener;
-        this.samplingAccess = config.behavior().samplingAccessPolicy();
+        this.samplingAccess = config.samplingAccessPolicy();
         this.principal = new Principal(config.principal(), Set.of());
-        this.pingInterval = config.transport().pingInterval().toMillis();
-        this.pingTimeout = config.transport().pingTimeout().toMillis();
-        this.initializationTimeout = config.session().initializeRequestTimeout().toMillis();
+        this.pingInterval = config.pingInterval().toMillis();
+        this.pingTimeout = config.pingTimeout().toMillis();
+        this.initializationTimeout = config.initializeRequestTimeout().toMillis();
 
         registerRequest(RequestMethod.SAMPLING_CREATE_MESSAGE, this::handleCreateMessage);
         registerRequest(RequestMethod.ROOTS_LIST, this::handleListRoots);
@@ -117,7 +117,7 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
                                              boolean globalVerbose) throws IOException {
         String spec = config.commandSpec();
         String[] cmds = spec == null || spec.isBlank() ? new String[0] : spec.split(" ");
-        boolean verbose = config.behavior().verbose() || globalVerbose;
+        boolean verbose = config.verbose() || globalVerbose;
         return cmds.length == 0
                 ? new StdioTransport(System.in, System.out)
                 : new StdioTransport(cmds, verbose ? System.err::println : s -> {

--- a/src/main/java/com/amannmalik/mcp/api/McpClientConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClientConfiguration.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 /// Complete MCP client configuration merging connection, session, and protocol settings
-/// - [Architecture](specification/2025-06-18/architecture/index.mdx)  
+/// - [Architecture](specification/2025-06-18/architecture/index.mdx)
 /// - [Client Features](specification/2025-06-18/client/index.mdx)
 public record McpClientConfiguration(
         String clientId,
@@ -17,10 +17,21 @@ public record McpClientConfiguration(
         String principal,
         Set<ClientCapability> clientCapabilities,
         String commandSpec,
-        ConnectionConfig connection,
-        SessionConfig session,
-        TransportConfig transport,
-        BehaviorConfig behavior
+        Duration defaultReceiveTimeout,
+        String defaultOriginHeader,
+        Duration httpRequestTimeout,
+        boolean enableKeepAlive,
+        int sessionIdByteLength,
+        Duration initializeRequestTimeout,
+        boolean strictVersionValidation,
+        Duration pingTimeout,
+        Duration pingInterval,
+        int progressPerSecond,
+        Duration rateLimiterWindow,
+        boolean verbose,
+        boolean interactiveSampling,
+        List<String> rootDirectories,
+        SamplingAccessPolicy samplingAccessPolicy
 ) {
 
     public McpClientConfiguration {
@@ -31,14 +42,27 @@ public record McpClientConfiguration(
         if (principal == null || principal.isBlank())
             throw new IllegalArgumentException("Principal is required");
         clientCapabilities = Set.copyOf(clientCapabilities);
-        if (connection == null)
-            throw new IllegalArgumentException("Connection config is required");
-        if (session == null)
-            throw new IllegalArgumentException("Session config is required");
-        if (transport == null)
-            throw new IllegalArgumentException("Transport config is required");
-        if (behavior == null)
-            throw new IllegalArgumentException("Behavior config is required");
+        if (defaultReceiveTimeout == null || defaultReceiveTimeout.isNegative() || defaultReceiveTimeout.isZero())
+            throw new IllegalArgumentException("Default receive timeout must be positive");
+        if (defaultOriginHeader == null || defaultOriginHeader.isBlank())
+            throw new IllegalArgumentException("Default origin header is required");
+        if (httpRequestTimeout == null || httpRequestTimeout.isNegative() || httpRequestTimeout.isZero())
+            throw new IllegalArgumentException("HTTP request timeout must be positive");
+        if (sessionIdByteLength <= 0)
+            throw new IllegalArgumentException("Session ID byte length must be positive");
+        if (initializeRequestTimeout == null || initializeRequestTimeout.isNegative() || initializeRequestTimeout.isZero())
+            throw new IllegalArgumentException("Initialize request timeout must be positive");
+        if (pingTimeout == null || pingTimeout.isNegative() || pingTimeout.isZero())
+            throw new IllegalArgumentException("Ping timeout must be positive");
+        if (pingInterval == null || pingInterval.isNegative())
+            throw new IllegalArgumentException("Ping interval must be non-negative");
+        if (progressPerSecond < 0)
+            throw new IllegalArgumentException("Progress per second must be non-negative");
+        if (rateLimiterWindow == null || rateLimiterWindow.isNegative() || rateLimiterWindow.isZero())
+            throw new IllegalArgumentException("Rate limiter window must be positive");
+        rootDirectories = List.copyOf(rootDirectories);
+        if (samplingAccessPolicy == null)
+            throw new IllegalArgumentException("Sampling access policy is required");
     }
 
     public static McpClientConfiguration defaultConfiguration(String clientId, String serverName, String principal) {
@@ -50,109 +74,22 @@ public record McpClientConfiguration(
                 principal,
                 Set.of(ClientCapability.SAMPLING, ClientCapability.ROOTS),
                 "",
-                ConnectionConfig.defaultConfig(),
-                SessionConfig.defaultConfig(),
-                TransportConfig.defaultConfig(),
-                BehaviorConfig.defaultConfig()
+                Duration.ofSeconds(10),
+                "http://127.0.0.1",
+                Duration.ofSeconds(30),
+                true,
+                32,
+                Duration.ofSeconds(30),
+                true,
+                Duration.ofSeconds(10),
+                Duration.ofSeconds(30),
+                10,
+                Duration.ofMinutes(1),
+                false,
+                true,
+                List.of(),
+                SamplingAccessPolicy.PERMISSIVE
         );
     }
-
-    public record ConnectionConfig(
-            Duration defaultReceiveTimeout,
-            String defaultOriginHeader,
-            Duration httpRequestTimeout,
-            boolean enableKeepAlive
-    ) {
-
-        public ConnectionConfig {
-            if (defaultReceiveTimeout == null || defaultReceiveTimeout.isNegative() || defaultReceiveTimeout.isZero())
-                throw new IllegalArgumentException("Default receive timeout must be positive");
-            if (defaultOriginHeader == null || defaultOriginHeader.isBlank())
-                throw new IllegalArgumentException("Default origin header is required");
-            if (httpRequestTimeout == null || httpRequestTimeout.isNegative() || httpRequestTimeout.isZero())
-                throw new IllegalArgumentException("HTTP request timeout must be positive");
-        }
-
-        public static ConnectionConfig defaultConfig() {
-            return new ConnectionConfig(
-                    Duration.ofSeconds(10),
-                    "http://127.0.0.1",
-                    Duration.ofSeconds(30),
-                    true
-            );
-        }
-    }
-
-    public record SessionConfig(
-            int sessionIdByteLength,
-            Duration initializeRequestTimeout,
-            boolean strictVersionValidation
-    ) {
-
-        public SessionConfig {
-            if (sessionIdByteLength <= 0)
-                throw new IllegalArgumentException("Session ID byte length must be positive");
-            if (initializeRequestTimeout == null || initializeRequestTimeout.isNegative() || initializeRequestTimeout.isZero())
-                throw new IllegalArgumentException("Initialize request timeout must be positive");
-        }
-
-        public static SessionConfig defaultConfig() {
-            return new SessionConfig(
-                    32,
-                    Duration.ofSeconds(30),
-                    true
-            );
-        }
-    }
-
-    public record TransportConfig(
-            Duration pingTimeout,
-            Duration pingInterval,
-            int progressPerSecond,
-            Duration rateLimiterWindow
-    ) {
-
-        public TransportConfig {
-            if (pingTimeout == null || pingTimeout.isNegative() || pingTimeout.isZero())
-                throw new IllegalArgumentException("Ping timeout must be positive");
-            if (pingInterval == null || pingInterval.isNegative())
-                throw new IllegalArgumentException("Ping interval must be non-negative");
-            if (progressPerSecond < 0)
-                throw new IllegalArgumentException("Progress per second must be non-negative");
-            if (rateLimiterWindow == null || rateLimiterWindow.isNegative() || rateLimiterWindow.isZero())
-                throw new IllegalArgumentException("Rate limiter window must be positive");
-        }
-
-        public static TransportConfig defaultConfig() {
-            return new TransportConfig(
-                    Duration.ofSeconds(10),
-                    Duration.ofSeconds(30),
-                    10,
-                    Duration.ofMinutes(1)
-            );
-        }
-    }
-
-    public record BehaviorConfig(
-            boolean verbose,
-            boolean interactiveSampling,
-            List<String> rootDirectories,
-            SamplingAccessPolicy samplingAccessPolicy
-    ) {
-
-        public BehaviorConfig {
-            rootDirectories = List.copyOf(rootDirectories);
-            if (samplingAccessPolicy == null)
-                throw new IllegalArgumentException("Sampling access policy is required");
-        }
-
-        public static BehaviorConfig defaultConfig() {
-            return new BehaviorConfig(
-                    false,
-                    true,
-                    List.of(),
-                    SamplingAccessPolicy.PERMISSIVE
-            );
-        }
-    }
 }
+

--- a/src/main/java/com/amannmalik/mcp/api/McpHost.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpHost.java
@@ -44,15 +44,15 @@ public final class McpHost implements AutoCloseable {
         for (McpClientConfiguration clientConfig : config.clientConfigurations()) {
             grantConsent(clientConfig.clientId());
 
-            SamplingProvider samplingProvider = new InteractiveSamplingProvider(clientConfig.behavior().interactiveSampling());
+            SamplingProvider samplingProvider = new InteractiveSamplingProvider(clientConfig.interactiveSampling());
 
             // Create roots from configured directories
-            List<Root> roots = clientConfig.behavior().rootDirectories().stream()
+            List<Root> roots = clientConfig.rootDirectories().stream()
                     .map(dir -> new Root("file://" + dir, dir, null))
                     .toList();
             InMemoryRootsProvider rootsProvider = new InMemoryRootsProvider(roots);
 
-            McpClientListener listener = (clientConfig.behavior().verbose() || config.globalVerbose()) ? new McpClientListener() {
+            McpClientListener listener = (clientConfig.verbose() || config.globalVerbose()) ? new McpClientListener() {
                 @Override
                 public void onMessage(LoggingMessageNotification notification) {
                     String logger = notification.logger() == null ? "" : ":" + notification.logger();
@@ -102,8 +102,8 @@ public final class McpHost implements AutoCloseable {
         client.setPrincipal(principal);
         client.setSamplingAccessPolicy(samplingAccess);
         client.configurePing(
-                clientConfig.transport().pingInterval().toMillis(),
-                clientConfig.transport().pingTimeout().toMillis());
+                clientConfig.pingInterval().toMillis(),
+                clientConfig.pingTimeout().toMillis());
     }
 
     public void connect(String id) throws IOException {

--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -81,20 +81,21 @@ public final class HostCommand {
                         McpHostConfiguration.defaultConfiguration().hostPrincipal(),
                         capabilities,
                         command,
-                        McpClientConfiguration.ConnectionConfig.defaultConfig(),
-                        McpClientConfiguration.SessionConfig.defaultConfig(),
-                        new McpClientConfiguration.TransportConfig(
-                                java.time.Duration.ofMillis(5_000L),     // pingTimeout
-                                java.time.Duration.ofMillis(0L),         // pingInterval
-                                20,                                       // progressPerSecond
-                                java.time.Duration.ofMillis(1_000L)      // rateLimiterWindow
-                        ),
-                        new McpClientConfiguration.BehaviorConfig(
-                                clientVerbose,
-                                false,
-                                List.of(System.getProperty("user.dir")),
-                                SamplingAccessPolicy.PERMISSIVE
-                        )
+                        java.time.Duration.ofSeconds(10),
+                        "http://127.0.0.1",
+                        java.time.Duration.ofSeconds(30),
+                        true,
+                        32,
+                        java.time.Duration.ofSeconds(30),
+                        true,
+                        java.time.Duration.ofMillis(5_000L),
+                        java.time.Duration.ofMillis(0L),
+                        20,
+                        java.time.Duration.ofMillis(1_000L),
+                        clientVerbose,
+                        false,
+                        List.of(System.getProperty("user.dir")),
+                        SamplingAccessPolicy.PERMISSIVE
                 );
                 clientConfigs.add(clientConfig);
             }
@@ -104,7 +105,7 @@ public final class HostCommand {
             try (McpHost host = new McpHost(config)) {
                 for (McpClientConfiguration clientConfig : clientConfigs) {
                     host.connect(clientConfig.clientId());
-                    if (verbose || clientConfig.behavior().verbose()) {
+                    if (verbose || clientConfig.verbose()) {
                         System.err.println("Registered client: " + clientConfig.clientId());
                     }
                 }


### PR DESCRIPTION
## Summary
- flatten McpClientConfiguration into a single record
- adapt client, host, CLI, and HTTP transport to new configuration fields

## Testing
- `./verify.sh` *(fails: Suite did not discover any tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a629c3e74832497f1e0e99e477dd4