### PR TITLE
fix resource subscription existence check

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
+++ b/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
@@ -169,7 +169,11 @@ final class ResourceOrchestrator implements AutoCloseable {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         }
         String uri = sr.uri();
-        return withExistingResource(req, uri, block -> {
+        return withAccessibleUri(req, uri, () -> {
+            if (resources.get(uri).isEmpty()) {
+                return JsonRpcError.of(req.id(), -32002, "Resource not found",
+                        Json.createObjectBuilder().add("uri", uri).build());
+            }
             if (subscriptions.containsKey(uri)) {
                 return JsonRpcError.of(req.id(), -32602, "Already subscribed to resource",
                         Json.createObjectBuilder().add("uri", uri).build());


### PR DESCRIPTION
## Summary
- allow resource subscription without requiring resource content to exist

## Testing
- `gradle test` *(fails: Resource unsubscription, Progress token type requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68a276a862748324be858be508042a03