### PR TITLE
Allow HTTP POST Accept headers to include additional types

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/AcceptHeader.java
+++ b/src/main/java/com/amannmalik/mcp/transport/AcceptHeader.java
@@ -50,12 +50,25 @@ final class AcceptHeader {
         return type.toLowerCase(Locale.ROOT);
     }
 
+    boolean containsAll(String... requiredTypes) {
+        for (var type : requiredTypes) {
+            var normalized = normalizeType(type);
+            if (!mediaTypes.contains(normalized)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     boolean matchesExactly(String... requiredTypes) {
         Set<String> expected = new LinkedHashSet<>(requiredTypes.length);
         for (var type : requiredTypes) {
             expected.add(normalizeType(type));
         }
-        return mediaTypes.equals(Set.copyOf(expected));
+        if (!mediaTypes.equals(Set.copyOf(expected))) {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -362,8 +362,8 @@ public final class StreamableHttpServerTransport implements Transport {
 
     boolean validateAccept(HttpServletRequest req, HttpServletResponse resp, boolean post) throws IOException {
         return post
-                ? requireAcceptHeader(req, resp, AcceptHeader.APPLICATION_JSON, AcceptHeader.TEXT_EVENT_STREAM)
-                : requireAcceptHeader(req, resp, AcceptHeader.TEXT_EVENT_STREAM);
+                ? requireAcceptHeader(req, resp, true, AcceptHeader.APPLICATION_JSON, AcceptHeader.TEXT_EVENT_STREAM)
+                : requireAcceptHeader(req, resp, false, AcceptHeader.TEXT_EVENT_STREAM);
     }
 
     boolean validateSession(HttpServletRequest req,
@@ -375,6 +375,7 @@ public final class StreamableHttpServerTransport implements Transport {
 
     private boolean requireAcceptHeader(HttpServletRequest req,
                                         HttpServletResponse resp,
+                                        boolean allowAdditional,
                                         String... expectedTypes) throws IOException {
         var header = req.getHeader("Accept");
         if (header == null) {
@@ -388,7 +389,10 @@ public final class StreamableHttpServerTransport implements Transport {
             resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
             return false;
         }
-        if (!parsed.matchesExactly(expectedTypes)) {
+        var valid = allowAdditional
+                ? parsed.containsAll(expectedTypes)
+                : parsed.matchesExactly(expectedTypes);
+        if (!valid) {
             resp.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
             return false;
         }

--- a/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/01_protocol_lifecycle.feature
@@ -65,6 +65,7 @@ Feature: MCP Connection Lifecycle
       | POST   | application/json                    | false         |
       | POST   | text/event-stream                   | false         |
       | POST   | application/json, text/event-stream | true          |
+      | POST   | application/json, text/event-stream, */* | true          |
       | GET    | none                                | false         |
       | GET    | application/json                    | false         |
       | GET    | text/event-stream                   | true          |


### PR DESCRIPTION
## Summary
- relax streamable HTTP POST Accept header validation to accept the required media types even when additional values are present
- keep GET validation strict while reusing the new helper for subset checks in the transport
- extend the Accept header feature coverage to verify POST requests with an additional */* media type

## Testing
- gradle test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e1802b37dc83248073104970d11fc6