### PR TITLE
Refine progress tracking and SSE routing

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -620,12 +620,10 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
 
     private void cancelled(JsonRpcNotification note) {
         var cn = CANCELLED_NOTIFICATION_JSON_CODEC.fromJson(note.params());
-        progress.cancel(cn.requestId(), cn.reason());
+        var reason = progress.cancel(cn.requestId(), cn.reason());
         progress.release(cn.requestId());
-        var reason = progress.reason(cn.requestId());
-        if (reason != null) {
-            LOG.log(Logger.Level.INFO, () -> "Request " + cn.requestId() + " cancelled: " + reason);
-        }
+        reason.ifPresent(value ->
+                LOG.log(Logger.Level.INFO, () -> "Request " + cn.requestId() + " cancelled: " + value));
     }
 
     public interface McpClientListener {

--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -402,12 +402,11 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
 
     private void cancelled(JsonRpcNotification note) {
         var cn = CANCELLED_NOTIFICATION_JSON_CODEC.fromJson(note.params());
-        progress.cancel(cn.requestId(), cn.reason());
+        var reason = progress.cancel(cn.requestId(), cn.reason());
         progress.release(cn.requestId());
         try {
-            var reason = progress.reason(cn.requestId());
-            sendLog(LoggingLevel.INFO, config.cancellationLoggerName(),
-                    reason == null ? JsonValue.NULL : Json.createValue(reason));
+            var payload = reason.<JsonValue>map(Json::createValue).orElse(JsonValue.NULL);
+            sendLog(LoggingLevel.INFO, config.cancellationLoggerName(), payload);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/amannmalik/mcp/core/MessageRouter.java
+++ b/src/main/java/com/amannmalik/mcp/core/MessageRouter.java
@@ -88,6 +88,7 @@ public final class MessageRouter {
 
     private boolean deliverToPendingClient(JsonObject message) {
         return routes.pendingGeneralClient()
+                .filter(SseClient::isActive)
                 .map(client -> {
                     client.send(message);
                     return true;

--- a/src/main/java/com/amannmalik/mcp/transport/SseClients.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseClients.java
@@ -106,7 +106,11 @@ final class SseClients {
     }
 
     private Optional<SseClient> lastGeneralClient() {
-        return Optional.ofNullable(lastGeneral.get());
+        var client = lastGeneral.get();
+        if (client == null || !client.isActive()) {
+            return Optional.empty();
+        }
+        return Optional.of(client);
     }
 
     void removeGeneral(SseClient client) {


### PR DESCRIPTION
## Summary
- centralize request progress bookkeeping in `ProgressManager` to enforce duplicate request detection, retain cancellation metadata, and expose optional reasons to callers
- adjust MCP client and server cancellation flows to use the new optional reason handling without redundant lookups
- ensure SSE routing only treats active clients as delivery targets to avoid silently dropping messages

## Testing
- gradle check

------
https://chatgpt.com/codex/tasks/task_e_68cebcc314448324a2d08aedea64a2f1