### PR TITLE
Handle server error response assertions

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
@@ -815,7 +815,7 @@ public final class ServerFeaturesSteps {
         }
     }
 
-    @Then("I should receive appropriate JSON-RPC error responses")
+    @Then("^I should receive appropriate JSON-RPC error responses(?: for (?:each scenario|logging|completion))?$")
     public void i_should_receive_appropriate_json_rpc_error_responses() {
         if (currentErrorScenarios.isEmpty()) {
             throw new AssertionError("no error scenarios");


### PR DESCRIPTION
## Summary
- accept more variants of error-response step wording in server feature tests

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68a25c02daf883248641cde8d377d929