### PR TITLE
test: cover roots list without configuration

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
@@ -820,6 +820,13 @@ public final class ClientFeaturesSteps {
         }
     }
 
+    @Then("I should return no roots")
+    public void i_should_return_no_roots() {
+        if (!returnedRoots.isEmpty()) {
+            throw new AssertionError("expected no roots");
+        }
+    }
+
     @Then("each root should have a valid file:\\/\\/ URI")
     public void each_root_should_have_a_valid_file_uri() {
         for (Map<String, String> root : returnedRoots) {

--- a/src/test/resources/com/amannmalik/mcp/test/03_client_features.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/03_client_features.feature
@@ -106,6 +106,13 @@ Feature: MCP Client Features
     And each root should have a valid file:// URI
     And each root should include an optional human-readable name
 
+  @roots @listing @empty
+  Scenario: Roots listing with no configured roots
+    # Tests specification/2025-06-18/client/roots.mdx:47-76 (Listing roots)
+    Given I have declared roots capability with no configured roots
+    When I receive a roots/list request
+    Then I should return no roots
+
   @roots @change-notifications
   Scenario: Roots list change notifications
     # Tests specification/2025-06-18/client/roots.mdx:78-104 (Root list changes)


### PR DESCRIPTION


------
https://chatgpt.com/codex/tasks/task_e_68a37aca61cc83248496e0d2563acfdf