### PR TITLE
refactor: remove paginated helpers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ListToolsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/api/ListToolsRequest.java
@@ -1,13 +1,13 @@
 package com.amannmalik.mcp.api;
 
-import com.amannmalik.mcp.codec.AbstractEntityCodec;
+import com.amannmalik.mcp.codec.EntityCursorPageCodec;
 import com.amannmalik.mcp.codec.JsonCodec;
 import com.amannmalik.mcp.util.ValidationUtil;
 import jakarta.json.JsonObject;
 
 public record ListToolsRequest(String cursor, JsonObject _meta) {
     public static final JsonCodec<ListToolsRequest> CODEC =
-            AbstractEntityCodec.paginatedRequest(
+            new EntityCursorPageCodec<>(
                     ListToolsRequest::cursor,
                     ListToolsRequest::_meta,
                     ListToolsRequest::new);

--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -325,16 +325,16 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         return list(
                 cursor,
                 RequestMethod.RESOURCES_LIST,
-                token -> AbstractEntityCodec.paginatedRequest(
+                token -> new EntityCursorPageCodec<>(
                         ListResourcesRequest::cursor,
                         ListResourcesRequest::_meta,
                         ListResourcesRequest::new).toJson(new ListResourcesRequest(token, null)),
-                json -> AbstractEntityCodec.paginatedResult(
+                json -> new ResourceEntityFieldCodec<>(
                         "resources",
-                        "resource",
                         r -> new Pagination.Page<>(r.resources(), r.nextCursor()),
-                        ListResourcesResult::_meta,
                         new ResourceAbstractEntityCodec(),
+                        ListResourcesResult::_meta,
+                        "resource",
                         (page, meta) -> new ListResourcesResult(page.items(), page.nextCursor(), meta)).fromJson(json)
         );
     }
@@ -343,16 +343,16 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         return list(
                 cursor,
                 RequestMethod.RESOURCES_TEMPLATES_LIST,
-                token -> AbstractEntityCodec.paginatedRequest(
+                token -> new EntityCursorPageCodec<>(
                         ListResourceTemplatesRequest::cursor,
                         ListResourceTemplatesRequest::_meta,
                         ListResourceTemplatesRequest::new).toJson(new ListResourceTemplatesRequest(token, null)),
-                json -> AbstractEntityCodec.paginatedResult(
+                json -> new ResourceEntityFieldCodec<>(
                         "resourceTemplates",
-                        "resourceTemplate",
                         r -> new Pagination.Page<>(r.resourceTemplates(), r.nextCursor()),
-                        ListResourceTemplatesResult::_meta,
                         new ResourceTemplateAbstractEntityCodec(),
+                        ListResourceTemplatesResult::_meta,
+                        "resourceTemplate",
                         (page, meta) -> new ListResourceTemplatesResult(page.items(), page.nextCursor(), meta)).fromJson(json)
         );
     }

--- a/src/main/java/com/amannmalik/mcp/api/McpHost.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpHost.java
@@ -21,12 +21,12 @@ public final class McpHost implements AutoCloseable {
     private static final CallToolRequestAbstractEntityCodec CALL_TOOL_REQUEST_CODEC = new CallToolRequestAbstractEntityCodec();
     private static final JsonCodec<ToolResult> TOOL_RESULT_ABSTRACT_ENTITY_CODEC = new ToolResultAbstractEntityCodec();
     private static final JsonCodec<ListToolsResult> LIST_TOOLS_RESULT_JSON_CODEC =
-            AbstractEntityCodec.paginatedResult(
+            new ResourceEntityFieldCodec<>(
                     "tools",
-                    "tool",
                     r -> new Pagination.Page<>(r.tools(), r.nextCursor()),
-                    ListToolsResult::_meta,
                     new ToolAbstractEntityCodec(),
+                    ListToolsResult::_meta,
+                    "tool",
                     (page, meta) -> new ListToolsResult(page.items(), page.nextCursor(), meta));
 
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
@@ -147,7 +147,7 @@ public final class McpHost implements AutoCloseable {
         var token = cursor instanceof Cursor.Token(var value) ? value : null;
         var resp = JsonRpc.expectResponse(client.request(
                 RequestMethod.TOOLS_LIST,
-                AbstractEntityCodec.paginatedRequest(
+                new EntityCursorPageCodec<>(
                         ListToolsRequest::cursor,
                         ListToolsRequest::_meta,
                         ListToolsRequest::new).toJson(new ListToolsRequest(token, null)),

--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -30,21 +30,21 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
     private static final CancelledNotificationJsonCodec CANCELLED_NOTIFICATION_JSON_CODEC = new CancelledNotificationJsonCodec();
     private static final JsonCodec<ToolListChangedNotification> TOOL_LIST_CHANGED_NOTIFICATION_JSON_CODEC = new ToolListChangedNotificationJsonCodec();
     private static final JsonCodec<ListToolsResult> LIST_TOOLS_RESULT_JSON_CODEC =
-            AbstractEntityCodec.paginatedResult(
+            new ResourceEntityFieldCodec<>(
                     "tools",
-                    "tool",
                     r -> new Pagination.Page<>(r.tools(), r.nextCursor()),
-                    ListToolsResult::_meta,
                     new ToolAbstractEntityCodec(),
+                    ListToolsResult::_meta,
+                    "tool",
                     (page, meta) -> new ListToolsResult(page.items(), page.nextCursor(), meta));
 
     private static final JsonCodec<ListPromptsResult> LIST_PROMPTS_RESULT_CODEC =
-            AbstractEntityCodec.paginatedResult(
+            new ResourceEntityFieldCodec<>(
                     "prompts",
-                    "prompt",
                     r -> new Pagination.Page<>(r.prompts(), r.nextCursor()),
-                    ListPromptsResult::_meta,
                     new PromptAbstractEntityCodec(),
+                    ListPromptsResult::_meta,
+                    "prompt",
                     (page, meta) -> new ListPromptsResult(page.items(), page.nextCursor(), meta));
 
     private final McpServerConfiguration config;

--- a/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
+++ b/src/main/java/com/amannmalik/mcp/api/ResourceOrchestrator.java
@@ -86,7 +86,7 @@ final class ResourceOrchestrator implements AutoCloseable {
         }
         var progressToken = ProgressToken.fromMeta(req.params());
         try {
-            var lr = AbstractEntityCodec.paginatedRequest(
+            var lr = new EntityCursorPageCodec<>(
                     ListResourcesRequest::cursor,
                     ListResourcesRequest::_meta,
                     ListResourcesRequest::new).fromJson(req.params());
@@ -99,12 +99,12 @@ final class ResourceOrchestrator implements AutoCloseable {
                     .toList();
             progressToken.ifPresent(t -> sendProgress(t, 1.0, "Completed resource list"));
             var result = new ListResourcesResult(filtered, list.nextCursor(), null);
-            return new JsonRpcResponse(req.id(), AbstractEntityCodec.paginatedResult(
+            return new JsonRpcResponse(req.id(), new ResourceEntityFieldCodec<>(
                     "resources",
-                    "resource",
                     r -> new Pagination.Page<>(r.resources(), r.nextCursor()),
-                    ListResourcesResult::_meta,
                     new ResourceAbstractEntityCodec(),
+                    ListResourcesResult::_meta,
+                    "resource",
                     (page, meta) -> new ListResourcesResult(page.items(), page.nextCursor(), meta)).toJson(result));
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
@@ -127,7 +127,7 @@ final class ResourceOrchestrator implements AutoCloseable {
     private JsonRpcMessage listTemplates(JsonRpcRequest req) {
         try {
             var request =
-                    AbstractEntityCodec.paginatedRequest(
+                    new EntityCursorPageCodec<>(
                             ListResourceTemplatesRequest::cursor,
                             ListResourceTemplatesRequest::_meta,
                             ListResourceTemplatesRequest::new).fromJson(req.params());
@@ -137,12 +137,12 @@ final class ResourceOrchestrator implements AutoCloseable {
                     .filter(t -> allowed(t.annotations()))
                     .toList();
             var result = new ListResourceTemplatesResult(filtered, page.nextCursor(), null);
-            return new JsonRpcResponse(req.id(), AbstractEntityCodec.paginatedResult(
+            return new JsonRpcResponse(req.id(), new ResourceEntityFieldCodec<>(
                     "resourceTemplates",
-                    "resourceTemplate",
                     r -> new Pagination.Page<>(r.resourceTemplates(), r.nextCursor()),
-                    ListResourceTemplatesResult::_meta,
                     new ResourceTemplateAbstractEntityCodec(),
+                    ListResourceTemplatesResult::_meta,
+                    "resourceTemplate",
                     (page1, meta) -> new ListResourceTemplatesResult(page1.items(), page1.nextCursor(), meta)).toJson(result));
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());

--- a/src/main/java/com/amannmalik/mcp/codec/AbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/AbstractEntityCodec.java
@@ -5,7 +5,8 @@ import jakarta.json.*;
 
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public sealed abstract class AbstractEntityCodec<T> implements JsonCodec<T> permits
         EntityCursorPageCodec,
@@ -50,25 +51,6 @@ public sealed abstract class AbstractEntityCodec<T> implements JsonCodec<T> perm
         if (page.nextCursor() instanceof Cursor.Token(var value)) b.add("nextCursor", value);
         if (meta != null) b.add("_meta", meta);
         return b.build();
-    }
-
-    // TODO: add comments on what this does
-    public static <T> JsonCodec<T> paginatedRequest(
-            Function<T, String> cursor,
-            Function<T, JsonObject> meta,
-            BiFunction<String, JsonObject, T> from) {
-        return new EntityCursorPageCodec<>(cursor, meta, from);
-    }
-
-    // TODO: add comments on what this does
-    public static <I, R> JsonCodec<R> paginatedResult(
-            String field,
-            String itemName,
-            Function<R, Pagination.Page<I>> toPage,
-            Function<R, JsonObject> meta,
-            JsonCodec<I> itemCodec,
-            BiFunction<Pagination.Page<I>, JsonObject, R> from) {
-        return new ResourceEntityFieldCodec<>(field, toPage, itemCodec, meta, itemName, from);
     }
 
     public static <T> JsonCodec<T> metaOnly(

--- a/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
+++ b/src/main/java/com/amannmalik/mcp/prompts/ListPromptsRequest.java
@@ -1,13 +1,13 @@
 package com.amannmalik.mcp.prompts;
 
-import com.amannmalik.mcp.codec.AbstractEntityCodec;
+import com.amannmalik.mcp.codec.EntityCursorPageCodec;
 import com.amannmalik.mcp.codec.JsonCodec;
 import com.amannmalik.mcp.util.ValidationUtil;
 import jakarta.json.JsonObject;
 
 public record ListPromptsRequest(String cursor, JsonObject _meta) {
     public static final JsonCodec<ListPromptsRequest> CODEC =
-            AbstractEntityCodec.paginatedRequest(
+            new EntityCursorPageCodec<>(
                     ListPromptsRequest::cursor,
                     ListPromptsRequest::_meta,
                     ListPromptsRequest::new);


### PR DESCRIPTION
## Summary
- inline paginated request/result codec construction
- drop unused paginated helpers

## Testing
- `gradle test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68a52c0333f88324b0d7c42d461dfa03