### PR TITLE
Ensure HTTP transport responses include session headers

### DIFF
--- a/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
+++ b/src/main/java/com/amannmalik/mcp/transport/McpServlet.java
@@ -133,7 +133,7 @@ final class McpServlet extends HttpServlet {
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType("text/event-stream;charset=UTF-8");
         resp.setHeader("Cache-Control", "no-cache");
-        resp.setHeader(TransportHeaders.PROTOCOL_VERSION, transport.protocolVersion());
+        applySessionHeaders(resp);
         resp.flushBuffer();
         var ac = req.startAsync();
         ac.setTimeout(0);
@@ -144,10 +144,16 @@ final class McpServlet extends HttpServlet {
         try {
             transport.submitIncoming(obj);
             resp.setStatus(HttpServletResponse.SC_ACCEPTED);
+            applySessionHeaders(resp);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         }
+    }
+
+    private void applySessionHeaders(HttpServletResponse resp) {
+        transport.sessionId().ifPresent(id -> resp.setHeader(TransportHeaders.SESSION_ID, id));
+        resp.setHeader(TransportHeaders.PROTOCOL_VERSION, transport.protocolVersion());
     }
 
     private void handleRequest(JsonObject obj,

--- a/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
+++ b/src/main/java/com/amannmalik/mcp/transport/SessionManager.java
@@ -65,6 +65,11 @@ final class SessionManager {
         return validateVersion(initializing, sanitized.version(), resp);
     }
 
+    Optional<String> currentSessionId() {
+        var state = current.get();
+        return state == null ? Optional.empty() : Optional.of(state.id());
+    }
+
     private boolean handleMissingSession(HttpServletRequest req,
                                          HttpServletResponse resp,
                                          Principal principal,

--- a/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
+++ b/src/main/java/com/amannmalik/mcp/transport/StreamableHttpServerTransport.java
@@ -254,6 +254,10 @@ public final class StreamableHttpServerTransport implements Transport {
         clients.removeResponseQueue(id);
     }
 
+    Optional<String> sessionId() {
+        return sessions.currentSessionId();
+    }
+
     SseClient registerGeneralClient(AsyncContext context, String lastEventId) throws IOException {
         return clients.registerGeneral(context, lastEventId, this::createClient);
     }


### PR DESCRIPTION
## Summary
- expose the current session identifier from the transport session manager and streamable HTTP transport
- ensure HTTP SSE and POST responses include both the MCP session ID and protocol version headers

## Testing
- gradle test --tests com.amannmalik.mcp.test.McpConformanceSuite --console=plain --no-daemon
- gradle check --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e1be7ca0d88324b41e6904e01b7358