### PR TITLE
Refine MCP server request handling and lifecycle checks

### DIFF
--- a/src/main/java/com/amannmalik/mcp/roots/RequestSender.java
+++ b/src/main/java/com/amannmalik/mcp/roots/RequestSender.java
@@ -5,9 +5,10 @@ import com.amannmalik.mcp.api.RequestMethod;
 import jakarta.json.JsonObject;
 
 import java.io.IOException;
+import java.time.Duration;
 
 @FunctionalInterface
 public interface RequestSender {
-    JsonRpcMessage send(RequestMethod method, JsonObject params, long timeoutMillis) throws IOException;
+    JsonRpcMessage send(RequestMethod method, JsonObject params, Duration timeout) throws IOException;
 }
 

--- a/src/main/java/com/amannmalik/mcp/roots/RootsManager.java
+++ b/src/main/java/com/amannmalik/mcp/roots/RootsManager.java
@@ -11,6 +11,7 @@ import com.amannmalik.mcp.util.PlatformLog;
 
 import java.io.IOException;
 import java.lang.System.Logger;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -74,7 +75,7 @@ public final class RootsManager {
     private List<Root> fetchRoots() throws IOException {
         requireClientCapability(ClientCapability.ROOTS);
         var msg = requester.send(RequestMethod.ROOTS_LIST,
-                CODEC.toJson(new ListRootsRequest(null)), 0L);
+                CODEC.toJson(new ListRootsRequest(null)), Duration.ZERO);
         if (msg instanceof JsonRpcResponse resp) {
             return LIST_RESULTS_CODEC.fromJson(resp.result()).roots();
         }


### PR DESCRIPTION
## Summary
- harden JsonRpcEndpoint request/notification registration and clarify timeout exceptions
- reuse shared codecs and enforce initialization/capability checks while routing Duration-based timeouts on McpServer
- align roots request sender abstraction with Duration-based timeouts

## Testing
- gradle --console=plain check

------
https://chatgpt.com/codex/tasks/task_e_68cd179dc2c083248bea949773b1f2e3