### PR TITLE
test: verify ping rejects meta param

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -25,6 +25,7 @@ public final class UtilitiesSteps {
 
     private String lastPingId;
     private String lastPingResponseId;
+    private JsonRpcMessage lastPingResponse;
     private boolean monitoring;
     private boolean pingTimedOut;
     private boolean connectionStale;
@@ -254,6 +255,7 @@ public final class UtilitiesSteps {
     public void i_want_to_verify_connection_health() {
         lastPingId = null;
         lastPingResponseId = null;
+        lastPingResponse = null;
         monitoring = false;
         pingFrequencyConfigured = false;
         pingTimeoutHandlingConfigured = false;
@@ -262,16 +264,30 @@ public final class UtilitiesSteps {
     }
 
     @When("I send a ping request with ID {string}")
-    public void i_send_a_ping_request_with_id(String id) {
+    public void i_send_a_ping_request_with_id(String id) throws Exception {
         lastPingId = id;
-        lastPingResponseId = id; // simulate immediate echo
+        lastPingResponse = activeConnection.request(
+                clientId,
+                new RequestId.StringId(id),
+                RequestMethod.PING,
+                null
+        );
+        var m = java.util.regex.Pattern.compile("id=([^,]+)")
+                .matcher(lastPingResponse.toString());
+        lastPingResponseId = m.find() ? m.group(1) : null;
     }
 
     @When("I send a ping request with parameters:")
     public void i_send_a_ping_request_with_parameters(DataTable table) throws Exception {
         JsonObjectBuilder b = Json.createObjectBuilder();
         for (Map<String, String> row : table.asMaps()) {
-            b.add(row.get("field"), row.get("value"));
+            String field = row.get("field");
+            String value = row.get("value");
+            try (JsonReader r = Json.createReader(new StringReader(value))) {
+                b.add(field, r.readValue());
+            } catch (Exception ex) {
+                b.add(field, value);
+            }
         }
         JsonRpcMessage msg = activeConnection.request(clientId, RequestMethod.PING, b.build());
         String repr = msg.toString();
@@ -287,7 +303,10 @@ public final class UtilitiesSteps {
 
     @Then("the receiver should respond promptly with an empty result")
     public void the_receiver_should_respond_promptly_with_an_empty_result() {
-        if (lastPingResponseId == null) throw new AssertionError("no ping response");
+        if (lastPingResponse == null) throw new AssertionError("no ping response");
+        if (!lastPingResponse.toString().contains("result={}")) {
+            throw new AssertionError("ping result not empty");
+        }
     }
 
     @Then("the response should have the same ID {string}")
@@ -297,7 +316,9 @@ public final class UtilitiesSteps {
 
     @Then("the response format should be valid JSON-RPC")
     public void the_response_format_should_be_valid_json_rpc() {
-        if (lastPingResponseId == null) throw new AssertionError("invalid response");
+        if (lastPingResponse == null || !lastPingResponse.toString().startsWith("JsonRpcResponse")) {
+            throw new AssertionError("invalid response");
+        }
     }
 
     @Then("the error message should be {string}")

--- a/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
@@ -108,6 +108,17 @@ Feature: MCP Protocol Utilities
     Then the error message should be "Invalid params"
     And the error code should be -32602
 
+  @ping @meta-parameter
+  Scenario: Ping request with reserved meta parameter
+    # Tests specification/2025-06-18/basic/utilities/ping.mdx:17-27 (Message format)
+    Given I have an established MCP connection for utilities
+    And I want to verify connection health
+    When I send a ping request with parameters:
+      | field | value |
+      | _meta | {}    |
+    Then the error message should be "Invalid params"
+    And the error code should be -32602
+
   @progress @token-tracking
   Scenario: Progress tracking with progress tokens
     # Tests specification/2025-06-18/basic/utilities/progress.mdx:14-33 (Progress flow)


### PR DESCRIPTION
Adds scenario ensuring ping requests with `_meta` are rejected and tightens ping step validations.

------
https://chatgpt.com/codex/tasks/task_e_68a2b611f76c8324a0345d1b74612cd3