### PR TITLE
Fix stdio launch failures by targeting Java 21 bytecode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
+    options.release.set(21)
     options.compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-serial"))
 }
 

--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -90,14 +90,14 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         if (this.capabilities.contains(ClientCapability.ROOTS) && roots == null) {
             throw new IllegalArgumentException("roots capability requires provider");
         }
-        this.roots = roots == null ? _ -> {
+        this.roots = roots == null ? ignored -> {
             throw new UnsupportedOperationException("Roots not supported");
         } : roots;
         this.rootsListChangedSupported = this.capabilities.contains(ClientCapability.ROOTS) && this.roots.supportsListChanged();
         if (this.capabilities.contains(ClientCapability.ELICITATION) && elicitation == null) {
             throw new IllegalArgumentException("elicitation capability requires provider");
         }
-        this.elicitation = elicitation == null ? (_, _) -> {
+        this.elicitation = elicitation == null ? (ignoredClient, ignoredRequest) -> {
             throw new UnsupportedOperationException("Elicitation not supported");
         } : elicitation;
         this.listener = listener == null ? new McpClientListener() {

--- a/src/main/java/com/amannmalik/mcp/completion/InMemoryCompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/completion/InMemoryCompletionProvider.java
@@ -21,12 +21,11 @@ public final class InMemoryCompletionProvider extends InMemoryProvider<Ref> impl
     private final List<Entry> entries = new CopyOnWriteArrayList<>();
 
     private static boolean refEquals(Ref a, Ref b) {
-        if (a instanceof Ref.PromptRef(var aName, var _, var _) &&
-                b instanceof Ref.PromptRef(var bName, var _, var _)) {
-            return aName.equals(bName);
+        if (a instanceof Ref.PromptRef promptA && b instanceof Ref.PromptRef promptB) {
+            return promptA.name().equals(promptB.name());
         }
-        if (a instanceof Ref.ResourceRef(var aUri) && b instanceof Ref.ResourceRef(var bUri)) {
-            return aUri.equals(bUri);
+        if (a instanceof Ref.ResourceRef resourceA && b instanceof Ref.ResourceRef resourceB) {
+            return resourceA.uri().equals(resourceB.uri());
         }
         return false;
     }

--- a/src/main/java/com/amannmalik/mcp/spi/CompletionProvider.java
+++ b/src/main/java/com/amannmalik/mcp/spi/CompletionProvider.java
@@ -8,8 +8,8 @@ import jakarta.json.Json;
 public non-sealed interface CompletionProvider extends ExecutingProvider<Ref, CompleteResult> {
     static String encode(Ref ref) {
         return switch (ref) {
-            case Ref.PromptRef(var name, var _, var _) -> "prompt:" + name;
-            case Ref.ResourceRef(var uri) -> "resource:" + uri;
+            case Ref.PromptRef prompt -> "prompt:" + prompt.name();
+            case Ref.ResourceRef resource -> "resource:" + resource.uri();
         };
     }
 

--- a/src/main/java/com/amannmalik/mcp/spi/Cursor.java
+++ b/src/main/java/com/amannmalik/mcp/spi/Cursor.java
@@ -20,9 +20,9 @@ public sealed interface Cursor permits Cursor.Start, Cursor.End, Cursor.Token {
     static int index(Cursor cursor) {
         return switch (cursor) {
             case null -> 0;
-            case Start _ -> 0;
+            case Start ignored -> 0;
             case Token(var value) -> decode(value);
-            case End _ -> throw new IllegalArgumentException("Invalid cursor");
+            case End ignored -> throw new IllegalArgumentException("Invalid cursor");
         };
     }
 


### PR DESCRIPTION
## Summary
- emit Java 21 class files so the packaged server JAR can be run by the Gradle-supplied JVM used in the conformance suite
- replace unnamed pattern variables in client and completion utilities with explicit identifiers compatible with the Java 21 source level

## Testing
- gradle test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e18aa1ce588324a36217c446e14ecd