### PR TITLE
Refine lifecycle negotiation and progress tracking

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/InitializeRequest.java
+++ b/src/main/java/com/amannmalik/mcp/util/InitializeRequest.java
@@ -4,17 +4,15 @@ import com.amannmalik.mcp.api.ClientInfo;
 import com.amannmalik.mcp.core.Capabilities;
 import com.amannmalik.mcp.core.ClientFeatures;
 
+import java.util.Objects;
+
 public record InitializeRequest(
         String protocolVersion,
         Capabilities capabilities,
         ClientInfo clientInfo,
         ClientFeatures features) {
     public InitializeRequest {
-        if (protocolVersion == null) {
-            throw new IllegalArgumentException("protocolVersion must not be null");
-        }
-        if (features == null) {
-            features = ClientFeatures.EMPTY;
-        }
+        protocolVersion = Objects.requireNonNull(protocolVersion, "protocolVersion");
+        features = Objects.requireNonNullElse(features, ClientFeatures.EMPTY);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/util/InitializeResponse.java
+++ b/src/main/java/com/amannmalik/mcp/util/InitializeResponse.java
@@ -4,6 +4,7 @@ import com.amannmalik.mcp.api.ServerFeature;
 import com.amannmalik.mcp.api.ServerInfo;
 import com.amannmalik.mcp.core.Capabilities;
 
+import java.util.Objects;
 import java.util.Set;
 
 public record InitializeResponse(
@@ -13,6 +14,10 @@ public record InitializeResponse(
         String instructions,
         Set<ServerFeature> features) {
     public InitializeResponse {
+        protocolVersion = Objects.requireNonNull(protocolVersion, "protocolVersion");
+        capabilities = Objects.requireNonNull(capabilities, "capabilities");
+        serverInfo = Objects.requireNonNull(serverInfo, "serverInfo");
+        instructions = Objects.requireNonNullElse(instructions, "");
         features = Immutable.enumSet(features);
     }
 


### PR DESCRIPTION
## Summary
- normalize supported protocol versions deterministically and tighten lifecycle state handling
- ensure initialize request/response records default optional values and guard against null protocol metadata
- refactor progress manager registration, validation, and notification flow for stricter checks and cleaner concurrency

## Testing
- gradle test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ceb68e4bbc8324a0ef689f1481e986