### PR TITLE
Refine server defaults and utility helpers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/Immutable.java
+++ b/src/main/java/com/amannmalik/mcp/util/Immutable.java
@@ -1,6 +1,10 @@
 package com.amannmalik.mcp.util;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public final class Immutable {
     private Immutable() {

--- a/src/main/java/com/amannmalik/mcp/util/StringMetrics.java
+++ b/src/main/java/com/amannmalik/mcp/util/StringMetrics.java
@@ -1,18 +1,26 @@
 package com.amannmalik.mcp.util;
 
 import java.util.Locale;
+import java.util.Objects;
 
 public final class StringMetrics {
     private StringMetrics() {
     }
 
     public static int levenshtein(String a, String b) {
+        Objects.requireNonNull(a, "a");
+        Objects.requireNonNull(b, "b");
+
+        if (a.equals(b)) {
+            return 0;
+        }
+
         var prev = new int[b.length() + 1];
+        var curr = new int[b.length() + 1];
         for (var j = 0; j <= b.length(); j++) {
             prev[j] = j;
         }
         for (var i = 1; i <= a.length(); i++) {
-            var curr = new int[b.length() + 1];
             curr[0] = i;
             var ca = a.charAt(i - 1);
             for (var j = 1; j <= b.length(); j++) {
@@ -22,7 +30,9 @@ public final class StringMetrics {
                 var sub = prev[j - 1] + cost;
                 curr[j] = Math.min(Math.min(ins, del), sub);
             }
+            var swap = prev;
             prev = curr;
+            curr = swap;
         }
         return prev[b.length()];
     }


### PR DESCRIPTION
## Summary
* Refactored `ServerDefaults` to centralize default provider initialization, reuse helper builders for tool responses, and add dedicated delegating wrapper implementations.
* Tightened root checking and validation utilities by using clearer contracts, explicit imports, and extracted meta validation helpers.
* Optimized shared helpers such as `Immutable` and `StringMetrics` for cleaner APIs and reduced allocations.

## Testing
* `gradle --console=plain test`


------
https://chatgpt.com/codex/tasks/task_e_68cd179dc2c083248bea949773b1f2e3