### PR TITLE
Fix resource pagination and progress token handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/ServerDefaults.java
+++ b/src/main/java/com/amannmalik/mcp/util/ServerDefaults.java
@@ -23,13 +23,13 @@ public final class ServerDefaults {
     static {
         Annotations ann = new Annotations(Set.of(Role.USER), 0.5, Instant.parse("2024-01-01T00:00:00Z"));
         Resource r0 = new Resource("test://example", "example", null, null, "text/plain", 5L, ann, null);
-        Resource sample = new Resource("file:///sample", "sample", null, null, "text/plain", 6L, ann, null);
+        Resource r1 = new Resource("test://sample", "sample", null, null, "text/plain", 6L, ann, null);
         Map<String, ResourceBlock> content = Map.of(
                 r0.uri(), new ResourceBlock.Text(r0.uri(), "text/plain", "hello", null),
-                sample.uri(), new ResourceBlock.Text(sample.uri(), "text/plain", "sample", null)
+                r1.uri(), new ResourceBlock.Text(r1.uri(), "text/plain", "sample", null)
         );
         ResourceTemplate template = new ResourceTemplate("test://template", "example_template", null, null, "text/plain", null, null);
-        RESOURCES = new InMemoryResourceProvider(List.of(r0, sample), content, List.of(template));
+        RESOURCES = new InMemoryResourceProvider(List.of(r0, r1), content, List.of(template));
 
         var schema = Json.createObjectBuilder().add("type", "object").build();
         var outSchema = Json.createObjectBuilder()

--- a/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
@@ -82,13 +82,14 @@ public final class ServerFeaturesSteps {
         String java = System.getProperty("java.home") + "/bin/java";
         String jar = Path.of("build", "libs", "mcp-0.1.0.jar").toString();
         String cmd = java + " -jar " + jar + " server --stdio --test-mode";
+        List<String> roots = Stream.concat(base.rootDirectories().stream(), Stream.of("/sample")).toList();
         McpClientConfiguration clientConfig = new McpClientConfiguration(
                 base.clientId(), base.serverName(), base.serverDisplayName(), base.serverVersion(),
                 base.principal(), base.clientCapabilities(), cmd, base.defaultReceiveTimeout(),
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+                base.verbose(), base.interactiveSampling(), roots, base.samplingAccessPolicy()
         );
         McpHostConfiguration hostConfig = new McpHostConfiguration(
                 "2025-06-18",
@@ -105,6 +106,7 @@ public final class ServerFeaturesSteps {
                 List.of(clientConfig)
         );
         activeConnection = new McpHost(hostConfig);
+        activeConnection.allowAudience(Role.USER);
         activeConnection.grantConsent("server");
         activeConnection.grantConsent("tool:test_tool");
         activeConnection.grantConsent("tool:error_tool");

--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -801,11 +801,12 @@ public final class UtilitiesSteps {
 
     @When("I record a progress notification with progress {double} and total {double}")
     public void i_record_a_progress_notification_with_progress_and_total(double progress, double total) {
-        if (progress <= lastProgressValue) {
+        double pct = total <= 0.0 ? progress : progress / total;
+        if (pct <= lastProgressValue) {
             lifecycleTokenActive = false;
         }
-        lastProgressValue = progress;
-        if (progress >= 1.0) {
+        lastProgressValue = pct;
+        if (pct >= 1.0) {
             lifecycleTokenActive = false;
         }
     }


### PR DESCRIPTION
## Summary
- ensure default server exposes multiple resources for pagination
- wire test harness to allow resource access and roots
- normalize progress values in utility tests

## Testing
- `./verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a3cc169e08832480151d839f1d36ea