### PR TITLE
Refine routing outcomes and backlog handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/core/RouteOutcome.java
+++ b/src/main/java/com/amannmalik/mcp/core/RouteOutcome.java
@@ -1,0 +1,24 @@
+package com.amannmalik.mcp.core;
+
+/**
+ * Result of attempting to deliver a JSON-RPC message to a connected client.
+ */
+public enum RouteOutcome {
+    /** Message has been delivered (or persisted for eventual replay). */
+    DELIVERED,
+
+    /** Message could not be delivered yet but may succeed later. */
+    PENDING,
+
+    /** No route exists for the message and it should be discarded. */
+    NOT_FOUND;
+
+    public boolean isDelivered() {
+        return this == DELIVERED;
+    }
+
+    public boolean shouldRetry() {
+        return this == PENDING;
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce a `RouteOutcome` enum to represent routing results for JSON-RPC messages
- update `MessageRouter` to return explicit outcomes and drop messages that can never be delivered
- refine `MessageDispatcher` backlog handling to log and remove unroutable messages while retrying pending ones

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68ccd7cdc5a0832497bf0244034f31d5