### PR TITLE
Add security error step definitions

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/SecurityErrorsSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/SecurityErrorsSteps.java
@@ -1,0 +1,632 @@
+package com.amannmalik.mcp.test;
+
+import com.amannmalik.mcp.api.*;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
+import io.cucumber.java.en.*;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+
+public final class SecurityErrorsSteps {
+    private McpHost activeConnection;
+    private String clientId;
+
+    private boolean securityControlsEnabled;
+    private boolean loggingConfigured;
+    private String resourceUri;
+    private boolean resourceAccessControls;
+    private boolean limitedPrincipal;
+    private boolean rateLimitingConfigured;
+    private int rateLimitPerMinute;
+    private boolean sessionManagementEnabled;
+    private boolean transportSecurityTesting;
+    private boolean inputValidationEnabled;
+    private boolean proxyWithStaticClientId;
+    private boolean thirdPartyAuthServer;
+    private boolean upstreamApis;
+    private boolean oauthFlowWithPkce;
+    private boolean authorizationServer;
+    private boolean sensitiveInfoHandling;
+    private boolean securityMonitoringEnabled;
+    private boolean securityFailsafeMechanisms;
+    private boolean standardsComplianceClaimed;
+
+    private final List<Map<String, String>> authorizationScenarios = new ArrayList<>();
+    private final List<Map<String, String>> tokenAudienceScenarios = new ArrayList<>();
+    private final List<Map<String, String>> jsonRpcErrorScenarios = new ArrayList<>();
+    private final List<Map<String, String>> accessControlScenarios = new ArrayList<>();
+    private final List<Map<String, String>> rateLimitingScenarios = new ArrayList<>();
+    private final List<Map<String, String>> sessionSecurityScenarios = new ArrayList<>();
+    private final List<Map<String, String>> transportScenarios = new ArrayList<>();
+    private final List<Map<String, String>> maliciousInputScenarios = new ArrayList<>();
+    private final List<Map<String, String>> confusedDeputyScenarios = new ArrayList<>();
+    private final List<Map<String, String>> tokenPassthroughScenarios = new ArrayList<>();
+    private final List<Map<String, String>> authFlowScenarios = new ArrayList<>();
+    private final List<Map<String, String>> redirectScenarios = new ArrayList<>();
+    private final List<Map<String, String>> disclosureScenarios = new ArrayList<>();
+    private final List<Map<String, String>> capabilityBoundaryScenarios = new ArrayList<>();
+    private final List<Map<String, String>> securityLoggingScenarios = new ArrayList<>();
+    private final List<Map<String, String>> securityFailsafeScenarios = new ArrayList<>();
+    private final List<Map<String, String>> complianceScenarios = new ArrayList<>();
+
+    @Given("security controls are enabled")
+    public void security_controls_are_enabled() {
+        securityControlsEnabled = true;
+    }
+
+    @Given("appropriate logging is configured")
+    public void appropriate_logging_is_configured() {
+        loggingConfigured = true;
+    }
+
+    @Given("an MCP server requiring authorization")
+    public void an_mcp_server_requiring_authorization() throws Exception {
+        McpClientConfiguration base = McpClientConfiguration.defaultConfiguration("client", "client", "default");
+        String java = System.getProperty("java.home") + "/bin/java";
+        String jar = Path.of("build", "libs", "mcp-0.1.0.jar").toString();
+        String cmd = java + " -jar " + jar + " server --stdio --test-mode";
+        McpClientConfiguration clientConfig = new McpClientConfiguration(
+                base.clientId(), base.serverName(), base.serverDisplayName(), base.serverVersion(),
+                base.principal(), base.clientCapabilities(), cmd, base.defaultReceiveTimeout(),
+                base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
+                base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
+                base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+        );
+        McpHostConfiguration hostConfig = new McpHostConfiguration(
+                "2025-06-18",
+                "2025-03-26",
+                "mcp-host",
+                "MCP Host",
+                "1.0.0",
+                Set.of(ClientCapability.SAMPLING, ClientCapability.ROOTS, ClientCapability.ELICITATION),
+                "default",
+                Duration.ofSeconds(2),
+                100,
+                100,
+                false,
+                List.of(clientConfig)
+        );
+        activeConnection = new McpHost(hostConfig);
+        activeConnection.grantConsent("server");
+        clientId = clientConfig.clientId();
+        activeConnection.connect(clientId);
+        // TODO enable authorization requirements
+    }
+
+    @When("I test authorization scenarios:")
+    public void i_test_authorization_scenarios(DataTable table) {
+        authorizationScenarios.clear();
+        authorizationScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute authorization scenarios
+    }
+
+    @Then("I should receive appropriate HTTP error responses")
+    public void i_should_receive_appropriate_http_error_responses() {
+        // TODO verify HTTP error responses
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("the WWW-Authenticate header should be included for 401 responses")
+    public void the_www_authenticate_header_should_be_included_for_401_responses() {
+        // TODO verify WWW-Authenticate headers
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with resource URI {string}")
+    public void an_mcp_server_with_resource_uri(String uri) {
+        resourceUri = uri;
+        // TODO configure server resource URI
+    }
+
+    @When("I test token audience validation with different scenarios:")
+    public void i_test_token_audience_validation_with_different_scenarios(DataTable table) {
+        tokenAudienceScenarios.clear();
+        tokenAudienceScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute token audience validation
+    }
+
+    @Then("the server should validate token audience correctly")
+    public void the_server_should_validate_token_audience_correctly() {
+        // TODO verify token audience validation
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("only accept tokens issued specifically for the server")
+    public void only_accept_tokens_issued_specifically_for_the_server() {
+        // TODO ensure only proper tokens accepted
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @When("I send JSON-RPC requests with authorization issues:")
+    public void i_send_json_rpc_requests_with_authorization_issues(DataTable table) {
+        jsonRpcErrorScenarios.clear();
+        jsonRpcErrorScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO send JSON-RPC requests with issues
+    }
+
+    @Then("I should receive proper JSON-RPC error responses")
+    public void i_should_receive_proper_json_rpc_error_responses() {
+        // TODO verify JSON-RPC errors
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("errors should not expose sensitive implementation details")
+    public void errors_should_not_expose_sensitive_implementation_details() {
+        // TODO ensure sensitive details are not exposed
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with resource access controls")
+    public void an_mcp_server_with_resource_access_controls() {
+        resourceAccessControls = true;
+    }
+
+    @Given("a principal with limited permissions")
+    public void a_principal_with_limited_permissions() {
+        limitedPrincipal = true;
+    }
+
+    @When("I attempt to access restricted resources:")
+    public void i_attempt_to_access_restricted_resources(DataTable table) {
+        accessControlScenarios.clear();
+        accessControlScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO attempt resource access
+    }
+
+    @Then("access should be denied with appropriate error responses")
+    public void access_should_be_denied_with_appropriate_error_responses() {
+        // TODO verify access denial
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("the server should log access control violations")
+    public void the_server_should_log_access_control_violations() {
+        // TODO verify access control logging
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with rate limiting configured")
+    public void an_mcp_server_with_rate_limiting_configured() {
+        rateLimitingConfigured = true;
+    }
+
+    @Given("rate limits of {int} requests per minute per principal")
+    public void rate_limits_of_requests_per_minute_per_principal(int limit) {
+        rateLimitPerMinute = limit;
+    }
+
+    @When("I test rate limiting scenarios:")
+    public void i_test_rate_limiting_scenarios(DataTable table) {
+        rateLimitingScenarios.clear();
+        rateLimitingScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute rate limiting scenarios
+    }
+
+    @Then("rate limits should be enforced appropriately")
+    public void rate_limits_should_be_enforced_appropriately() {
+        // TODO verify rate limit enforcement
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("violating requests should receive SecurityException errors")
+    public void violating_requests_should_receive_security_exception_errors() {
+        // TODO verify SecurityException errors
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("rate limiting should not affect legitimate users")
+    public void rate_limiting_should_not_affect_legitimate_users() {
+        // TODO ensure legitimate users unaffected
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with session management enabled")
+    public void an_mcp_server_with_session_management_enabled() {
+        sessionManagementEnabled = true;
+    }
+
+    @When("I test session security scenarios:")
+    public void i_test_session_security_scenarios(DataTable table) {
+        sessionSecurityScenarios.clear();
+        sessionSecurityScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute session security scenarios
+    }
+
+    @Then("the server should implement secure session management")
+    public void the_server_should_implement_secure_session_management() {
+        // TODO verify secure session management
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("sessions should not be used for authentication")
+    public void sessions_should_not_be_used_for_authentication() {
+        // TODO ensure sessions not used for authentication
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("session IDs should be cryptographically secure")
+    public void session_ids_should_be_cryptographically_secure() {
+        // TODO verify session ID security
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("I want to test transport security requirements")
+    public void i_want_to_test_transport_security_requirements() {
+        transportSecurityTesting = true;
+    }
+
+    @When("I attempt connections with different transport configurations:")
+    public void i_attempt_connections_with_different_transport_configurations(DataTable table) {
+        transportScenarios.clear();
+        transportScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO attempt connections with transport configs
+    }
+
+    @Then("only secure transports should be accepted")
+    public void only_secure_transports_should_be_accepted() {
+        // TODO verify transport security enforcement
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("appropriate transport security errors should be returned")
+    public void appropriate_transport_security_errors_should_be_returned() {
+        // TODO verify transport security errors
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with input validation enabled")
+    public void an_mcp_server_with_input_validation_enabled() {
+        inputValidationEnabled = true;
+    }
+
+    @When("I test malicious input scenarios:")
+    public void i_test_malicious_input_scenarios(DataTable table) {
+        maliciousInputScenarios.clear();
+        maliciousInputScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute input validation scenarios
+    }
+
+    @Then("all inputs should be validated and sanitized")
+    public void all_inputs_should_be_validated_and_sanitized() {
+        // TODO verify input validation and sanitization
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("dangerous payloads should be rejected")
+    public void dangerous_payloads_should_be_rejected() {
+        // TODO verify payload rejection
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("appropriate error messages should be returned")
+    public void appropriate_error_messages_should_be_returned() {
+        // TODO verify error messages
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP proxy server with static client ID")
+    public void an_mcp_proxy_server_with_static_client_id() {
+        proxyWithStaticClientId = true;
+    }
+
+    @Given("a third-party authorization server")
+    public void a_third_party_authorization_server() {
+        thirdPartyAuthServer = true;
+    }
+
+    @When("I test confused deputy attack scenarios:")
+    public void i_test_confused_deputy_attack_scenarios(DataTable table) {
+        confusedDeputyScenarios.clear();
+        confusedDeputyScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute confused deputy scenarios
+    }
+
+    @Then("the proxy server should obtain user consent for each client")
+    public void the_proxy_server_should_obtain_user_consent_for_each_client() {
+        // TODO verify per-client consent
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("implement proper PKCE validation")
+    public void implement_proper_pkce_validation() {
+        // TODO verify PKCE validation
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("prevent authorization code theft")
+    public void prevent_authorization_code_theft() {
+        // TODO ensure authorization code protection
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server that connects to upstream APIs")
+    public void an_mcp_server_that_connects_to_upstream_apis() {
+        upstreamApis = true;
+    }
+
+    @When("I test token passthrough scenarios:")
+    public void i_test_token_passthrough_scenarios(DataTable table) {
+        tokenPassthroughScenarios.clear();
+        tokenPassthroughScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute token passthrough scenarios
+    }
+
+    @Then("the server should never pass through client tokens")
+    public void the_server_should_never_pass_through_client_tokens() {
+        // TODO verify token passthrough prevention
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("always validate token audience before use")
+    public void always_validate_token_audience_before_use() {
+        // TODO verify token audience validation before use
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("use separate tokens for upstream API access")
+    public void use_separate_tokens_for_upstream_api_access() {
+        // TODO ensure separate tokens for upstream access
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an OAuth 2.1 authorization flow with PKCE")
+    public void an_oauth_21_authorization_flow_with_pkce() {
+        oauthFlowWithPkce = true;
+    }
+
+    @When("I test authentication security scenarios:")
+    public void i_test_authentication_security_scenarios(DataTable table) {
+        authFlowScenarios.clear();
+        authFlowScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute authentication security scenarios
+    }
+
+    @Then("PKCE validation should be enforced")
+    public void pkce_validation_should_be_enforced() {
+        // TODO verify PKCE enforcement
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("resource parameters should be required")
+    public void resource_parameters_should_be_required() {
+        // TODO verify resource parameter requirement
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("state parameters should prevent CSRF attacks")
+    public void state_parameters_should_prevent_csrf_attacks() {
+        // TODO verify state parameter CSRF protection
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP authorization server")
+    public void an_mcp_authorization_server() {
+        authorizationServer = true;
+    }
+
+    @When("I test redirect security scenarios:")
+    public void i_test_redirect_security_scenarios(DataTable table) {
+        redirectScenarios.clear();
+        redirectScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute redirect security scenarios
+    }
+
+    @Then("only registered redirect URIs should be accepted")
+    public void only_registered_redirect_uris_should_be_accepted() {
+        // TODO verify redirect URI registration
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("exact URI matching should be enforced")
+    public void exact_uri_matching_should_be_enforced() {
+        // TODO verify exact URI matching
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("malicious redirects should be prevented")
+    public void malicious_redirects_should_be_prevented() {
+        // TODO verify prevention of malicious redirects
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server handling sensitive information")
+    public void an_mcp_server_handling_sensitive_information() {
+        sensitiveInfoHandling = true;
+    }
+
+    @When("I test information disclosure scenarios:")
+    public void i_test_information_disclosure_scenarios(DataTable table) {
+        disclosureScenarios.clear();
+        disclosureScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute information disclosure scenarios
+    }
+
+    @Then("sensitive information should not be exposed in logs")
+    public void sensitive_information_should_not_be_exposed_in_logs() {
+        // TODO verify sensitive info not logged
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("error messages should be sanitized")
+    public void error_messages_should_be_sanitized() {
+        // TODO verify error message sanitization
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("implementation details should be protected")
+    public void implementation_details_should_be_protected() {
+        // TODO verify implementation detail protection
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("I have declared only specific client capabilities")
+    public void i_have_declared_only_specific_client_capabilities() {
+        // TODO declare specific client capabilities
+    }
+
+    @When("I test client capability security boundaries:")
+    public void i_test_client_capability_security_boundaries(DataTable table) {
+        capabilityBoundaryScenarios.clear();
+        capabilityBoundaryScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO execute capability boundary scenarios
+    }
+
+    @Then("the server should respect capability boundaries")
+    public void the_server_should_respect_capability_boundaries() {
+        // TODO verify capability boundaries respected
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("not attempt to use undeclared capabilities")
+    public void not_attempt_to_use_undeclared_capabilities() {
+        // TODO verify undeclared capabilities not used
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("maintain security isolation between capabilities")
+    public void maintain_security_isolation_between_capabilities() {
+        // TODO verify security isolation between capabilities
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with security monitoring enabled")
+    public void an_mcp_server_with_security_monitoring_enabled() {
+        securityMonitoringEnabled = true;
+    }
+
+    @When("security violations occur:")
+    public void security_violations_occur(DataTable table) {
+        securityLoggingScenarios.clear();
+        securityLoggingScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO log security violations
+    }
+
+    @Then("security events should be logged appropriately")
+    public void security_events_should_be_logged_appropriately() {
+        // TODO verify security event logging
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("sensitive information should be excluded from logs")
+    public void sensitive_information_should_be_excluded_from_logs() {
+        // TODO verify sensitive information exclusion
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("log levels should reflect severity correctly")
+    public void log_levels_should_reflect_severity_correctly() {
+        // TODO verify log level severity
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP server with security failsafe mechanisms")
+    public void an_mcp_server_with_security_failsafe_mechanisms() {
+        securityFailsafeMechanisms = true;
+    }
+
+    @When("security systems encounter errors:")
+    public void security_systems_encounter_errors(DataTable table) {
+        securityFailsafeScenarios.clear();
+        securityFailsafeScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO simulate security system errors
+    }
+
+    @Then("the system should fail securely")
+    public void the_system_should_fail_securely() {
+        // TODO verify secure failure behaviour
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("deny access when security cannot be verified")
+    public void deny_access_when_security_cannot_be_verified() {
+        // TODO verify access denial when security uncertain
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("provide clear error messages for legitimate users")
+    public void provide_clear_error_messages_for_legitimate_users() {
+        // TODO verify user-facing error messages
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Given("an MCP implementation claiming standards compliance")
+    public void an_mcp_implementation_claiming_standards_compliance() {
+        standardsComplianceClaimed = true;
+    }
+
+    @When("I validate security standards compliance:")
+    public void i_validate_security_standards_compliance(DataTable table) {
+        complianceScenarios.clear();
+        complianceScenarios.addAll(table.asMaps(String.class, String.class));
+        // TODO validate security standards compliance
+    }
+
+    @Then("all required security standards should be implemented")
+    public void all_required_security_standards_should_be_implemented() {
+        // TODO verify required standards
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("optional security enhancements should be documented")
+    public void optional_security_enhancements_should_be_documented() {
+        // TODO verify optional enhancements documentation
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @Then("compliance should be verifiable through testing")
+    public void compliance_should_be_verifiable_through_testing() {
+        // TODO verify compliance via testing
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @After
+    public void closeConnection() throws IOException {
+        if (activeConnection != null) {
+            activeConnection.close();
+            activeConnection = null;
+            clientId = null;
+        }
+        securityControlsEnabled = false;
+        loggingConfigured = false;
+        resourceUri = null;
+        resourceAccessControls = false;
+        limitedPrincipal = false;
+        rateLimitingConfigured = false;
+        rateLimitPerMinute = 0;
+        sessionManagementEnabled = false;
+        transportSecurityTesting = false;
+        inputValidationEnabled = false;
+        proxyWithStaticClientId = false;
+        thirdPartyAuthServer = false;
+        upstreamApis = false;
+        oauthFlowWithPkce = false;
+        authorizationServer = false;
+        sensitiveInfoHandling = false;
+        securityMonitoringEnabled = false;
+        securityFailsafeMechanisms = false;
+        standardsComplianceClaimed = false;
+
+        authorizationScenarios.clear();
+        tokenAudienceScenarios.clear();
+        jsonRpcErrorScenarios.clear();
+        accessControlScenarios.clear();
+        rateLimitingScenarios.clear();
+        sessionSecurityScenarios.clear();
+        transportScenarios.clear();
+        maliciousInputScenarios.clear();
+        confusedDeputyScenarios.clear();
+        tokenPassthroughScenarios.clear();
+        authFlowScenarios.clear();
+        redirectScenarios.clear();
+        disclosureScenarios.clear();
+        capabilityBoundaryScenarios.clear();
+        securityLoggingScenarios.clear();
+        securityFailsafeScenarios.clear();
+        complianceScenarios.clear();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Cucumber steps for security error handling scenarios

## Testing
- `gradle test --no-daemon --console=plain` *(fails: 116 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a23bffd2b08324b6c382199cbfcf36