### PR TITLE
Fix progress completion to respect reported totals

### DIFF
--- a/src/main/java/com/amannmalik/mcp/core/ProgressManager.java
+++ b/src/main/java/com/amannmalik/mcp/core/ProgressManager.java
@@ -101,9 +101,17 @@ public final class ProgressManager {
         Objects.requireNonNull(note, "note");
         var state = requireActiveState(note.token());
         state.advance(note.progress());
-        if (note.progress() >= 1.0) {
+        if (isComplete(note)) {
             completeToken(note.token(), state);
         }
+    }
+
+    private static boolean isComplete(ProgressNotification note) {
+        var total = note.total();
+        if (total != null) {
+            return note.progress() >= total;
+        }
+        return note.progress() >= 1.0;
     }
 
     private void completeToken(ProgressToken token, TokenState state) {


### PR DESCRIPTION
## Summary
- ensure `ProgressManager` only retires tokens when they reach their declared total
- add logic to treat total-less notifications as normalized 0-1 progress

## Testing
- gradle test --console=plain --rerun-tasks
- gradle check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dcb36520788324bf1653dad5c4bdc0