### PR TITLE
fix: stabilize protocol lifecycle tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.test {
     useJUnitPlatform()
     javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
+    dependsOn(tasks.jar)
     finalizedBy(tasks.jacocoTestReport)
     val agentFile = configurations.jacocoAgent.get().singleFile.absolutePath.replace(".jar", "-runtime.jar")
     systemProperty("jacoco.agent.jar", agentFile)

--- a/src/main/java/com/amannmalik/mcp/api/McpHost.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpHost.java
@@ -29,6 +29,7 @@ public final class McpHost implements AutoCloseable {
                     new ToolAbstractEntityCodec(),
                     (page, meta) -> new ListToolsResult(page.items(), page.nextCursor(), meta));
 
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
     private final Map<String, McpClient> clients = new ConcurrentHashMap<>();
     private final ConsentController consents;
     private final Principal principal;
@@ -132,7 +133,7 @@ public final class McpHost implements AutoCloseable {
                         ListToolsRequest::cursor,
                         ListToolsRequest::_meta,
                         ListToolsRequest::new).toJson(new ListToolsRequest(token, null)),
-                Duration.ZERO
+                TIMEOUT
         ));
         return LIST_TOOLS_RESULT_JSON_CODEC.fromJson(resp.result());
     }
@@ -147,7 +148,7 @@ public final class McpHost implements AutoCloseable {
         JsonRpcResponse resp = JsonRpc.expectResponse(client.request(
                 RequestMethod.TOOLS_CALL,
                 CALL_TOOL_REQUEST_CODEC.toJson(new CallToolRequest(name, args, null)),
-                Duration.ZERO
+                TIMEOUT
         ));
         return TOOL_RESULT_ABSTRACT_ENTITY_CODEC.fromJson(resp.result());
     }
@@ -169,12 +170,12 @@ public final class McpHost implements AutoCloseable {
         requireCapability(client, ClientCapability.SAMPLING);
         consents.requireConsent(principal, "sampling");
         samplingAccess.requireAllowed(principal);
-        JsonRpcResponse resp = JsonRpc.expectResponse(client.request(RequestMethod.SAMPLING_CREATE_MESSAGE, params, Duration.ZERO));
+        JsonRpcResponse resp = JsonRpc.expectResponse(client.request(RequestMethod.SAMPLING_CREATE_MESSAGE, params, TIMEOUT));
         return resp.result();
     }
 
     public JsonRpcMessage request(String id, RequestMethod method, JsonObject params) throws IOException {
-        return requireClientForMethod(id, method).request(method, params, Duration.ZERO);
+        return requireClientForMethod(id, method).request(method, params, TIMEOUT);
     }
 
     public void notify(String id, NotificationMethod method, JsonObject params) throws IOException {

--- a/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
@@ -89,6 +89,16 @@ public final class StdioTransport implements Transport {
                 }
             }
 
+            if (process != null && !process.isAlive()) {
+                int code;
+                try {
+                    code = process.exitValue();
+                } catch (IllegalThreadStateException ignore) {
+                    code = -1;
+                }
+                throw new IOException("Process exited with code " + code);
+            }
+
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e) {


### PR DESCRIPTION
## Summary
- launch test server from built jar to avoid module path issues
- guard stdio transport against early process exit
- apply reasonable request timeouts in MCP host
- clean up protocol lifecycle steps for metadata and cancellation

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68a218eded088324966613cdb61452ed