### PR TITLE
test: add https scenarios

### DIFF
--- a/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
@@ -848,6 +848,26 @@ public final class ClientFeaturesSteps {
         }
     }
 
+    @Then("it should support TLS protocols:")
+    public void it_should_support_tls_protocols(DataTable table) {
+        var expected = table.asList();
+        for (String protocol : expected.subList(1, expected.size())) {
+            if (!tlsConfig.tlsProtocols().contains(protocol)) {
+                throw new AssertionError("missing protocol: " + protocol);
+            }
+        }
+    }
+
+    @Then("it should support cipher suites:")
+    public void it_should_support_cipher_suites(DataTable table) {
+        var expected = table.asList();
+        for (String suite : expected.subList(1, expected.size())) {
+            if (!tlsConfig.cipherSuites().contains(suite)) {
+                throw new AssertionError("missing cipher suite: " + suite);
+            }
+        }
+    }
+
     @Then("each root should have a valid file:\\/\\/ URI")
     public void each_root_should_have_a_valid_file_uri() {
         for (Map<String, String> root : returnedRoots) {

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -115,6 +115,18 @@ Scenario: HTTP GET response handling
       | none              | false         |
     Then each response should be handled according to Content-Type requirements
 
+  @connection @https @enforcement
+  Scenario: HTTPS enforcement behavior
+    When I evaluate HTTPS enforcement with the following configurations:
+      | mode    | is_secure | expected_status |
+      | MIXED   | false     | 0               |
+      | REDIRECT| false     | 301             |
+      | STRICT  | false     | 426             |
+      | MIXED   | true      | 0               |
+      | REDIRECT| true      | 0               |
+      | STRICT  | true      | 0               |
+    Then the HTTPS enforcement outcomes should match
+
   @connection @http @post-responses
   Scenario: HTTP POST notifications and responses
     # Tests specification/2025-06-18/basic/transports.mdx:93-98 (Notification/response POST handling)

--- a/src/test/resources/com/amannmalik/mcp/test/03_client_features.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/03_client_features.feature
@@ -18,6 +18,18 @@ Feature: MCP Client Features
     Then hostname verification should be enabled
     And certificate validation mode should be "STRICT"
 
+  @tls @defaults
+  Scenario: Client TLS protocol and cipher suite defaults
+    When I inspect the default client TLS configuration
+    Then it should support TLS protocols:
+      | protocol |
+      | TLSv1.3  |
+      | TLSv1.2  |
+    And it should support cipher suites:
+      | suite                  |
+      | TLS_AES_128_GCM_SHA256 |
+      | TLS_AES_256_GCM_SHA384 |
+
   @elicitation @capability
   Scenario: Elicitation capability declaration
     # Tests specification/2025-06-18/client/elicitation.mdx:44-55 (Capability declaration)


### PR DESCRIPTION
## Summary
- add client TLS protocol and cipher suite checks
- verify server HTTPS enforcement modes

## Testing
- `./verify.sh` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed9903408324985f4f20c639e456