### PR TITLE
test: validate progress exceeds total

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -55,6 +55,7 @@ public final class UtilitiesSteps {
     private boolean rateLimitingImplemented;
     private boolean activeTokensTracked;
     private boolean notificationsStoppedAfterCompletion;
+    private boolean progressNotificationRejected;
     private JsonObject misplacedProgressParams;
     private int progressTokenErrorCode;
     private String progressTokenErrorMessage;
@@ -556,6 +557,25 @@ public final class UtilitiesSteps {
     @Then("message field should be optional")
     public void message_field_should_be_optional() {
         if (!messageSeen || !missingMessageSeen) throw new AssertionError("message field not optional");
+    }
+
+    @Given("I am validating progress notification totals")
+    public void i_am_validating_progress_notification_totals() {
+        progressNotificationRejected = false;
+    }
+
+    @When("I create a progress notification with progress {double} and total {double}")
+    public void i_create_a_progress_notification_with_progress_and_total(double progress, double total) {
+        try {
+            new ProgressNotification(new ProgressToken.StringToken("token"), progress, total, null);
+        } catch (IllegalArgumentException ex) {
+            progressNotificationRejected = true;
+        }
+    }
+
+    @Then("the progress notification should be rejected")
+    public void the_progress_notification_should_be_rejected() {
+        if (!progressNotificationRejected) throw new AssertionError("progress notification accepted");
     }
 
     @Given("I have requests with and without progress tokens")

--- a/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
@@ -181,6 +181,13 @@ Feature: MCP Protocol Utilities
     And total value should be optional
     And message field should be optional
 
+  @progress @validation
+  Scenario: Progress value exceeding total is rejected
+    # Tests specification/2025-06-18/basic/utilities/progress.mdx:35-53 (Notification format)
+    Given I am validating progress notification totals
+    When I create a progress notification with progress 150 and total 100
+    Then the progress notification should be rejected
+
   @progress @behavior-requirements
   Scenario: Progress notification behavior requirements
     # Tests specification/2025-06-18/basic/utilities/progress.mdx:60-71 (Behavior requirements)


### PR DESCRIPTION
## Summary
- add progress notification validation scenario
- ensure progress values above totals are rejected

## Testing
- `gradle test -Dcucumber.filter.tags='@progress and @validation'`


------
https://chatgpt.com/codex/tasks/task_e_68a33d79ab288324b476efbcb7ea2e66