### PR TITLE
test: check HTTP response Content-Type

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -70,6 +70,18 @@ Feature: MCP Connection Lifecycle
       | GET    | text/event-stream                   | true          |
     Then each request should be handled according to Accept header requirements
 
+  @connection @http @content-type
+  Scenario: HTTP response Content-Type enforcement
+    # Tests specification/2025-06-18/basic/transports.mdx:100-101 (POST response Content-Type)
+    Given an MCP server using "http" transport
+    When I validate server HTTP POST responses with the following Content-Types:
+      | content_type      | should_accept |
+      | application/json  | true          |
+      | text/event-stream | true          |
+      | text/plain        | false         |
+      | none              | false         |
+    Then each response should be handled according to Content-Type requirements
+
   @connection @http @session
   Scenario: HTTP session ID requirement
     # Tests specification/2025-06-18/basic/transports.mdx:177-205 (Session management)


### PR DESCRIPTION
## Summary
- test HTTP POST responses return permitted Content-Types
- add step definitions for Content-Type validation

## Testing
- `./verify.sh` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68a324a081ec8324a0364a270d8c7c41