### PR TITLE
Handle blank pagination cursors

### DIFF
--- a/src/main/java/com/amannmalik/mcp/util/CursorUtil.java
+++ b/src/main/java/com/amannmalik/mcp/util/CursorUtil.java
@@ -11,6 +11,9 @@ public final class CursorUtil {
             return Cursor.Start.INSTANCE;
         }
         var clean = ValidationUtil.cleanNullable(cursor);
+        if (clean == null || clean.isBlank()) {
+            return Cursor.Start.INSTANCE;
+        }
         return new Cursor.Token(clean);
     }
 }

--- a/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
+++ b/src/test/resources/com/amannmalik/mcp/test/04_utilities.feature
@@ -339,6 +339,14 @@ Feature: MCP Protocol Utilities
     Then the response should include the current page of results
     And the response should not include a nextCursor field
 
+  @pagination @blank-cursor
+  Scenario: Blank cursor defaults to the first page
+    # Tests specification/2025-06-18/server/utilities/pagination.mdx:43-56 (Request format)
+    Given an established MCP connection
+    And I am handling pagination requests
+    When I request the tools list with a blank cursor
+    Then the tools list request should succeed
+
   @pagination @supported-operations
   Scenario: Operations supporting pagination
     # Tests specification/2025-06-18/server/utilities/pagination.mdx:72-80 (Supported operations)


### PR DESCRIPTION
## Summary
- treat null or blank pagination cursors as the start of a result set
- exercise the tools list endpoint with a blank cursor through the utilities step definitions
- document the blank cursor scenario in the utilities feature file

## Testing
- gradle test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e1be7ca0d88324b41e6904e01b7358