### PR TITLE
Implement server capability inspection for tests

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -191,6 +191,14 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         return Set.copyOf(capabilities);
     }
 
+    public Set<ServerCapability> serverCapabilities() {
+        return Set.copyOf(serverCapabilities);
+    }
+
+    public Set<ServerFeature> serverFeatures() {
+        return Set.copyOf(serverFeatures);
+    }
+
     public String context() {
         return instructions == null ? "" : instructions;
     }
@@ -247,10 +255,6 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
 
     public ServerInfo serverInfo() {
         return serverInfo;
-    }
-
-    public Set<ServerCapability> serverCapabilities() {
-        return serverCapabilities;
     }
 
     public Set<String> serverCapabilityNames() {

--- a/src/main/java/com/amannmalik/mcp/api/McpHost.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpHost.java
@@ -224,6 +224,14 @@ public final class McpHost implements AutoCloseable {
         return client;
     }
 
+    public Set<ServerCapability> serverCapabilities(String id) {
+        return EnumSet.copyOf(requireClient(id).serverCapabilities());
+    }
+
+    public Set<ServerFeature> serverFeatures(String id) {
+        return EnumSet.copyOf(requireClient(id).serverFeatures());
+    }
+
     private McpClient requireConnectedClient(String id) {
         McpClient client = requireClient(id);
         if (!client.connected()) throw new IllegalStateException("Client not connected: " + id);


### PR DESCRIPTION
## Summary
- expose server capabilities and features from host
- add accessors on client
- implement server feature step definitions for capability checks

## Testing
- `gradle test` *(fails: 58)*

------
https://chatgpt.com/codex/tasks/task_e_68a23948207c8324b3fdea8b29bd7d96