### PR TITLE
Reject fractional request identifiers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/api/RequestId.java
@@ -34,7 +34,11 @@ public sealed interface RequestId permits
         }
         return switch (value.getValueType()) {
             case STRING -> new StringId(((JsonString) value).getString());
-            case NUMBER -> new NumericId(((JsonNumber) value).longValue());
+            case NUMBER -> {
+                JsonNumber num = (JsonNumber) value;
+                if (!num.isIntegral()) throw new IllegalArgumentException("id must be an integer");
+                yield new NumericId(num.longValue());
+            }
             default -> throw new IllegalArgumentException("Invalid id type");
         };
     }


### PR DESCRIPTION
## Summary
- ensure RequestId.from rejects fractional numeric identifiers

## Testing
- `./verify.sh` *(fails: Token audience validation errors, PrincipalPermissions SecurityException)*

------
https://chatgpt.com/codex/tasks/task_e_68a33f41a10c8324af3f14137b025d07