### PR TITLE
Refine message routing abstractions and event handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -73,12 +73,7 @@ public final class StreamableHttpServerTransport implements Transport {
         this.resourceMetadataUrl = metadataUrl(config, scheme, https != null ? this.httpsPort : this.port, https != null);
         this.canonicalResource = scheme + "://" + config.bindAddress() + ":" + (https != null ? this.httpsPort : this.port);
         this.authorizationServers = authorizationServers(config, https != null);
-        var router = new MessageRouter(
-                clients::requestClient,
-                clients::removeResponse,
-                clients::generalSnapshot,
-                clients::lastGeneralClient,
-                clients::removeRequest);
+        var router = new MessageRouter(clients.routes());
         this.dispatcher = new MessageDispatcher(router);
     }
 

--- a/src/main/java/com/amannmalik/mcp/util/EventSupport.java
+++ b/src/main/java/com/amannmalik/mcp/util/EventSupport.java
@@ -1,19 +1,38 @@
 package com.amannmalik.mcp.util;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class EventSupport {
     private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
 
     public AutoCloseable subscribe(Runnable listener) {
+        var subscription = new Subscription(Objects.requireNonNull(listener, "listener"));
         listeners.add(listener);
-        return () -> listeners.remove(listener);
+        return subscription;
     }
 
     public void notifyListeners() {
         for (var l : listeners) {
             l.run();
+        }
+    }
+
+    private final class Subscription implements AutoCloseable {
+        private final Runnable listener;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private Subscription(Runnable listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                listeners.remove(listener);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the MessageRouter constructor with a dedicated Routes contract and simplify routing fallbacks
- expose a typed routes view from SseClients while tightening its internal surface area
- streamline MessageDispatcher backlog handling and harden EventSupport subscription cleanup

## Testing
- gradle --console=plain check

------
https://chatgpt.com/codex/tasks/task_e_68ceab9df0788324a41371b638dcfaff