### PR TITLE
Ensure prompts/get requires initialization

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -579,6 +579,11 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
     }
 
     private JsonRpcMessage getPrompt(JsonRpcRequest req) {
+        var initCheck = lifecycle.ensureInitialized(req.id(), config.errorNotInitialized())
+                .map(error -> (JsonRpcMessage) error);
+        if (initCheck.isPresent()) {
+            return initCheck.get();
+        }
         requireServerCapability(ServerCapability.PROMPTS);
         try {
             var getRequest = GET_PROMPT_REQUEST_JSON_CODEC.fromJson(req.params());


### PR DESCRIPTION
## Summary
- guard the `prompts/get` handler with a lifecycle initialization check so the server responds with the configured not-initialized error when clients query prompts before completing initialization

## Testing
- `gradle --no-daemon --console plain check`

------
https://chatgpt.com/codex/tasks/task_e_68d0d40349408324acce9a62fa21870b