### PR TITLE
Fix sampling interruption handling in McpClient

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -614,7 +614,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         } catch (IllegalArgumentException e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INVALID_PARAMS, e.getMessage());
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, "Sampling interrupted");
         } catch (Exception e) {
             return JsonRpcError.of(req.id(), JsonRpcErrorCode.INTERNAL_ERROR, e.getMessage());


### PR DESCRIPTION
## Summary
- preserve the thread interruption status when sampling is interrupted so higher-level callers can observe the signal

## Testing
- gradle test --rerun-tasks --console=plain
- gradle check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e1be7ca0d88324b41e6904e01b7358