### PR TITLE
Ensure provide step validates active connection

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
@@ -518,7 +518,7 @@ public final class ClientFeaturesSteps {
                             throw new AssertionError("missing expected behavior");
                         }
                     }
-                } else if (activeConnection == null) {
+                } else if (activeConnection == null || clientId == null) {
                     throw new AssertionError("no active connection");
                 }
             }


### PR DESCRIPTION
## Summary
- verify `provide`-related steps fail when no active connection exists

## Testing
- `gradle test` *(fails: UndefinedStepException in security error features)*

------
https://chatgpt.com/codex/tasks/task_e_68a2428c5f8483249bf51b42c1979334