### PR TITLE
Refine duration handling across transports

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClientConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClientConfiguration.java
@@ -1,6 +1,7 @@
 package com.amannmalik.mcp.api;
 
 import com.amannmalik.mcp.spi.SamplingAccessPolicy;
+import com.amannmalik.mcp.util.ValidationUtil;
 
 import java.time.Duration;
 import java.util.List;
@@ -49,33 +50,21 @@ public record McpClientConfiguration(
             throw new IllegalArgumentException("Principal is required");
         }
         clientCapabilities = Set.copyOf(clientCapabilities);
-        if (defaultReceiveTimeout == null || defaultReceiveTimeout.isNegative() || defaultReceiveTimeout.isZero()) {
-            throw new IllegalArgumentException("Default receive timeout must be positive");
-        }
+        defaultReceiveTimeout = ValidationUtil.requirePositive(defaultReceiveTimeout, "Default receive timeout");
         if (defaultOriginHeader == null || defaultOriginHeader.isBlank()) {
             throw new IllegalArgumentException("Default origin header is required");
         }
-        if (httpRequestTimeout == null || httpRequestTimeout.isNegative() || httpRequestTimeout.isZero()) {
-            throw new IllegalArgumentException("HTTP request timeout must be positive");
-        }
+        httpRequestTimeout = ValidationUtil.requirePositive(httpRequestTimeout, "HTTP request timeout");
         if (sessionIdByteLength <= 0) {
             throw new IllegalArgumentException("Session ID byte length must be positive");
         }
-        if (initializeRequestTimeout == null || initializeRequestTimeout.isNegative() || initializeRequestTimeout.isZero()) {
-            throw new IllegalArgumentException("Initialize request timeout must be positive");
-        }
-        if (pingTimeout == null || pingTimeout.isNegative() || pingTimeout.isZero()) {
-            throw new IllegalArgumentException("Ping timeout must be positive");
-        }
-        if (pingInterval == null || pingInterval.isNegative() || pingInterval.isZero()) {
-            throw new IllegalArgumentException("Ping interval must be positive");
-        }
+        initializeRequestTimeout = ValidationUtil.requirePositive(initializeRequestTimeout, "Initialize request timeout");
+        pingTimeout = ValidationUtil.requirePositive(pingTimeout, "Ping timeout");
+        pingInterval = ValidationUtil.requirePositive(pingInterval, "Ping interval");
         if (progressPerSecond < 0) {
             throw new IllegalArgumentException("Progress per second must be non-negative");
         }
-        if (rateLimiterWindow == null || rateLimiterWindow.isNegative() || rateLimiterWindow.isZero()) {
-            throw new IllegalArgumentException("Rate limiter window must be positive");
-        }
+        rateLimiterWindow = ValidationUtil.requirePositive(rateLimiterWindow, "Rate limiter window");
         rootDirectories = List.copyOf(rootDirectories);
         if (samplingAccessPolicy == null) {
             throw new IllegalArgumentException("Sampling access policy is required");

--- a/src/main/java/com/amannmalik/mcp/api/McpServerConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServerConfiguration.java
@@ -2,6 +2,7 @@ package com.amannmalik.mcp.api;
 
 import com.amannmalik.mcp.spi.SamplingAccessPolicy;
 import com.amannmalik.mcp.spi.ToolAccessPolicy;
+import com.amannmalik.mcp.util.ValidationUtil;
 
 import java.time.Duration;
 import java.util.List;
@@ -126,9 +127,7 @@ public record McpServerConfiguration(
         if (sessionIdByteLength <= 0) {
             throw new IllegalArgumentException("Session ID byte length must be positive");
         }
-        if (initializeRequestTimeout.isNegative() || initializeRequestTimeout.isZero()) {
-            throw new IllegalArgumentException("Initialize request timeout must be positive");
-        }
+        ValidationUtil.requirePositive(initializeRequestTimeout, "Initialize request timeout");
         if (sseClientPrefixByteLength <= 0) {
             throw new IllegalArgumentException("Client prefix byte length must be positive");
         }

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -268,11 +268,13 @@ public final class StreamableHttpServerTransport implements Transport {
     }
 
     @Override
-    public JsonObject receive(Duration timeoutMillis) throws IOException {
+    public JsonObject receive(Duration timeout) throws IOException {
+        var duration = ValidationUtil.requirePositive(timeout, "timeout");
+        var waitMillis = duration.toMillis();
         try {
-            var obj = incoming.poll(timeoutMillis.toMillis(), TimeUnit.MILLISECONDS);
+            var obj = incoming.poll(waitMillis, TimeUnit.MILLISECONDS);
             if (obj == null) {
-                throw new IOException("Timeout after " + timeoutMillis + "ms waiting for message");
+                throw new IOException("Timeout after " + waitMillis + "ms waiting for message");
             }
             if (closed.get() && obj.containsKey("_close")) {
                 throw new EOFException();

--- a/src/main/java/com/amannmalik/mcp/util/ValidationUtil.java
+++ b/src/main/java/com/amannmalik/mcp/util/ValidationUtil.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.util;
 import jakarta.json.JsonObject;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -184,6 +185,13 @@ public final class ValidationUtil {
         if (depth != 0) {
             throw new IllegalArgumentException("Unmatched braces in URI template: " + template);
         }
+    }
+
+    public static Duration requirePositive(Duration value, String field) {
+        if (value == null || value.isZero() || value.isNegative()) {
+            throw new IllegalArgumentException(field + " must be positive");
+        }
+        return value;
     }
 
     public static int requirePositive(int value, String field) {


### PR DESCRIPTION
## Summary
- add a ValidationUtil.requirePositive helper for Duration inputs
- enforce positive duration validation in transport implementations and configuration records
- align timeout error messages to report millisecond values consistently

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68cea8a1f7e48324a5a407dd8aa85372