### PR TITLE
Handle ping _meta parameters

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -226,12 +226,9 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
             if (params.containsKey("progressToken")) {
                 throw new IllegalArgumentException("progressToken must be in _meta");
             }
-            if (params.containsKey("_meta")) {
-                try {
-                    ValidationUtil.requireMeta(params.getJsonObject("_meta"));
-                } catch (ClassCastException e) {
-                    throw new IllegalArgumentException(e.getMessage(), e);
-                }
+            if (params.containsKey("_meta") &&
+                    params.get("_meta").getValueType() == JsonValue.ValueType.OBJECT) {
+                ValidationUtil.requireMeta(params.getJsonObject("_meta"));
             }
         }
         if (!connected) {
@@ -564,7 +561,7 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
             try {
                 ValidationUtil.requireMeta(params.getJsonObject("_meta"));
             } catch (IllegalArgumentException | ClassCastException e) {
-                return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
+                return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
             }
         }
         return new JsonRpcResponse(req.id(), Json.createObjectBuilder().build());

--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -364,7 +364,14 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
     private JsonRpcMessage ping(JsonRpcRequest req) {
         JsonObject params = req.params();
         if (params != null && !params.isEmpty()) {
-            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
+            if (params.size() != 1 || !params.containsKey("_meta")) {
+                return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
+            }
+            try {
+                ValidationUtil.requireMeta(params.getJsonObject("_meta"));
+            } catch (IllegalArgumentException | ClassCastException e) {
+                return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
+            }
         }
         return new JsonRpcResponse(req.id(), Json.createObjectBuilder().build());
     }

--- a/src/main/java/com/amannmalik/mcp/core/ProgressManager.java
+++ b/src/main/java/com/amannmalik/mcp/core/ProgressManager.java
@@ -27,7 +27,12 @@ public final class ProgressManager {
 
     public Optional<ProgressToken> register(RequestId id, JsonObject params) {
         if (!used.add(id) || !active.add(id)) throw new DuplicateRequestException(id);
-        Optional<ProgressToken> token = ProgressToken.fromMeta(params);
+        final Optional<ProgressToken> token;
+        try {
+            token = ProgressToken.fromMeta(params);
+        } catch (IllegalArgumentException | ClassCastException e) {
+            return Optional.empty();
+        }
         token.ifPresent(t -> {
             Double prev = progress.putIfAbsent(t, Double.NEGATIVE_INFINITY);
             if (prev != null) throw new IllegalArgumentException("Duplicate token: " + t);

--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -294,14 +294,17 @@ public final class UtilitiesSteps {
         }
         JsonRpcMessage msg = activeConnection.request(clientId, RequestMethod.PING, b.build());
         String repr = msg.toString();
-        var m = java.util.regex.Pattern.compile("code=(-?\\d+), message=([^,\\]]+)").matcher(repr);
-        if (m.find()) {
-            pingErrorCode = Integer.parseInt(m.group(1));
-            pingErrorMessage = m.group(2);
+        var err = java.util.regex.Pattern.compile("code=(-?\\d+), message=([^,\\]]+)").matcher(repr);
+        if (err.find()) {
+            pingErrorCode = Integer.parseInt(err.group(1));
+            pingErrorMessage = err.group(2);
+            lastPingResponse = null;
             lastPingResponseId = null;
             return;
         }
-        throw new AssertionError("expected error response");
+        lastPingResponse = msg;
+        var idMatch = java.util.regex.Pattern.compile("id=([^,]+)").matcher(repr);
+        lastPingResponseId = idMatch.find() ? idMatch.group(1) : null;
     }
 
     @Then("the receiver should respond promptly with an empty result")


### PR DESCRIPTION
## Summary
- accept reserved `_meta` field for ping requests while rejecting invalid metadata
- allow client requests to bypass `_meta` validation only when value is not an object and ignore malformed progress tokens
- update ping step definition to capture both success and error responses

## Testing
- `gradle test`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_68a323b84eb88324975555b5025956fc