### PR TITLE
Add tests for missing error fields in MCP responses

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -1409,12 +1409,46 @@ public final class ProtocolLifecycleSteps {
         }
     }
 
+    @When("I receive an error response missing code")
+    public void i_receive_an_error_response_missing_code() {
+        var response = Json.createObjectBuilder()
+                .add("jsonrpc", "2.0")
+                .add("id", RequestId.toJsonValue(new RequestId.NumericId(1)))
+                .add("error", Json.createObjectBuilder().add("message", "oops").build())
+                .build();
+        try {
+            var value = response.getJsonObject("error").get("code");
+            if (!(value instanceof JsonNumber number) || !number.isIntegral()) throw new IllegalArgumentException();
+            number.intValueExact();
+            invalidResponseError = null;
+        } catch (Exception e) {
+            invalidResponseError = e;
+        }
+    }
+
     @When("I receive an error response with non-string message {int}")
     public void i_receive_an_error_response_with_non_string_message(int message) {
         var response = Json.createObjectBuilder()
                 .add("jsonrpc", "2.0")
                 .add("id", RequestId.toJsonValue(new RequestId.NumericId(1)))
                 .add("error", Json.createObjectBuilder().add("code", -1).add("message", message).build())
+                .build();
+        try {
+            var value = response.getJsonObject("error").get("message");
+            if (!(value instanceof JsonString string)) throw new IllegalArgumentException();
+            string.getString();
+            invalidResponseError = null;
+        } catch (Exception e) {
+            invalidResponseError = e;
+        }
+    }
+
+    @When("I receive an error response missing message")
+    public void i_receive_an_error_response_missing_message() {
+        var response = Json.createObjectBuilder()
+                .add("jsonrpc", "2.0")
+                .add("id", RequestId.toJsonValue(new RequestId.NumericId(1)))
+                .add("error", Json.createObjectBuilder().add("code", -1).build())
                 .build();
         try {
             var value = response.getJsonObject("error").get("message");

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -274,6 +274,20 @@ Scenario: HTTP GET response handling
     When I receive an error response with non-string message 123
     Then I should detect an invalid error message
 
+  @messaging @error-format
+  Scenario: Missing error code rejection
+    # Tests specification/2025-06-18/basic/index.mdx:64-78 (Error code requirements)
+    Given I have an established MCP connection
+    When I receive an error response missing code
+    Then I should detect an invalid error code
+
+  @messaging @error-format
+  Scenario: Missing error message rejection
+    # Tests specification/2025-06-18/basic/index.mdx:64-78 (Error message requirements)
+    Given I have an established MCP connection
+    When I receive an error response missing message
+    Then I should detect an invalid error message
+
   @connection @cleanup
   Scenario: Graceful connection termination
     # Tests specification/2025-06-18/basic/lifecycle.mdx:183-200 (Shutdown - stdio)


### PR DESCRIPTION
## Summary
- add Gherkin scenarios for responses missing error code/message
- implement step definitions to detect missing error fields

## Testing
- `gradle test` *(fails: command interrupted; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a394c11fd08324b107ae513c7f4c61