### PR TITLE
Refine SSE client registration and resume flow

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/SseClients.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseClients.java
@@ -7,10 +7,14 @@ import com.amannmalik.mcp.codec.JsonRpcMessageJsonCodec;
 import com.amannmalik.mcp.jsonrpc.JsonRpcError;
 import com.amannmalik.mcp.jsonrpc.JsonRpcErrorCode;
 import com.amannmalik.mcp.util.CloseUtil;
+import com.amannmalik.mcp.util.PlatformLog;
 import jakarta.json.JsonObject;
+import jakarta.servlet.AsyncContext;
 import jakarta.servlet.AsyncEvent;
 import jakarta.servlet.AsyncListener;
 
+import java.io.IOException;
+import java.lang.System.Logger;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -22,32 +26,44 @@ import java.util.concurrent.atomic.AtomicReference;
 
 final class SseClients {
     static final JsonCodec<JsonRpcMessage> CODEC = new JsonRpcMessageJsonCodec();
+    private static final Logger LOG = PlatformLog.get(SseClients.class);
+
+    @FunctionalInterface
+    interface ClientFactory {
+        SseClient create(AsyncContext context) throws IOException;
+    }
+
     private final Set<SseClient> general = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<RequestId, SseClient> request = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, SseClient> byPrefix = new ConcurrentHashMap<>();
     private final AtomicReference<SseClient> lastGeneral = new AtomicReference<>();
     private final ConcurrentHashMap<RequestId, BlockingQueue<JsonObject>> responses = new ConcurrentHashMap<>();
 
-    Optional<SseClient> findByPrefix(String prefix) {
-        Objects.requireNonNull(prefix, "prefix");
-        return Optional.ofNullable(byPrefix.get(prefix));
-    }
+    SseClient registerGeneral(AsyncContext context, String lastEventId, ClientFactory factory) throws IOException {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(factory, "factory");
 
-    void registerGeneral(SseClient client) {
-        Objects.requireNonNull(client, "client");
-        general.add(client);
-        byPrefix.put(client.prefix(), client);
-        lastGeneral.set(null);
-    }
-
-    void registerRequest(RequestId key, SseClient client) {
-        Objects.requireNonNull(key, "key");
-        Objects.requireNonNull(client, "client");
-        var existing = request.putIfAbsent(key, client);
-        if (existing != null) {
-            throw new IllegalStateException("duplicate request client: " + key);
+        var resumed = resume(lastEventId, context);
+        SseClient client;
+        if (resumed.isPresent()) {
+            client = resumed.get();
+        } else {
+            client = factory.create(context);
         }
-        byPrefix.put(client.prefix(), client);
+        registerGeneral(client);
+        context.addListener(listener(() -> removeGeneral(client)));
+        return client;
+    }
+
+    SseClient registerRequest(RequestId key, AsyncContext context, ClientFactory factory) throws IOException {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(factory, "factory");
+
+        var client = factory.create(context);
+        registerRequest(key, client);
+        context.addListener(listener(() -> removeRequest(key, client)));
+        return client;
     }
 
     BlockingQueue<JsonObject> registerResponseQueue(RequestId key, int capacity) {
@@ -76,12 +92,6 @@ final class SseClients {
         CloseUtil.close(client);
     }
 
-    AsyncListener requestListener(RequestId key, SseClient client) {
-        Objects.requireNonNull(key, "key");
-        Objects.requireNonNull(client, "client");
-        return listener(() -> removeRequest(key, client));
-    }
-
     SseClient requestClient(RequestId key) {
         Objects.requireNonNull(key, "key");
         return request.get(key);
@@ -105,11 +115,6 @@ final class SseClients {
         general.remove(client);
         lastGeneral.set(client);
         CloseUtil.close(client);
-    }
-
-    AsyncListener generalListener(SseClient client) {
-        Objects.requireNonNull(client, "client");
-        return listener(() -> removeGeneral(client));
     }
 
     private AsyncListener listener(Runnable cleanup) {
@@ -140,6 +145,37 @@ final class SseClients {
         }
     }
 
+    private Optional<SseClient> resume(String lastEventId, AsyncContext context) throws IOException {
+        var parsed = SseLastEventId.parse(lastEventId);
+        if (parsed.isEmpty()) {
+            return Optional.empty();
+        }
+        var token = parsed.get();
+        var candidate = byPrefix.get(token.prefix());
+        if (candidate == null) {
+            return Optional.empty();
+        }
+        candidate.attach(context, token.eventId());
+        return Optional.of(candidate);
+    }
+
+    private void registerGeneral(SseClient client) {
+        Objects.requireNonNull(client, "client");
+        general.add(client);
+        byPrefix.put(client.prefix(), client);
+        lastGeneral.set(null);
+    }
+
+    private void registerRequest(RequestId key, SseClient client) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(client, "client");
+        var existing = request.putIfAbsent(key, client);
+        if (existing != null) {
+            throw new IllegalStateException("duplicate request client: " + key);
+        }
+        byPrefix.put(client.prefix(), client);
+    }
+
     private static final class CleanupAsyncListener implements AsyncListener {
         private final Runnable cleanup;
 
@@ -166,5 +202,35 @@ final class SseClients {
         public void onStartAsync(AsyncEvent event) {
         }
     }
-}
 
+    private record SseLastEventId(String prefix, long eventId) {
+        private static Optional<SseLastEventId> parse(String header) {
+            if (header == null || header.isBlank()) {
+                return Optional.empty();
+            }
+            var idx = header.lastIndexOf('-');
+            if (idx <= 0 || idx == header.length() - 1) {
+                return invalid(header, null);
+            }
+            var prefix = header.substring(0, idx);
+            try {
+                var eventId = Long.parseLong(header.substring(idx + 1));
+                if (eventId < 0) {
+                    return invalid(header, null);
+                }
+                return Optional.of(new SseLastEventId(prefix, eventId));
+            } catch (NumberFormatException e) {
+                return invalid(header, e);
+            }
+        }
+
+        private static Optional<SseLastEventId> invalid(String header, Exception cause) {
+            if (cause == null) {
+                LOG.log(Logger.Level.WARNING, "Invalid Last-Event-ID: " + header);
+            } else {
+                LOG.log(Logger.Level.WARNING, "Invalid Last-Event-ID: " + header, cause);
+            }
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- centralize SSE client creation and resume logic inside `SseClients`, including parsing of Last-Event-ID tokens and listener registration
- update `StreamableHttpServerTransport` to delegate SSE registration to the consolidated helper

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ccbe2f3b5c8324b307ad90bbe6bddb