### PR TITLE
Reject blank progress tokens

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/ProgressToken.java
+++ b/src/main/java/com/amannmalik/mcp/api/ProgressToken.java
@@ -38,7 +38,7 @@ public sealed interface ProgressToken permits
 
     record StringToken(String value) implements ProgressToken {
         public StringToken {
-            value = ValidationUtil.requireClean(value);
+            value = ValidationUtil.requireNonBlank(value);
         }
     }
 

--- a/src/main/java/com/amannmalik/mcp/codec/ProgressNotificationJsonCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/ProgressNotificationJsonCodec.java
@@ -27,7 +27,7 @@ public class ProgressNotificationJsonCodec implements JsonCodec<ProgressNotifica
     public ProgressNotification fromJson(JsonObject obj) {
         var pt = obj.get("progressToken");
         ProgressToken token = switch (pt) {
-            case JsonString js -> new ProgressToken.StringToken(ValidationUtil.requireClean(js.getString()));
+            case JsonString js -> new ProgressToken.StringToken(ValidationUtil.requireNonBlank(js.getString()));
             case JsonNumber num -> {
                 if (!num.isIntegral()) {
                     throw new IllegalArgumentException("progressToken must be an integer");


### PR DESCRIPTION
## Summary
- ensure server-side progress token validation rejects blank string values
- require decoded progress notifications to enforce non-blank string tokens

## Testing
- gradle --console=plain --no-daemon test
- gradle --console=plain --no-daemon check

------
https://chatgpt.com/codex/tasks/task_e_68e18aa1ce588324a36217c446e14ecd