### PR TITLE
Normalize token audience comparison

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
+++ b/src/main/java/com/amannmalik/mcp/auth/JwtTokenValidator.java
@@ -98,11 +98,11 @@ public final class JwtTokenValidator implements TokenValidator {
 
     private boolean mismatch(JsonValue val) {
         return switch (val.getValueType()) {
-            case STRING -> !expectedAudience.equals(((JsonString) val).getString());
+            case STRING -> !expectedAudience.equalsIgnoreCase(((JsonString) val).getString());
             case ARRAY -> val.asJsonArray()
                     .getValuesAs(JsonString.class)
                     .stream()
-                    .noneMatch(js -> expectedAudience.equals(js.getString()));
+                    .noneMatch(js -> expectedAudience.equalsIgnoreCase(js.getString()));
             default -> true;
         };
     }

--- a/src/test/java/com/amannmalik/mcp/test/SecurityErrorsSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/SecurityErrorsSteps.java
@@ -211,7 +211,7 @@ public final class SecurityErrorsSteps {
             String aud = row.get("token_audience");
             boolean matches = aud != null && Arrays.stream(aud.split(","))
                     .map(String::trim)
-                    .anyMatch(a -> a.equals(resourceUri));
+                    .anyMatch(a -> a.equalsIgnoreCase(resourceUri));
             int status = Integer.parseInt(row.get("expected_status"));
             String error = row.get("expected_error");
             if (matches) {


### PR DESCRIPTION
## Summary
- ensure JWT audience comparisons ignore case
- adjust token audience validation test to expect case-insensitive match

## Testing
- `gradle --no-daemon --console=plain test --tests "*Token audience validation errors"` *(fails: Ping request with empty parameters, Ping interval must be positive, Progress token type requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68a33cce6b38832497c36927926e488e