### PR TITLE
test: cover fractional request id

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -637,6 +637,23 @@ public final class ProtocolLifecycleSteps {
         i_send_a_request_with_identifier(Long.toString(id));
     }
 
+    @When("I send a request with fractional identifier {double}")
+    public void i_send_a_request_with_fractional_identifier(double id) {
+        lastRequest = Json.createObjectBuilder()
+                .add("jsonrpc", "2.0")
+                .add("id", id)
+                .add("method", RequestMethod.PING.method())
+                .build();
+        try {
+            RequestId.from(Json.createValue(id));
+            lastErrorCode = 0;
+            lastErrorMessage = null;
+        } catch (RuntimeException e) {
+            lastErrorCode = -32600;
+            lastErrorMessage = e.getMessage();
+        }
+    }
+
     @Then("the request should use proper message format")
     public void the_request_should_use_proper_message_format() {
         if (lastRequest == null || !"2.0".equals(lastRequest.getString("jsonrpc", null))

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -174,6 +174,14 @@ Scenario: HTTP Accept header case insensitivity
     When I send a request with identifier null
     Then I should receive an invalid identifier error
 
+  @messaging @invalid-id
+  Scenario: Fractional request identifier rejection
+    # Tests specification/2025-06-18/basic/index.mdx:33-52 (Request format)
+    # Tests specification/2025-06-18/basic/index.mdx:48-51 (Request ID requirements)
+    Given I have an established MCP connection
+    When I send a request with fractional identifier 3.14
+    Then I should receive an invalid identifier error
+
   @messaging @duplicate-id
   Scenario: Duplicate request identifier rejection
     # Tests specification/2025-06-18/basic/index.mdx:48-51 (Request ID requirements)


### PR DESCRIPTION
## Summary
- test fractional request identifiers

## Testing
- `./verify.sh` *(fails: 160 tests completed, 18 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a33c556b788324bb78db00dee6ceab