### PR TITLE
test: add protocol version header scenario

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -800,4 +800,11 @@ public final class ProtocolLifecycleSteps {
         String versionString = String.join(",", versions);
         the_server_supports_versions(versionString);
     }
+
+    @Then("the connection should be rejected due to missing protocol version header")
+    public void the_connection_should_be_rejected_due_to_missing_protocol_version_header() {
+        if (lastErrorCode == 0) {
+            throw new AssertionError("missing protocol version header not rejected");
+        }
+    }
 }

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -41,10 +41,18 @@ Feature: MCP Connection Lifecycle
     Given the server supports the following versions:
       | version    |
       | 2024-11-05 |
-      | 2025-06-18 | 
+      | 2025-06-18 |
     When I request connection with unsupported version "1.0.0"
     Then the server should offer its latest supported version
     And I should be able to decide whether to proceed
+
+  @connection @http @version-header
+  Scenario: Missing protocol version header on HTTP request
+    # Tests specification/2025-06-18/basic/lifecycle.mdx:140-144 (Protocol version header requirement)
+    # Tests specification/2025-06-18/basic/transports.mdx:244-259 (Protocol version header enforcement)
+    Given I have an established MCP connection using "http" transport
+    When I send a request with identifier "missing-header"
+    Then the connection should be rejected due to missing protocol version header
 
   @capabilities
   Scenario: Server capability discovery


### PR DESCRIPTION
Adds a conformance scenario for missing `MCP-Protocol-Version` headers on HTTP requests and a corresponding step assertion. The new test exposes missing enforcement for the protocol version header (and incomplete HTTP transport support), currently causing the suite to fail.

------
https://chatgpt.com/codex/tasks/task_e_68a278694d248324bc3facf4c3c36dda