### PR TITLE
Handle case-insensitive HTTP Accept headers

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -447,7 +447,7 @@ public final class ProtocolLifecycleSteps {
         var types = (header == null || header.isBlank() || "none".equalsIgnoreCase(header))
                 ? Set.<String>of()
                 : Arrays.stream(header.split(","))
-                .map(String::trim)
+                .map(s -> s.trim().toLowerCase(Locale.ROOT))
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toSet());
         return switch (method) {


### PR DESCRIPTION
## Summary
- normalize HTTP Accept headers in protocol lifecycle tests to lower case to align with spec

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a3387b8ee88324bfeab4741d7999ef