### PR TITLE
Refine transport routing and validation

### DIFF
--- a/src/main/java/com/amannmalik/mcp/core/MessageDispatcher.java
+++ b/src/main/java/com/amannmalik/mcp/core/MessageDispatcher.java
@@ -35,11 +35,8 @@ public final class MessageDispatcher {
     }
 
     private void drainBacklog() {
-        while (true) {
-            var next = backlog.peek();
-            if (next == null) {
-                return;
-            }
+        JsonObject next;
+        while ((next = backlog.peek()) != null) {
             var outcome = router.route(next);
             if (outcome == RouteOutcome.PENDING) {
                 return;
@@ -47,7 +44,6 @@ public final class MessageDispatcher {
             backlog.poll();
             if (outcome == RouteOutcome.NOT_FOUND) {
                 logDrop(next, true);
-                continue;
             }
             // Successful delivery, continue draining remaining backlog entries.
         }

--- a/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.*;
 import java.io.IOException;
 import java.io.Serial;
 import java.lang.System.Logger;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +30,10 @@ final class McpServlet extends HttpServlet {
     private final int responseQueueCapacity;
 
     McpServlet(StreamableHttpServerTransport transport, int responseQueueCapacity) {
-        this.transport = transport;
+        this.transport = Objects.requireNonNull(transport, "transport");
+        if (responseQueueCapacity <= 0) {
+            throw new IllegalArgumentException("responseQueueCapacity must be positive");
+        }
         this.responseQueueCapacity = responseQueueCapacity;
     }
 

--- a/src/main/java/com/amannmalik/mcp/transport/SseClients.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SseClients.java
@@ -115,8 +115,9 @@ final class SseClients {
 
     void removeGeneral(SseClient client) {
         Objects.requireNonNull(client, "client");
-        general.remove(client);
-        lastGeneral.set(client);
+        if (general.remove(client)) {
+            lastGeneral.set(client);
+        }
         CloseUtil.close(client);
     }
 


### PR DESCRIPTION
## Summary
- deduplicate request client eviction in the router and streamline backlog draining
- centralize SSE context cleanup and tighten SSE general client tracking
- harden HTTP servlet validation, including Accept headers, session shutdown, and constructor invariants

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68cf201dc1988324b56053a4004e58cb