### PR TITLE
Refactor JSON-RPC routing and SSE client management

### DIFF
--- a/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcEnvelope.java
+++ b/src/main/java/com/amannmalik/mcp/jsonrpc/JsonRpcEnvelope.java
@@ -1,0 +1,81 @@
+package com.amannmalik.mcp.jsonrpc;
+
+import com.amannmalik.mcp.api.RequestId;
+import jakarta.json.JsonObject;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Lightweight classifier for JSON-RPC messages that extracts the request id and method, if present.
+ */
+public final class JsonRpcEnvelope {
+    private final JsonObject message;
+    private final Optional<RequestId> id;
+    private final Optional<String> method;
+    private final Type type;
+
+    private JsonRpcEnvelope(JsonObject message) {
+        this.message = Objects.requireNonNull(message, "message");
+        this.id = RequestId.fromNullable(message.get("id"));
+        this.method = Optional.ofNullable(message.getString("method", null));
+        this.type = classify(message, method.isPresent(), id.isPresent());
+    }
+
+    public static JsonRpcEnvelope of(JsonObject message) {
+        return new JsonRpcEnvelope(message);
+    }
+
+    private static Type classify(JsonObject message, boolean hasMethod, boolean hasId) {
+        if (hasMethod && hasId) {
+            return Type.REQUEST;
+        }
+        if (hasMethod) {
+            return Type.NOTIFICATION;
+        }
+        if (message.containsKey("result") || message.containsKey("error")) {
+            return Type.RESPONSE;
+        }
+        return Type.INVALID;
+    }
+
+    public JsonObject message() {
+        return message;
+    }
+
+    public Optional<RequestId> id() {
+        return id;
+    }
+
+    public Optional<String> method() {
+        return method;
+    }
+
+    public Type type() {
+        return type;
+    }
+
+    public boolean isRequest() {
+        return type == Type.REQUEST;
+    }
+
+    public boolean isNotification() {
+        return type == Type.NOTIFICATION;
+    }
+
+    public boolean isResponse() {
+        return type == Type.RESPONSE;
+    }
+
+    public RequestId requireId() {
+        return id.orElseThrow(() -> new IllegalArgumentException("request id missing"));
+    }
+
+    public enum Type {
+        REQUEST,
+        NOTIFICATION,
+        RESPONSE,
+        INVALID
+    }
+}
+

--- a/src/main/java/com/amannmalik/mcp/transport/MetadataServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/MetadataServlet.java
@@ -23,7 +23,7 @@ final class MetadataServlet extends HttpServlet {
         if (!transport.enforceHttps(req, resp)) {
             return;
         }
-        var meta = new ResourceMetadata(transport.canonicalResource, transport.authorizationServers);
+        var meta = new ResourceMetadata(transport.canonicalResource(), transport.authorizationServers());
         var body = new ResourceMetadataJsonCodec().toJson(meta);
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType("application/json");


### PR DESCRIPTION
## Summary
- add a JsonRpcEnvelope helper to classify JSON-RPC messages and expose request metadata
- refactor MessageRouter and McpServlet to route via the envelope and new StreamableHttpServerTransport APIs
- encapsulate SSE client registration/lookup inside StreamableHttpServerTransport and SseClients and adjust MetadataServlet accessors

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68caa7c054b08324a1958699dc4f4074