### PR TITLE
Refine SSE routing and request ID handling

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
+    <Match>
+        <Package name="com.amannmalik.mcp.test"/>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/com/amannmalik/mcp/api/JsonRpcEndpoint.java
+++ b/src/main/java/com/amannmalik/mcp/api/JsonRpcEndpoint.java
@@ -25,11 +25,8 @@ sealed class JsonRpcEndpoint implements AutoCloseable permits McpClient, McpServ
     private final AtomicLong counter;
 
     protected JsonRpcEndpoint(Transport transport, ProgressManager progress, long initialId) {
-        if (transport == null || progress == null) {
-            throw new IllegalArgumentException("transport and progress required");
-        }
-        this.transport = transport;
-        this.progress = progress;
+        this.transport = Objects.requireNonNull(transport, "transport required");
+        this.progress = Objects.requireNonNull(progress, "progress required");
         this.counter = new AtomicLong(initialId);
     }
 

--- a/src/main/java/com/amannmalik/mcp/api/RequestId.java
+++ b/src/main/java/com/amannmalik/mcp/api/RequestId.java
@@ -4,6 +4,7 @@ import com.amannmalik.mcp.util.PlatformLog;
 import jakarta.json.*;
 
 import java.lang.System.Logger;
+import java.util.Optional;
 
 public sealed interface RequestId permits
         RequestId.StringId,
@@ -59,6 +60,16 @@ public sealed interface RequestId permits
             }
             default -> throw new IllegalArgumentException("Invalid id type");
         };
+    }
+
+    static Optional<RequestId> fromNullable(JsonValue value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (value.getValueType() == JsonValue.ValueType.NULL) {
+            return Optional.of(NullId.INSTANCE);
+        }
+        return Optional.of(from(value));
     }
 
     enum NullId implements RequestId {

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -69,10 +69,10 @@ public final class StreamableHttpServerTransport implements Transport {
         this.canonicalResource = scheme + "://" + config.bindAddress() + ":" + (https != null ? this.httpsPort : this.port);
         this.authorizationServers = authorizationServers(config, https != null);
         var router = new MessageRouter(
-                clients.request,
-                clients.responses,
-                clients.general,
-                clients.lastGeneral,
+                clients::requestClient,
+                clients::removeResponse,
+                clients::generalSnapshot,
+                clients::lastGeneralClient,
                 clients::removeRequest);
         this.dispatcher = new MessageDispatcher(router);
     }


### PR DESCRIPTION
## Summary
- add RequestId.fromNullable and use it across the HTTP transport to avoid raw JsonValue string handling
- harden SseClient concurrency and encapsulation, exposing prefix via a getter and replaying history thread-safely
- refactor MessageRouter to depend on functional lookups instead of shared collections and adjust StreamableHttpServerTransport/SseClients accordingly
- guard JsonRpcEndpoint constructor parameters with Objects.requireNonNull and ignore SpotBugs warnings for Cucumber test code

## Testing
- ORG_GRADLE_CONSOLE=plain gradle check > /tmp/gradle-check.log

------
https://chatgpt.com/codex/tasks/task_e_68ca9f09b350832491206d309091dd3b