### PR TITLE
Improve Accept header parsing and SSE resume logic

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/AcceptHeader.java
+++ b/src/main/java/com/amannmalik/mcp/transport/AcceptHeader.java
@@ -1,0 +1,65 @@
+package com.amannmalik.mcp.transport;
+
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+final class AcceptHeader {
+    static final String APPLICATION_JSON = "application/json";
+    static final String TEXT_EVENT_STREAM = "text/event-stream";
+
+    private final Set<String> mediaTypes;
+
+    private AcceptHeader(Set<String> mediaTypes) {
+        this.mediaTypes = mediaTypes;
+    }
+
+    static AcceptHeader parse(String header) {
+        Objects.requireNonNull(header, "header");
+        Set<String> types = new LinkedHashSet<>();
+        for (var token : header.split(",")) {
+            normalize(token).ifPresent(types::add);
+        }
+        if (types.isEmpty()) {
+            throw new IllegalArgumentException("No media types present");
+        }
+        return new AcceptHeader(Set.copyOf(types));
+    }
+
+    boolean matchesExactly(String... requiredTypes) {
+        Set<String> expected = new LinkedHashSet<>(requiredTypes.length);
+        for (var type : requiredTypes) {
+            expected.add(normalizeType(type));
+        }
+        return mediaTypes.equals(Set.copyOf(expected));
+    }
+
+    private static Optional<String> normalize(String token) {
+        var trimmed = token.trim();
+        if (trimmed.isEmpty()) {
+            return Optional.empty();
+        }
+        var semicolon = trimmed.indexOf(';');
+        var type = semicolon >= 0 ? trimmed.substring(0, semicolon) : trimmed;
+        var cleaned = type.trim();
+        if (cleaned.isEmpty()) {
+            return Optional.empty();
+        }
+        if (cleaned.indexOf(' ') >= 0) {
+            throw new IllegalArgumentException("Invalid media type: " + token);
+        }
+        var slash = cleaned.indexOf('/');
+        if (slash <= 0 || slash == cleaned.length() - 1) {
+            throw new IllegalArgumentException("Invalid media type: " + token);
+        }
+        return Optional.of(cleaned.toLowerCase(Locale.ROOT));
+    }
+
+    private static String normalizeType(String type) {
+        Objects.requireNonNull(type, "type");
+        return type.toLowerCase(Locale.ROOT);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add an `AcceptHeader` helper to normalize and validate `Accept` header values while preserving the existing strict media-type combinations
- switch the HTTP transport to the new parser for `Accept` validation and embed SSE last-event parsing logic within the record that carries the token

## Testing
- gradle --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68cbf6a3005c8324a1809a2f4ee7bcce