### PR TITLE
Harden authorization helpers and refresh utilities

### DIFF
--- a/src/main/java/com/amannmalik/mcp/auth/AuthorizationManager.java
+++ b/src/main/java/com/amannmalik/mcp/auth/AuthorizationManager.java
@@ -3,6 +3,7 @@ package com.amannmalik.mcp.auth;
 import com.amannmalik.mcp.spi.Principal;
 
 import java.util.List;
+import java.util.Objects;
 
 /// - [Authorization](specification/2025-06-18/basic/authorization.mdx)
 /// - [Security Best Practices](specification/2025-06-18/basic/security_best_practices.mdx)
@@ -12,6 +13,9 @@ public final class AuthorizationManager {
     public AuthorizationManager(List<AuthorizationStrategy> strategies) {
         if (strategies == null || strategies.isEmpty()) {
             throw new IllegalArgumentException("strategies required");
+        }
+        if (strategies.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("strategies must not contain null elements");
         }
         this.strategies = List.copyOf(strategies);
     }

--- a/src/main/java/com/amannmalik/mcp/auth/BearerTokenAuthorizationStrategy.java
+++ b/src/main/java/com/amannmalik/mcp/auth/BearerTokenAuthorizationStrategy.java
@@ -2,13 +2,16 @@ package com.amannmalik.mcp.auth;
 
 import com.amannmalik.mcp.spi.Principal;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 public final class BearerTokenAuthorizationStrategy implements AuthorizationStrategy {
+    private static final Pattern BEARER_PREFIX = Pattern.compile("^bearer\\b", Pattern.CASE_INSENSITIVE);
     private final TokenValidator validator;
 
     public BearerTokenAuthorizationStrategy(TokenValidator validator) {
-        this.validator = validator;
+        this.validator = Objects.requireNonNull(validator, "validator");
     }
 
     @Override
@@ -16,10 +19,11 @@ public final class BearerTokenAuthorizationStrategy implements AuthorizationStra
         if (authorizationHeader == null) {
             return Optional.empty();
         }
-        var parts = authorizationHeader.split("\\s+", 2);
-        if (!"bearer".equalsIgnoreCase(parts[0])) {
+        var trimmed = authorizationHeader.trim();
+        if (trimmed.isEmpty() || !BEARER_PREFIX.matcher(trimmed).find()) {
             return Optional.empty();
         }
+        var parts = trimmed.split("\\s+", 2);
         if (parts.length != 2 || parts[1].trim().isEmpty()) {
             throw new AuthorizationException("Invalid bearer token", 400);
         }

--- a/src/main/java/com/amannmalik/mcp/completion/InMemoryCompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/completion/InMemoryCompletionProvider.java
@@ -35,6 +35,7 @@ public final class InMemoryCompletionProvider extends InMemoryProvider<Ref> impl
                     String argumentName,
                     Map<String, String> context,
                     List<String> values) {
+        Objects.requireNonNull(ref, "ref");
         argumentName = ValidationUtil.requireClean(argumentName);
         var ctx = ValidationUtil.requireCleanMap(context);
         List<String> vals = values == null ? List.of() : values.stream()

--- a/src/main/java/com/amannmalik/mcp/transport/AuthorizationUtil.java
+++ b/src/main/java/com/amannmalik/mcp/transport/AuthorizationUtil.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpResponse;
+import java.util.Objects;
 import java.util.Optional;
 
 final class AuthorizationUtil {
@@ -21,27 +22,46 @@ final class AuthorizationUtil {
                                          HttpServletResponse resp,
                                          String resourceMetadataUrl,
                                          Principal defaultPrincipal) throws IOException {
+        Objects.requireNonNull(req, "req");
+        Objects.requireNonNull(resp, "resp");
+        Objects.requireNonNull(defaultPrincipal, "defaultPrincipal");
+
         if (manager == null) {
             return Optional.of(defaultPrincipal);
         }
         try {
-            return Optional.of(manager.authorize(req.getHeader(TransportHeaders.AUTHORIZATION)));
+            var header = req.getHeader(TransportHeaders.AUTHORIZATION);
+            return Optional.of(manager.authorize(header));
         } catch (AuthorizationException e) {
-            if (resourceMetadataUrl != null
-                    && !resourceMetadataUrl.isBlank()
-                    && e.status() == HttpServletResponse.SC_UNAUTHORIZED) {
-                resp.setHeader(TransportHeaders.WWW_AUTHENTICATE, "Bearer resource=" + resourceMetadataUrl);
-            }
-            resp.sendError(e.status());
+            handleAuthorizationFailure(resp, resourceMetadataUrl, e);
             return Optional.empty();
         }
     }
 
     static void checkUnauthorized(HttpResponse<InputStream> response) throws IOException {
+        Objects.requireNonNull(response, "response");
         if (response.statusCode() == HttpServletResponse.SC_UNAUTHORIZED) {
             var header = response.headers().firstValue(TransportHeaders.WWW_AUTHENTICATE).orElse("");
-            response.body().close();
+            var body = response.body();
+            if (body != null) {
+                body.close();
+            }
             throw new UnauthorizedException(header);
         }
+    }
+
+    private static void handleAuthorizationFailure(HttpServletResponse resp,
+                                                   String resourceMetadataUrl,
+                                                   AuthorizationException failure) throws IOException {
+        if (shouldAdvertiseMetadata(resourceMetadataUrl, failure.status())) {
+            resp.setHeader(TransportHeaders.WWW_AUTHENTICATE, "Bearer resource=" + resourceMetadataUrl);
+        }
+        resp.sendError(failure.status());
+    }
+
+    private static boolean shouldAdvertiseMetadata(String resourceMetadataUrl, int status) {
+        return status == HttpServletResponse.SC_UNAUTHORIZED
+                && resourceMetadataUrl != null
+                && !resourceMetadataUrl.isBlank();
     }
 }


### PR DESCRIPTION
## Summary
- validate authorization strategy wiring and bearer parsing to prevent null dependencies and malformed headers
- guard authorization utilities with explicit null checks and centralized failure handling, including safe response-body cleanup
- tighten in-memory completion and roots refresh logic by enforcing non-null inputs and using a virtual thread refresher

## Testing
- gradle check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cec681fa1883248de10a9bc99dd421