### PR TITLE
Verify WWW-Authenticate header value

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/SecurityErrorsSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/SecurityErrorsSteps.java
@@ -120,11 +120,17 @@ public final class SecurityErrorsSteps {
 
     @Then("the WWW-Authenticate header should be included for 401 responses")
     public void the_www_authenticate_header_should_be_included_for_401_responses() {
+        String expected = "Bearer resource=\"https://mcp.example.com/.well-known/oauth-protected-resource\"";
         for (Map<String, String> row : authorizationScenarios) {
             int status = Integer.parseInt(row.get("expected_status"));
             String header = row.get("www_authenticate_header");
-            if (status == 401 && (header == null || header.isBlank())) {
-                throw new AssertionError("missing WWW-Authenticate header");
+            if (status == 401) {
+                if (header == null || header.isBlank()) {
+                    throw new AssertionError("missing WWW-Authenticate header");
+                }
+                if (!expected.equals(header.trim())) {
+                    throw new AssertionError("unexpected WWW-Authenticate header: " + header);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure authorization tests validate full WWW-Authenticate header

## Testing
- `gradle --console=plain test --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_68a261f202d88324a8214863164bf3a9