### PR TITLE
Reject non-integer progress token values

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ProgressToken.java
+++ b/src/main/java/com/amannmalik/mcp/api/ProgressToken.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.api;
 
 import com.amannmalik.mcp.util.ValidationUtil;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 
@@ -17,7 +18,13 @@ public sealed interface ProgressToken permits
         JsonValue val = meta.get("progressToken");
         ProgressToken token = switch (val.getValueType()) {
             case STRING -> new ProgressToken.StringToken(ValidationUtil.requireClean(meta.getString("progressToken")));
-            case NUMBER -> new ProgressToken.NumericToken(meta.getJsonNumber("progressToken").longValue());
+            case NUMBER -> {
+                JsonNumber num = meta.getJsonNumber("progressToken");
+                if (!num.isIntegral()) {
+                    throw new IllegalArgumentException("progressToken must be an integer");
+                }
+                yield new ProgressToken.NumericToken(num.longValue());
+            }
             default -> throw new IllegalArgumentException("progressToken must be a string or number");
         };
         return Optional.of(token);

--- a/src/main/java/com/amannmalik/mcp/codec/ProgressNotificationJsonCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/ProgressNotificationJsonCodec.java
@@ -23,7 +23,13 @@ public class ProgressNotificationJsonCodec implements JsonCodec<ProgressNotifica
     public ProgressNotification fromJson(JsonObject obj) {
         ProgressToken token = switch (obj.get("progressToken").getValueType()) {
             case STRING -> new ProgressToken.StringToken(ValidationUtil.requireClean(obj.getString("progressToken")));
-            case NUMBER -> new ProgressToken.NumericToken(obj.getJsonNumber("progressToken").longValue());
+            case NUMBER -> {
+                JsonNumber num = obj.getJsonNumber("progressToken");
+                if (!num.isIntegral()) {
+                    throw new IllegalArgumentException("progressToken must be an integer");
+                }
+                yield new ProgressToken.NumericToken(num.longValue());
+            }
             default -> throw new IllegalArgumentException("progressToken must be string or number");
         };
         double progress = obj.getJsonNumber("progress").doubleValue();


### PR DESCRIPTION
## Summary
- validate numeric progress tokens are integral
- reject non-integer progress tokens in notifications and metadata

## Testing
- `gradle test` *(fails: Resource unsubscription)*

------
https://chatgpt.com/codex/tasks/task_e_68a2766676188324a963cbd5e6b75a4b