### PR TITLE
Replace volatile fields with atomic types

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -21,6 +21,8 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -65,13 +67,13 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     private ClientBackgroundTasks background;
     private Duration pingInterval;
     private Duration pingTimeout;
-    private volatile boolean connected;
+    private final AtomicBoolean connected = new AtomicBoolean();
     private Set<ServerCapability> serverCapabilities = Set.of();
     private String instructions;
     private Set<ServerFeature> serverFeatures = EnumSet.noneOf(ServerFeature.class);
     private String protocolVersion;
     private ServerInfo serverInfo;
-    private volatile ResourceMetadata resourceMetadata;
+    private final AtomicReference<ResourceMetadata> resourceMetadata = new AtomicReference<>();
 
     public McpClient(McpClientConfiguration config,
                      boolean globalVerbose,
@@ -163,7 +165,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     }
 
     public synchronized void configurePing(Duration intervalMillis, Duration timeoutMillis) {
-        if (connected) {
+        if (connected.get()) {
             throw new IllegalStateException("already connected");
         }
         if (intervalMillis.isNegative() || timeoutMillis.isNegative()) {
@@ -190,7 +192,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     }
 
     public synchronized void connect() throws IOException {
-        if (connected) {
+        if (connected.get()) {
             return;
         }
         ClientHandshake.Result init;
@@ -205,7 +207,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         serverCapabilities = init.capabilities();
         serverFeatures = init.features();
         instructions = init.instructions();
-        connected = true;
+        connected.set(true);
         try {
             transport.listen();
         } catch (UnauthorizedException e) {
@@ -219,10 +221,10 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     }
 
     public synchronized void disconnect() throws IOException {
-        if (!connected) {
+        if (!connected.get()) {
             return;
         }
-        connected = false;
+        connected.set(false);
         if (background != null) {
             background.close();
             background = null;
@@ -236,7 +238,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     }
 
     public boolean connected() {
-        return connected;
+        return connected.get();
     }
 
     public Set<ClientCapability> capabilities() {
@@ -291,7 +293,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
                 }
             }
         }
-        if (!connected) {
+        if (!connected.get()) {
             return JsonRpcError.of(new RequestId.NumericId(0), -32002, "Server not initialized");
         }
         try {
@@ -312,7 +314,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
     }
 
     public void sendNotification(NotificationMethod method, JsonObject params) throws IOException {
-        if (!connected) {
+        if (!connected.get()) {
             throw new IllegalStateException("not connected");
         }
         send(new JsonRpcNotification(method.method(), params));
@@ -456,7 +458,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
             throw new IOException("failed to fetch resource metadata: HTTP " + resp.statusCode());
         }
         try (var body = resp.body(); var reader = Json.createReader(body)) {
-            resourceMetadata = new ResourceMetadataJsonCodec().fromJson(reader.readObject());
+            resourceMetadata.set(new ResourceMetadataJsonCodec().fromJson(reader.readObject()));
         }
     }
 

--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.lang.System.Logger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /// - [Server](specification/2025-06-18/server/index.mdx)
 /// - [MCP server conformance test](src/test/resources/com/amannmalik/mcp/mcp_conformance.feature:6-34)
@@ -71,7 +72,7 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
     private ClientFeatures clientFeatures = ClientFeatures.EMPTY;
     private AutoCloseable toolListSubscription;
     private AutoCloseable promptsSubscription;
-    private volatile LoggingLevel logLevel;
+    private final AtomicReference<LoggingLevel> logLevel = new AtomicReference<>();
 
     public McpServer(McpServerConfiguration config,
                      ResourceProvider resources,
@@ -114,7 +115,7 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
         this.principal = principal;
         this.toolHandler = createToolHandler(tools, config, principal);
         this.samplingAccess = config.samplingAccessPolicy();
-        this.logLevel = config.initialLogLevel();
+        this.logLevel.set(config.initialLogLevel());
         this.rootsManager = new RootsManager(this::negotiatedClientCapabilities, this::request);
         this.resourceOrchestrator = resources == null ? null :
                 new ResourceOrchestrator(resources, resourceAccess, principal, rootsManager, this::state, (method, params) -> send(new JsonRpcNotification(method.method(), params)), progress);
@@ -540,7 +541,7 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Missing params");
         }
         try {
-            logLevel = SET_LEVEL_REQUEST_JSON_CODEC.fromJson(params).level();
+            logLevel.set(SET_LEVEL_REQUEST_JSON_CODEC.fromJson(params).level());
             return new JsonRpcResponse(req.id(), JsonValue.EMPTY_JSON_OBJECT);
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, "Invalid params");
@@ -549,7 +550,7 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
 
     private void sendLog(LoggingMessageNotification note) throws IOException {
         if (rateLimit(logLimiter, note.logger() == null ? "" : note.logger()).isPresent() ||
-                note.level().ordinal() < logLevel.ordinal()) {
+                note.level().ordinal() < logLevel.get().ordinal()) {
             return;
         }
         requireServerCapability(ServerCapability.LOGGING);


### PR DESCRIPTION
## Summary
- replace `volatile` fields with atomic types

## Testing
- `./verify.sh` *(fails: Cannot load ruleset /workspace/mcp/config/pmd/ruleset.xml)*

------
https://chatgpt.com/codex/tasks/task_e_68a55e049d8883249e3779198ad08f13