### PR TITLE
Fix progress token parsing when metadata is malformed

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ProgressToken.java
+++ b/src/main/java/com/amannmalik/mcp/api/ProgressToken.java
@@ -14,7 +14,10 @@ public sealed interface ProgressToken permits
         if (params == null || !params.containsKey("_meta")) {
             return Optional.empty();
         }
-        var meta = params.getJsonObject("_meta");
+        var metaValue = params.get("_meta");
+        if (!(metaValue instanceof JsonObject meta)) {
+            throw new IllegalArgumentException("_meta must be an object");
+        }
         ValidationUtil.requireMeta(meta);
         if (!meta.containsKey("progressToken")) {
             return Optional.empty();


### PR DESCRIPTION
## Summary
- ensure progress token parsing rejects non-object `_meta` payloads with a clear error

## Testing
- gradle test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e1802b37dc83248073104970d11fc6