### PR TITLE
Ensure ping configuration rejects non-positive durations

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -400,11 +400,8 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         if (connected.get()) {
             throw new IllegalStateException("already connected");
         }
-        if (intervalMillis.isNegative() || timeoutMillis.isNegative()) {
-            throw new IllegalArgumentException("invalid ping settings");
-        }
-        this.pingInterval = intervalMillis;
-        this.pingTimeout = timeoutMillis;
+        this.pingInterval = ValidationUtil.requirePositive(intervalMillis, "Ping interval");
+        this.pingTimeout = ValidationUtil.requirePositive(timeoutMillis, "Ping timeout");
     }
 
     public void setSamplingAccessPolicy(SamplingAccessPolicy policy) {


### PR DESCRIPTION
## Summary
- require positive ping intervals and timeouts when configuring the MCP client to prevent invalid scheduler settings

## Testing
- gradle test --console=plain
- ./verify.sh


------
https://chatgpt.com/codex/tasks/task_e_68e1be7ca0d88324b41e6904e01b7358