### PR TITLE
Refine routing resilience and dispatcher backlog handling

### DIFF
--- a/src/main/java/com/amannmalik/mcp/core/MessageRouter.java
+++ b/src/main/java/com/amannmalik/mcp/core/MessageRouter.java
@@ -52,7 +52,15 @@ public final class MessageRouter {
 
     private RouteOutcome deliverToRequestStream(RequestId id, JsonRpcEnvelope envelope, SseClient client) {
         var message = envelope.message();
+        if (!client.isActive()) {
+            routes.removeRequestClient(id, client);
+            return RouteOutcome.NOT_FOUND;
+        }
         client.send(message);
+        if (!client.isActive()) {
+            routes.removeRequestClient(id, client);
+            return RouteOutcome.NOT_FOUND;
+        }
         if (envelope.isResponse()) {
             routes.removeRequestClient(id, client);
         }


### PR DESCRIPTION
## Summary
- simplify `MessageDispatcher` backlog processing by consolidating outcome handling and ensuring backlog drops are logged without redundant queue mutations
- harden request routing in `MessageRouter` by removing inactive SSE clients before treating messages as delivered, allowing graceful fallback to queues or general clients

## Testing
- gradle check

------
https://chatgpt.com/codex/tasks/task_e_68cec681fa1883248de10a9bc99dd421