### PR TITLE
test: cover logging level filtering

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/test/02_server_features.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/02_server_features.feature
@@ -261,6 +261,11 @@ Feature: MCP Server Features
     # Tests specification/2025-06-18/server/utilities/logging.mdx:49-64 (Setting log level)
     Given the server has logging capability enabled
     When I send a "logging/setLevel" request with level "info"
+    And the server generates log messages at levels:
+      | level |
+      | debug |
+      | info  |
+      | error |
     Then the server should accept the log level configuration
     And only messages at "info" level and above should be sent
 


### PR DESCRIPTION
## Summary
- ensure log level configuration test generates messages to verify filtering
- track current log level in test steps and ignore low-severity messages

## Testing
- `gradle --console=plain check` *(fails: Authorization header validation)*

------
https://chatgpt.com/codex/tasks/task_e_68a26625fc048324a3184d9dab2d84f5