### PR TITLE
Refine routing and resource lookups

### DIFF
--- a/src/main/java/com/amannmalik/mcp/core/MessageRouter.java
+++ b/src/main/java/com/amannmalik/mcp/core/MessageRouter.java
@@ -68,20 +68,22 @@ public final class MessageRouter {
     }
 
     private RouteOutcome routeToGeneralClients(JsonObject message) {
-        if (sendToActiveClient(message) || deliverToPendingClient(message)) {
+        if (sendToActiveClients(message) || deliverToPendingClient(message)) {
             return RouteOutcome.DELIVERED;
         }
         return RouteOutcome.PENDING;
     }
 
-    private boolean sendToActiveClient(JsonObject message) {
+    private boolean sendToActiveClients(JsonObject message) {
+        var delivered = false;
         for (var client : routes.generalClients()) {
-            if (client.isActive()) {
-                client.send(message);
-                return true;
+            if (!client.isActive()) {
+                continue;
             }
+            client.send(message);
+            delivered = true;
         }
-        return false;
+        return delivered;
     }
 
     private boolean deliverToPendingClient(JsonObject message) {

--- a/src/main/java/com/amannmalik/mcp/transport/TransportHeaders.java
+++ b/src/main/java/com/amannmalik/mcp/transport/TransportHeaders.java
@@ -4,6 +4,7 @@ final class TransportHeaders {
     public static final String PROTOCOL_VERSION = "MCP-Protocol-Version";
     public static final String SESSION_ID = "Mcp-Session-Id";
     public static final String AUTHORIZATION = "Authorization";
+    public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 
     private TransportHeaders() {
     }


### PR DESCRIPTION
## Summary
- broadcast routed messages to every active general SSE client instead of just the first connection
- centralize HTTP authorization header handling and reuse constants
- index in-memory resources and templates for quicker lookup and duplicate detection

## Testing
- gradle --console=plain check

------
https://chatgpt.com/codex/tasks/task_e_68ceb68e4bbc8324a0ef689f1481e986