### PR TITLE
Add uppercase audience token validation scenario

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/test/05_security_errors.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/05_security_errors.feature
@@ -54,6 +54,7 @@ Feature: MCP Security Error Handling
       | multiple_wrong_audiences   | https://other1.com,other2   | 401             | Unauthorized   |
       | partially_correct_audience | https://mcp.example.com,bad | 200             | none           |
       | correct_audience           | https://mcp.example.com     | 200             | none           |
+      | uppercase_audience         | https://MCP.EXAMPLE.COM     | 200             | none           |
     Then the server should validate token audience correctly
     And only accept tokens issued specifically for the server
 


### PR DESCRIPTION
## Summary
- add test case ensuring tokens with uppercase audience are accepted

## Testing
- `gradle test` *(fails: 151 tests completed, 57 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a32f600f608324b723324fbe7bca3d