### PR TITLE
test: add SSE resumption coverage

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -11,6 +11,15 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.net.URI;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import com.sun.net.httpserver.HttpServer;
 import java.util.stream.Collectors;
 
 public final class ProtocolLifecycleSteps {
@@ -61,6 +70,7 @@ public final class ProtocolLifecycleSteps {
     // New step definitions for message ordering guarantees
     private final List<Map<String, String>> dependentRequests = new ArrayList<>();
     private final Map<String, JsonObject> requestResponses = new HashMap<>();
+    private String lastEventIdHeader;
 
     private Set<ClientCapability> parseClientCapabilities(String capabilities) {
         if (capabilities == null || capabilities.trim().isEmpty()) {
@@ -194,6 +204,7 @@ public final class ProtocolLifecycleSteps {
         }
         currentConfiguration = null;
         promptExposed = false;
+        lastEventIdHeader = null;
     }
 
     @Given("a transport mechanism is available")
@@ -1170,6 +1181,54 @@ public final class ProtocolLifecycleSteps {
         // Implementation would check that dependencies are properly managed
         if (dependentRequests.isEmpty()) {
             throw new AssertionError("No dependent requests were configured for timing test");
+        }
+    }
+
+    @When("I attempt to resume an SSE stream after disconnection")
+    public void i_attempt_to_resume_an_sse_stream_after_disconnection() throws Exception {
+        var server = HttpServer.create(new InetSocketAddress(0), 0);
+        var requests = new AtomicInteger();
+        server.createContext("/mcp", exchange -> {
+            if (!"GET".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            int count = requests.incrementAndGet();
+            if (count == 1) {
+                exchange.getResponseHeaders().add("Content-Type", "text/event-stream");
+                exchange.sendResponseHeaders(200, 0);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write("id: 42\n".getBytes(StandardCharsets.UTF_8));
+                    os.write("data: {}\n\n".getBytes(StandardCharsets.UTF_8));
+                }
+            } else {
+                lastEventIdHeader = exchange.getRequestHeaders().getFirst("Last-Event-ID");
+                exchange.sendResponseHeaders(200, -1);
+            }
+        });
+        server.start();
+        try {
+            URI endpoint = URI.create("http://localhost:" + server.getAddress().getPort() + "/mcp");
+            var client = HttpClient.newHttpClient();
+            var first = HttpRequest.newBuilder(endpoint)
+                    .header("Accept", "text/event-stream")
+                    .GET()
+                    .build();
+            client.send(first, HttpResponse.BodyHandlers.discarding());
+            var second = HttpRequest.newBuilder(endpoint)
+                    .header("Accept", "text/event-stream")
+                    .GET()
+                    .build();
+            client.send(second, HttpResponse.BodyHandlers.discarding());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Then("the Last-Event-ID header should be {string}")
+    public void the_last_event_id_header_should_be(String expected) {
+        if (!Objects.equals(expected, lastEventIdHeader)) {
+            throw new AssertionError("Expected Last-Event-ID " + expected + " but was " + lastEventIdHeader);
         }
     }
 }

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -6,5 +6,7 @@ open module mcp.test {
     requires org.junit.platform.suite.api;
     requires org.junit.jupiter.api;
     requires jakarta.json;
+    requires jdk.httpserver;
+    requires java.net.http;
 
 }

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -96,6 +96,12 @@ Feature: MCP Connection Lifecycle
     Then the server should respond with HTTP 404 Not Found
     And I should start a new session by reinitializing
 
+  @connection @http @sse @resumption
+  Scenario: SSE stream resumption with Last-Event-ID header
+    # Tests specification/2025-06-18/basic/transports.mdx:151-167 (Resumability and redelivery)
+    When I attempt to resume an SSE stream after disconnection
+    Then the Last-Event-ID header should be "42"
+
   @capabilities
   Scenario: Server capability discovery
     # Tests specification/2025-06-18/basic/lifecycle.mdx:146-171 (Capability negotiation)


### PR DESCRIPTION
## Summary
- add scenario for SSE stream resumption and Last-Event-ID header
- cover resumability section of transports spec

## Testing
- `gradle test` *(fails: expected Last-Event-ID 42 but was null)*

------
https://chatgpt.com/codex/tasks/task_e_68a32f600f608324b723324fbe7bca3d