### PR TITLE
Add non-string cursor pagination test

### DIFF
--- a/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
@@ -275,6 +275,7 @@ Feature: MCP Protocol Utilities
       | expired_cursor   | -32602     | Invalid params |
       | malformed_cursor | -32602     | Invalid params |
       | unknown_cursor   | -32602     | Invalid params |
+      | non_string_cursor | -32602    | Invalid params |
     Then I should return appropriate error responses for utilities
     And use JSON-RPC error code -32602 for invalid parameters
 


### PR DESCRIPTION
## Summary
- test pagination errors by exercising server with invalid cursor types
- cover non-string cursor case

## Testing
- `./verify.sh` *(fails: There were failing tests. See the report at: file:///workspace/mcp/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a33385def483249c1a2e4703297961