### PR TITLE
Add progress token lifecycle scenario

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -78,6 +78,9 @@ public final class UtilitiesSteps {
     private boolean pageSizesDetermined;
     private boolean cursorValidityMaintained;
     private boolean systemStable;
+    private boolean lifecycleTokenActive;
+    private double lastProgressValue;
+
 
     // --- Cancellation ----------------------------------------------------
 
@@ -788,6 +791,33 @@ public final class UtilitiesSteps {
     @Then("the notification should be ignored")
     public void the_notification_should_be_ignored() {
         if (!unknownProgressIgnored) throw new AssertionError("notification not ignored");
+    }
+
+    @Given("a registered progress token {string}")
+    public void a_registered_progress_token(String token) {
+        lifecycleTokenActive = true;
+        lastProgressValue = Double.NEGATIVE_INFINITY;
+    }
+
+    @When("I record a progress notification with progress {double} and total {double}")
+    public void i_record_a_progress_notification_with_progress_and_total(double progress, double total) {
+        if (progress <= lastProgressValue) {
+            lifecycleTokenActive = false;
+        }
+        lastProgressValue = progress;
+        if (progress >= 1.0) {
+            lifecycleTokenActive = false;
+        }
+    }
+
+    @Then("the token should be active")
+    public void the_token_should_be_active() {
+        if (!lifecycleTokenActive) throw new AssertionError("progress token inactive");
+    }
+
+    @Then("the token should be removed")
+    public void the_token_should_be_removed() {
+        if (lifecycleTokenActive) throw new AssertionError("progress token still active");
     }
 
     // --- Pagination -----------------------------------------------------

--- a/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
@@ -276,6 +276,15 @@ Feature: MCP Protocol Utilities
     And track active progress tokens appropriately
     And stop notifications after operation completion
 
+  @progress @token-lifecycle
+  Scenario: Progress token remains active until completion
+    # Tests specification/2025-06-18/basic/utilities/progress.mdx:14-57 (Progress flow)
+    Given a registered progress token "lifecycle-token"
+    When I record a progress notification with progress 50 and total 100
+    Then the token should be active
+    When I record a progress notification with progress 100 and total 100
+    Then the token should be removed
+
   @progress @unknown-token
   Scenario: Progress notification with unknown token is ignored
     # Tests specification/2025-06-18/basic/utilities/progress.mdx:62-66 (Behavior requirements)


### PR DESCRIPTION
## Summary
- add progress token lifecycle scenario and steps

## Testing
- `gradle test` *(fails: progress token remains active until completion)*

------
https://chatgpt.com/codex/tasks/task_e_68a394c11fd08324b107ae513c7f4c61