### PR TITLE
test: verify origin header validation

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -70,6 +70,18 @@ Feature: MCP Connection Lifecycle
       | GET    | text/event-stream                   | true          |
     Then each request should be handled according to Accept header requirements
 
+@connection @http @origin-header
+  Scenario: HTTP Origin header validation
+    # Tests specification/2025-06-18/basic/transports.mdx:76-80 (Origin header validation)
+    Given an MCP server using "http" transport
+    When I send HTTP requests with the following Origin headers:
+      | origin_header    | should_accept |
+      | none             | false         |
+      | http://localhost | true          |
+      | http://evil.com   | false         |
+      | http://LOCALHOST | true          |
+    Then each request should be handled according to Origin header requirements
+
   @connection @http @content-type
   Scenario: HTTP response Content-Type enforcement
     # Tests specification/2025-06-18/basic/transports.mdx:100-101 (POST response Content-Type)


### PR DESCRIPTION
## Summary
- add conformance scenario for HTTP Origin header enforcement
- exercise origin validation logic in protocol lifecycle steps

## Testing
- `./verify.sh` *(fails: origin header case sensitivity)*

------
https://chatgpt.com/codex/tasks/task_e_68a32cbac49883249e7a718f5f8d919b