### PR TITLE
Return correct errors for resource reads

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
+++ b/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
@@ -12,6 +12,7 @@ import com.amannmalik.mcp.util.*;
 import jakarta.json.*;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -242,21 +243,33 @@ final class ResourceOrchestrator implements AutoCloseable {
     }
 
     private JsonRpcMessage withAccessibleUri(JsonRpcRequest req, String uri, Supplier<JsonRpcMessage> action) {
+        try {
+            URI.create(uri);
+        } catch (Exception e) {
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
+        }
         if (!canAccessResource(uri)) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
         }
         return action.get();
     }
 
+
     private JsonRpcMessage withExistingResource(JsonRpcRequest req, String uri, Function<ResourceBlock, JsonRpcMessage> action) {
-        return withAccessibleUri(req, uri, () -> {
-            ResourceBlock block = resources.read(uri);
-            if (block == null) {
-                return JsonRpcError.of(req.id(), -32002, "Resource not found",
-                        Json.createObjectBuilder().add("uri", uri).build());
-            }
-            return action.apply(block);
-        });
+        try {
+            URI.create(uri);
+        } catch (Exception e) {
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
+        }
+        ResourceBlock block = resources.read(uri);
+        if (block == null) {
+            return JsonRpcError.of(req.id(), -32002, "Resource not found",
+                    Json.createObjectBuilder().add("uri", uri).build());
+        }
+        if (!canAccessResource(uri)) {
+            return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Access denied");
+        }
+        return action.apply(block);
     }
 
     private AutoCloseable subscribeListChanges(


### PR DESCRIPTION
## Summary
- validate resource URIs and report `Invalid params` when malformed
- return `Resource not found` before access checks for missing resources

## Testing
- `gradle test --console=plain` *(fails: Fractional request identifier rejection, Non-integer error code rejection, High-frequency ping operations, Ping latency baseline measurement, Large resource streaming, Concurrent resource access, Concurrent tool invocations, Tool invocation throughput baseline, Message throughput baseline, Protocol scalability limits, Memory usage baseline, Error recovery performance impact, Performance regression detection)*

------
https://chatgpt.com/codex/tasks/task_e_68a340c5c7188324a105fc51b7931c74