### PR TITLE
test: add duplicate request id scenario

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -404,6 +404,13 @@ public final class ProtocolLifecycleSteps {
         }
     }
 
+    @Then("I should receive a duplicate identifier error")
+    public void i_should_receive_a_duplicate_identifier_error() {
+        if (lastErrorCode != -32600 || lastErrorMessage == null || !lastErrorMessage.toLowerCase().contains("duplicate")) {
+            throw new AssertionError("expected duplicate request id error");
+        }
+    }
+
     @When("the server responds")
     public void the_server_responds() {
         lastResponse = createResponse(lastRequestId, Json.createObjectBuilder().build());

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -79,6 +79,14 @@ Feature: MCP Connection Lifecycle
     Then the request should use proper message format
     And the request should have a unique identifier
 
+  @messaging @duplicate-id
+  Scenario: Duplicate request identifier rejection
+    # Tests specification/2025-06-18/basic/index.mdx:48-51 (Request ID requirements)
+    Given I have an established MCP connection
+    When I send a request with identifier "dup-123"
+    And I send a request with identifier "dup-123"
+    Then I should receive a duplicate identifier error
+
   @messaging
   Scenario: Response message validation
     # Tests specification/2025-06-18/basic/index.mdx:54-79 (Response format)


### PR DESCRIPTION
## Summary
- expand lifecycle feature coverage for duplicate request identifiers
- add step for duplicate identifier error expectation

## Testing
- `gradle --no-daemon --console=plain test` *(fails: Duplicate request identifier rejection)*

------
https://chatgpt.com/codex/tasks/task_e_68a2668f57808324865d4adb6b6b6c13