### PR TITLE
Improve EOF handling in StdioTransport

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StdioTransport.java
@@ -107,6 +107,7 @@ public final class StdioTransport implements Transport {
             throw new IOException("Interrupted while waiting for input", e);
         }
         if (line == null) {
+            resources.checkAlive();
             throw new EOFException();
         }
         try (var reader = Json.createReader(new StringReader(line))) {


### PR DESCRIPTION
## Summary
* ensure the STDIO transport checks whether the spawned process has terminated before propagating an EOF

## Testing
* `gradle test --console=plain --rerun-tasks`
* `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d0d40349408324acce9a62fa21870b