### PR TITLE
Add TLS error mapping

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpClientTransport.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.transport;
 
 import com.amannmalik.mcp.api.Protocol;
 import com.amannmalik.mcp.api.Transport;
+import com.amannmalik.mcp.util.TlsErrors;
 import com.amannmalik.mcp.util.ValidationUtil;
 import jakarta.json.*;
 
@@ -198,7 +199,7 @@ public final class StreamableHttpClientTransport implements Transport {
             Thread.currentThread().interrupt();
             throw new IOException(e);
         } catch (SSLException e) {
-            throw new IOException("TLS handshake failed", e);
+            throw TlsErrors.ioException(e);
         }
     }
 

--- a/src/main/java/com/amannmalik/mcp/util/TlsErrors.java
+++ b/src/main/java/com/amannmalik/mcp/util/TlsErrors.java
@@ -1,0 +1,32 @@
+package com.amannmalik.mcp.util;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.security.cert.CertificateException;
+
+/// - [Security Best Practices](specification/2025-06-18/basic/security_best_practices.mdx)
+public final class TlsErrors {
+    private TlsErrors() {
+    }
+
+    public static IOException ioException(SSLException e) {
+        return new IOException(message(e), e);
+    }
+
+    private static String message(SSLException e) {
+        if (e instanceof SSLHandshakeException h) {
+            Throwable c = h.getCause();
+            if (c instanceof CertificateException) return "Certificate validation failed";
+            if (c instanceof SSLPeerUnverifiedException) return "Client certificate authentication failed";
+            if (c instanceof SocketTimeoutException) return "TLS handshake timed out";
+            if (c instanceof SSLProtocolException) return "TLS protocol negotiation failed";
+            String m = h.getMessage();
+            if (m != null && m.contains("no cipher suites in common")) return "Cipher suite negotiation failed";
+            return "TLS handshake failed";
+        }
+        if (e instanceof SSLProtocolException) return "TLS protocol negotiation failed";
+        return "TLS error";
+    }
+}
+

--- a/src/test/java/com/amannmalik/mcp/test/TlsErrorHandlingTest.java
+++ b/src/test/java/com/amannmalik/mcp/test/TlsErrorHandlingTest.java
@@ -1,0 +1,59 @@
+package com.amannmalik.mcp.test;
+
+import com.amannmalik.mcp.util.TlsErrors;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.security.cert.CertificateException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TlsErrorHandlingTest {
+    @Test
+    public void mapsCertificateValidationFailure() {
+        var ex = new SSLHandshakeException("handshake");
+        ex.initCause(new CertificateException("bad cert"));
+        IOException io = TlsErrors.ioException(ex);
+        assertEquals("Certificate validation failed", io.getMessage());
+    }
+
+    @Test
+    public void mapsProtocolMismatch() {
+        var ex = new SSLProtocolException("version");
+        IOException io = TlsErrors.ioException(ex);
+        assertEquals("TLS protocol negotiation failed", io.getMessage());
+    }
+
+    @Test
+    public void mapsCipherSuiteNegotiationFailure() {
+        var ex = new SSLHandshakeException("no cipher suites in common");
+        IOException io = TlsErrors.ioException(ex);
+        assertEquals("Cipher suite negotiation failed", io.getMessage());
+    }
+
+    @Test
+    public void mapsClientCertificateAuthenticationFailure() {
+        var ex = new SSLHandshakeException("peer not verified");
+        ex.initCause(new SSLPeerUnverifiedException("missing"));
+        IOException io = TlsErrors.ioException(ex);
+        assertEquals("Client certificate authentication failed", io.getMessage());
+    }
+
+    @Test
+    public void mapsHandshakeTimeout() {
+        var ex = new SSLHandshakeException("timeout");
+        ex.initCause(new SocketTimeoutException("timeout"));
+        IOException io = TlsErrors.ioException(ex);
+        assertEquals("TLS handshake timed out", io.getMessage());
+    }
+
+    @Test
+    public void mapsGenericHandshakeFailure() {
+        var ex = new SSLHandshakeException("other");
+        IOException io = TlsErrors.ioException(ex);
+        assertEquals("TLS handshake failed", io.getMessage());
+    }
+}
+


### PR DESCRIPTION
Adds TLS error mapping utility and tests.

------
https://chatgpt.com/codex/tasks/task_e_68a3e67c72d083248760fedce9822e5f