### PR TITLE
Improve boolean validation in JSON codecs

### DIFF
--- a/src/main/java/com/amannmalik/mcp/codec/AbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/AbstractEntityCodec.java
@@ -4,6 +4,7 @@ import com.amannmalik.mcp.spi.*;
 import jakarta.json.*;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.*;
 
@@ -104,6 +105,31 @@ public sealed abstract class AbstractEntityCodec<T> implements JsonCodec<T> perm
 
     protected static JsonObject getObject(JsonObject obj, String key) {
         return obj.getJsonObject(key);
+    }
+
+    protected static boolean getBoolean(JsonObject obj, String key, boolean defaultValue) {
+        if (!obj.containsKey(key)) {
+            return defaultValue;
+        }
+        return toBoolean(key, obj.get(key));
+    }
+
+    protected static Optional<Boolean> findBoolean(JsonObject obj, String key) {
+        if (!obj.containsKey(key)) {
+            return Optional.empty();
+        }
+        return Optional.of(Boolean.valueOf(toBoolean(key, obj.get(key))));
+    }
+
+    private static boolean toBoolean(String key, JsonValue value) {
+        if (value == null) {
+            throw new IllegalArgumentException(key + " required");
+        }
+        return switch (value.getValueType()) {
+            case TRUE -> true;
+            case FALSE -> false;
+            default -> throw new IllegalArgumentException(key + " must be boolean");
+        };
     }
 
     protected static Role requireRole(JsonObject obj) {

--- a/src/main/java/com/amannmalik/mcp/codec/CompletionJsonCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/CompletionJsonCodec.java
@@ -28,7 +28,7 @@ class CompletionJsonCodec implements JsonCodec<Completion> {
                 .map(JsonString::getString)
                 .toList();
         var total = obj.containsKey("total") ? obj.getInt("total") : null;
-        var hasMore = obj.containsKey("hasMore") ? obj.getBoolean("hasMore") : null;
+        var hasMore = AbstractEntityCodec.findBoolean(obj, "hasMore").orElse(null);
         return new Completion(values, total, hasMore);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/codec/InitializeRequestAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/InitializeRequestAbstractEntityCodec.java
@@ -49,7 +49,7 @@ public final class InitializeRequestAbstractEntityCodec extends AbstractEntityCo
                     var c = cap.get();
                     client.add(c);
                     if (c == ClientCapability.ROOTS) {
-                        rootsList = v.getBoolean("listChanged", false);
+                        rootsList = getBoolean(v, "listChanged", false);
                     }
                 } else {
                     experimental.put(k, v);

--- a/src/main/java/com/amannmalik/mcp/codec/InitializeResponseAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/InitializeResponseAbstractEntityCodec.java
@@ -68,19 +68,19 @@ public final class InitializeResponseAbstractEntityCodec extends AbstractEntityC
         if (capsObj != null) {
             var res = capsObj.getJsonObject(ServerCapability.RESOURCES.code());
             if (res != null) {
-                if (res.getBoolean("subscribe", false)) {
+                if (getBoolean(res, "subscribe", false)) {
                     features.add(ServerFeature.RESOURCES_SUBSCRIBE);
                 }
-                if (res.getBoolean("listChanged", false)) {
+                if (getBoolean(res, "listChanged", false)) {
                     features.add(ServerFeature.RESOURCES_LIST_CHANGED);
                 }
             }
             var tools = capsObj.getJsonObject(ServerCapability.TOOLS.code());
-            if (tools != null && tools.getBoolean("listChanged", false)) {
+            if (tools != null && getBoolean(tools, "listChanged", false)) {
                 features.add(ServerFeature.TOOLS_LIST_CHANGED);
             }
             var prompts = capsObj.getJsonObject(ServerCapability.PROMPTS.code());
-            if (prompts != null && prompts.getBoolean("listChanged", false)) {
+            if (prompts != null && getBoolean(prompts, "listChanged", false)) {
                 features.add(ServerFeature.PROMPTS_LIST_CHANGED);
             }
         }

--- a/src/main/java/com/amannmalik/mcp/codec/PromptArgumentAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/PromptArgumentAbstractEntityCodec.java
@@ -34,7 +34,7 @@ public final class PromptArgumentAbstractEntityCodec extends AbstractEntityCodec
         var name = requireString(obj, "name");
         var title = obj.getString("title", null);
         var description = obj.getString("description", null);
-        var required = obj.getBoolean("required", false);
+        var required = getBoolean(obj, "required", false);
         var meta = obj.getJsonObject("_meta");
         return new PromptArgument(name, title, description, required, meta);
     }

--- a/src/main/java/com/amannmalik/mcp/codec/ToolAnnotationsAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/ToolAnnotationsAbstractEntityCodec.java
@@ -35,10 +35,10 @@ public final class ToolAnnotationsAbstractEntityCodec extends AbstractEntityCode
         }
         requireOnlyKeys(obj, Set.of("title", "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"));
         var title = obj.getString("title", null);
-        var readOnly = obj.containsKey("readOnlyHint") ? obj.getBoolean("readOnlyHint") : null;
-        var destructive = obj.containsKey("destructiveHint") ? obj.getBoolean("destructiveHint") : null;
-        var idempotent = obj.containsKey("idempotentHint") ? obj.getBoolean("idempotentHint") : null;
-        var openWorld = obj.containsKey("openWorldHint") ? obj.getBoolean("openWorldHint") : null;
+        var readOnly = findBoolean(obj, "readOnlyHint").orElse(null);
+        var destructive = findBoolean(obj, "destructiveHint").orElse(null);
+        var idempotent = findBoolean(obj, "idempotentHint").orElse(null);
+        var openWorld = findBoolean(obj, "openWorldHint").orElse(null);
         return new ToolAnnotations(title, readOnly, destructive, idempotent, openWorld);
     }
 }

--- a/src/main/java/com/amannmalik/mcp/codec/ToolResultAbstractEntityCodec.java
+++ b/src/main/java/com/amannmalik/mcp/codec/ToolResultAbstractEntityCodec.java
@@ -34,7 +34,7 @@ public final class ToolResultAbstractEntityCodec extends AbstractEntityCodec<Too
             throw new IllegalArgumentException("content required");
         }
         var structured = obj.getJsonObject("structuredContent");
-        var isError = obj.getBoolean("isError", false);
+        var isError = getBoolean(obj, "isError", false);
         var meta = obj.getJsonObject("_meta");
         return new ToolResult(content, structured, isError, meta);
     }


### PR DESCRIPTION
## Summary
- add reusable boolean parsing helpers to `AbstractEntityCodec` to normalize defaulted and optional flags
- update codecs handling completion, initialization, prompt arguments, tool annotations, and tool results to use the new helpers for consistent validation

## Testing
- `gradle --no-daemon test --console=plain`
- `gradle --no-daemon check --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e1a32b4c2483249012f2f935283d3d