### PR TITLE
Ensure jacoco report runs once per check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,6 @@ tasks.test {
     useJUnitPlatform()
     javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
     dependsOn(tasks.jar)
-    finalizedBy(tasks.jacocoTestReport)
     val agentFile = configurations.jacocoAgent.get().singleFile.absolutePath.replace(".jar", "-runtime.jar")
     systemProperty("jacoco.agent.jar", agentFile)
     systemProperty("jacoco.exec.file", "${layout.buildDirectory.get()}/jacoco/test.exec")
@@ -120,6 +119,10 @@ tasks.jacocoTestReport {
     doFirst {
         mkdir("${layout.buildDirectory.get()}/jacoco")
     }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestReport)
 }
 
 jmh {


### PR DESCRIPTION
## Summary
- remove the jacoco test finalizer to avoid racing report generation with Gradle task scheduling
- attach the jacoco report to the check lifecycle so coverage is still produced when running the verification suite

## Testing
- gradle clean check --console=plain
- ./verify.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0d40349408324acce9a62fa21870b