### PR TITLE
Handle ping request parameters

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
@@ -118,6 +118,16 @@ Feature: MCP Protocol Utilities
       | _meta | {}    |
     Then the receiver should respond promptly with an empty result
 
+  @ping @meta-type
+  Scenario: Ping request with non-object meta parameter
+    # Tests specification/2025-06-18/basic/utilities/ping.mdx:17-27 (Message format)
+    Given I have an established MCP connection for utilities
+    And I want to verify connection health
+    When I send a ping request with parameters:
+      | field | value |
+      | _meta | 1    |
+    Then the error code should be -32602
+
   @ping @meta-validation
   Scenario: Ping request with invalid meta parameter
     # Tests specification/2025-06-18/basic/utilities/ping.mdx:17-27 (Message format)


### PR DESCRIPTION
## Summary
- Handle both success and error paths when sending ping requests with parameters
- Add scenario ensuring ping rejects non-object _meta parameters

## Testing
- `gradle test` *(incomplete: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a324a081ec8324a0364a270d8c7c41