### PR TITLE
Reject null request identifiers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -222,6 +222,9 @@ final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
 
     public JsonRpcMessage request(RequestId id, RequestMethod method, JsonObject params, Duration timeoutMillis) throws IOException {
         requireCapability(method);
+        if (id instanceof RequestId.NullId) {
+            throw new IllegalArgumentException("id is required");
+        }
         if (params != null) {
             if (params.containsKey("progressToken")) {
                 throw new IllegalArgumentException("progressToken must be in _meta");


### PR DESCRIPTION
Null request identifiers now fail fast.

------
https://chatgpt.com/codex/tasks/task_e_68a35a41353c83248fb0a25b8479cdfe