### PR TITLE
Improve transport validation and progress tracking

### DIFF
--- a/src/main/java/com/amannmalik/mcp/core/MessageDispatcher.java
+++ b/src/main/java/com/amannmalik/mcp/core/MessageDispatcher.java
@@ -15,6 +15,7 @@ public final class MessageDispatcher {
     }
 
     public void dispatch(JsonObject message) {
+        Objects.requireNonNull(message, "message");
         if (router.route(message)) {
             flush();
         } else {

--- a/src/main/java/com/amannmalik/mcp/transport/MetadataServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/MetadataServlet.java
@@ -6,16 +6,19 @@ import jakarta.servlet.http.*;
 
 import java.io.IOException;
 import java.io.Serial;
+import java.util.Objects;
 
 final class MetadataServlet extends HttpServlet {
 
     @Serial
     private static final long serialVersionUID = 133742069L;
 
+    private static final ResourceMetadataJsonCodec METADATA_CODEC = new ResourceMetadataJsonCodec();
+
     private transient final StreamableHttpServerTransport transport;
 
     MetadataServlet(StreamableHttpServerTransport transport) {
-        this.transport = transport;
+        this.transport = Objects.requireNonNull(transport, "transport");
     }
 
     @Override
@@ -24,7 +27,7 @@ final class MetadataServlet extends HttpServlet {
             return;
         }
         var meta = new ResourceMetadata(transport.canonicalResource(), transport.authorizationServers());
-        var body = new ResourceMetadataJsonCodec().toJson(meta);
+        var body = METADATA_CODEC.toJson(meta);
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Objects;
 
 public final class StreamableHttpServerTransport implements Transport {
     // Default to the previous protocol revision when the version header is
@@ -57,7 +58,7 @@ public final class StreamableHttpServerTransport implements Transport {
 
     public StreamableHttpServerTransport(McpServerConfiguration config,
                                          AuthorizationManager auth) throws Exception {
-        this.config = config;
+        this.config = Objects.requireNonNull(config, "config");
         this.sessions = new SessionManager(COMPATIBILITY_VERSION, config.sessionIdByteLength());
         this.server = new Server();
         server.setHandler(servletContext(config));


### PR DESCRIPTION
## Summary
- tighten progress tracking to eliminate stale progress token references and reuse the shared codec
- enforce stronger validation around SSE clients, message dispatch, and session sanitization while reusing servlet codecs
- require HTTP server transport configuration objects and preserve metadata servlet reuse

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68ccc406c38c8324a2e779bd7677e7a9