### PR TITLE
Standardize invalid resource error response

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
+++ b/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
@@ -128,7 +128,7 @@ final class ResourceOrchestrator implements AutoCloseable {
         try {
             rrr = ((JsonCodec<ReadResourceRequest>) new ReadResourceRequestAbstractEntityCodec()).fromJson(req.params());
         } catch (IllegalArgumentException e) {
-            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
         }
         return withExistingResource(req, rrr.uri(), block -> {
             ReadResourceResult result = new ReadResourceResult(List.of(block), null);


### PR DESCRIPTION
## Summary
- use generic JSON-RPC message for invalid resource params

## Testing
- `gradle test` *(fails: Missing protocol version header on HTTP request)*

------
https://chatgpt.com/codex/tasks/task_e_68a27cfabc48832487985c96c8cbc101