### PR TITLE
feat: add client tls configuration

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/CertificateValidationMode.java
+++ b/src/main/java/com/amannmalik/mcp/api/CertificateValidationMode.java
@@ -1,0 +1,7 @@
+package com.amannmalik.mcp.api;
+
+public enum CertificateValidationMode {
+    STRICT,
+    PERMISSIVE,
+    CUSTOM
+}

--- a/src/main/java/com/amannmalik/mcp/api/McpClientConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClientConfiguration.java
@@ -31,7 +31,8 @@ public record McpClientConfiguration(
         boolean verbose,
         boolean interactiveSampling,
         List<String> rootDirectories,
-        SamplingAccessPolicy samplingAccessPolicy
+        SamplingAccessPolicy samplingAccessPolicy,
+        McpClientTlsConfiguration tlsConfiguration
 ) {
 
     public McpClientConfiguration {
@@ -63,6 +64,8 @@ public record McpClientConfiguration(
         rootDirectories = List.copyOf(rootDirectories);
         if (samplingAccessPolicy == null)
             throw new IllegalArgumentException("Sampling access policy is required");
+        if (tlsConfiguration == null)
+            throw new IllegalArgumentException("TLS configuration is required");
     }
 
     public static McpClientConfiguration defaultConfiguration(String clientId, String serverName, String principal) {
@@ -88,7 +91,8 @@ public record McpClientConfiguration(
                 false,
                 false,
                 List.of(),
-                SamplingAccessPolicy.PERMISSIVE
+                SamplingAccessPolicy.PERMISSIVE,
+                McpClientTlsConfiguration.defaultConfiguration()
         );
     }
 }

--- a/src/main/java/com/amannmalik/mcp/api/McpClientTlsConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClientTlsConfiguration.java
@@ -1,0 +1,51 @@
+package com.amannmalik.mcp.api;
+
+import java.util.List;
+
+public record McpClientTlsConfiguration(
+        String truststorePath,
+        String truststorePassword,
+        String truststoreType,
+        String keystorePath,
+        String keystorePassword,
+        String keystoreType,
+        CertificateValidationMode certificateValidationMode,
+        List<String> tlsProtocols,
+        List<String> cipherSuites,
+        List<String> certificatePins,
+        boolean verifyHostname
+) {
+    public McpClientTlsConfiguration {
+        if (truststorePath == null || truststorePassword == null || truststoreType == null)
+            throw new IllegalArgumentException("truststore configuration required");
+        if (keystorePath == null || keystorePassword == null || keystoreType == null)
+            throw new IllegalArgumentException("keystore configuration required");
+        if (certificateValidationMode == null)
+            throw new IllegalArgumentException("certificate validation mode required");
+        if (tlsProtocols == null || tlsProtocols.isEmpty() || tlsProtocols.stream().anyMatch(String::isBlank))
+            throw new IllegalArgumentException("tls protocols required");
+        if (cipherSuites == null || cipherSuites.isEmpty() || cipherSuites.stream().anyMatch(String::isBlank))
+            throw new IllegalArgumentException("cipher suites required");
+        if (certificatePins == null)
+            throw new IllegalArgumentException("certificate pins required");
+        tlsProtocols = List.copyOf(tlsProtocols);
+        cipherSuites = List.copyOf(cipherSuites);
+        certificatePins = List.copyOf(certificatePins);
+    }
+
+    public static McpClientTlsConfiguration defaultConfiguration() {
+        return new McpClientTlsConfiguration(
+                "",
+                "",
+                "PKCS12",
+                "",
+                "",
+                "PKCS12",
+                CertificateValidationMode.STRICT,
+                List.of("TLSv1.3", "TLSv1.2"),
+                List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"),
+                List.of(),
+                true
+        );
+    }
+}

--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -95,7 +95,8 @@ public final class HostCommand {
                         clientVerbose,
                         false,
                         List.of(System.getProperty("user.dir")),
-                        SamplingAccessPolicy.PERMISSIVE
+                        SamplingAccessPolicy.PERMISSIVE,
+                        McpClientTlsConfiguration.defaultConfiguration()
                 );
                 clientConfigs.add(clientConfig);
             }

--- a/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
@@ -41,6 +41,7 @@ public final class ClientFeaturesSteps {
     private String lastErrorMessage;
     private boolean combinedRequestProcessed;
     private String elicitationResponseAction;
+    private McpClientTlsConfiguration tlsConfig;
 
     private static ClientCapability parseCapability(String raw) {
         String normalized = raw.trim().toLowerCase();
@@ -75,7 +76,8 @@ public final class ClientFeaturesSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                McpClientTlsConfiguration.defaultConfiguration()
         );
         McpHostConfiguration hostConfig = new McpHostConfiguration(
                 "2025-06-18",
@@ -824,6 +826,25 @@ public final class ClientFeaturesSteps {
     public void i_should_return_no_roots() {
         if (!returnedRoots.isEmpty()) {
             throw new AssertionError("expected no roots");
+        }
+    }
+
+    @When("I inspect the default client TLS configuration")
+    public void i_inspect_the_default_client_tls_configuration() {
+        tlsConfig = McpClientTlsConfiguration.defaultConfiguration();
+    }
+
+    @Then("hostname verification should be enabled")
+    public void hostname_verification_should_be_enabled() {
+        if (!tlsConfig.verifyHostname()) {
+            throw new AssertionError("hostname verification disabled");
+        }
+    }
+
+    @Then("certificate validation mode should be {string}")
+    public void certificate_validation_mode_should_be(String mode) {
+        if (tlsConfig.certificateValidationMode() != CertificateValidationMode.valueOf(mode)) {
+            throw new AssertionError("unexpected mode");
         }
     }
 

--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -147,7 +147,8 @@ public final class ProtocolLifecycleSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                McpClientTlsConfiguration.defaultConfiguration()
         );
     }
 
@@ -158,7 +159,8 @@ public final class ProtocolLifecycleSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                McpClientTlsConfiguration.defaultConfiguration()
         );
     }
 

--- a/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
@@ -89,7 +89,8 @@ public final class ServerFeaturesSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), roots, base.samplingAccessPolicy()
+                base.verbose(), base.interactiveSampling(), roots, base.samplingAccessPolicy(),
+                McpClientTlsConfiguration.defaultConfiguration()
         );
         McpHostConfiguration hostConfig = new McpHostConfiguration(
                 "2025-06-18",

--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -97,7 +97,8 @@ public final class UtilitiesSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                McpClientTlsConfiguration.defaultConfiguration()
         );
         McpHostConfiguration hostConfig = new McpHostConfiguration(
                 "2025-06-18",
@@ -376,7 +377,8 @@ public final class UtilitiesSteps {
                     base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                     base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                     base.pingTimeout(), Duration.ofMillis(interval), base.progressPerSecond(), base.rateLimiterWindow(),
-                    base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy()
+                    base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                    McpClientTlsConfiguration.defaultConfiguration()
             );
             pingConfigurationFailed = false;
         } catch (IllegalArgumentException ex) {

--- a/src/test/resources/com/amannmalik/mcp/test/03_client_features.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/03_client_features.feature
@@ -12,6 +12,12 @@ Feature: MCP Client Features
     And I have established an MCP connection
     And I have declared client capabilities
 
+  @tls @configuration
+  Scenario: Client TLS default configuration
+    When I inspect the default client TLS configuration
+    Then hostname verification should be enabled
+    And certificate validation mode should be "STRICT"
+
   @elicitation @capability
   Scenario: Elicitation capability declaration
     # Tests specification/2025-06-18/client/elicitation.mdx:44-55 (Capability declaration)


### PR DESCRIPTION
## Summary
- add TLS configuration record for clients
- wire TLS defaults through client configuration and CLI
- cover defaults with client feature scenario

## Testing
- `./verify.sh` *(fails: 144 tests, 132 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e4ddef2483249fc501667511f51c