### PR TITLE
Handle token audience case-insensitively

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
@@ -98,11 +98,11 @@ public final class JwtTokenValidator implements TokenValidator {
 
     private boolean mismatch(JsonValue val) {
         return switch (val.getValueType()) {
-            case STRING -> !expectedAudience.equals(((JsonString) val).getString());
+            case STRING -> !expectedAudience.equalsIgnoreCase(((JsonString) val).getString());
             case ARRAY -> val.asJsonArray()
                     .getValuesAs(JsonString.class)
                     .stream()
-                    .noneMatch(js -> expectedAudience.equals(js.getString()));
+                    .noneMatch(js -> expectedAudience.equalsIgnoreCase(js.getString()));
             default -> true;
         };
     }


### PR DESCRIPTION
## Summary
- accept audience values regardless of case when validating JWT access tokens

## Testing
- `gradle test` *(fails: HTTP Accept header case insensitivity)*

------
https://chatgpt.com/codex/tasks/task_e_68a338a78d688324a5189373b58e1523