### PR TITLE
Refactor routing and transport utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -191,7 +191,7 @@ public final class StreamableHttpServerTransport implements Transport {
         return config.resourceMetadataUrl();
     }
 
-    private List<String> authorizationServers(McpServerConfiguration config, boolean https) {
+    private static List<String> authorizationServers(McpServerConfiguration config, boolean https) {
         if (config.authServers().isEmpty()) {
             return List.of();
         }
@@ -206,10 +206,7 @@ public final class StreamableHttpServerTransport implements Transport {
     }
 
     public List<String> authorizationServers() {
-        if (authorizationServers.isEmpty()) {
-            return List.of();
-        }
-        return Collections.unmodifiableList(new ArrayList<>(authorizationServers));
+        return authorizationServers;
     }
 
     public int port() {


### PR DESCRIPTION
## Summary
- consolidate JSON-RPC dispatch handling into a reusable helper to keep backlog management consistent
- streamline session header sanitisation by replacing optional plumbing with direct validation helpers
- reuse SSE client registration logic and preserve pre-computed authorization server lists without repeated copying

## Testing
- gradle test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cd179dc2c083248bea949773b1f2e3