### PR TITLE
Decouple runtime access policies from API config

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -84,6 +84,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         this.info = new ClientInfo(config.serverName(), config.serverDisplayName(), config.serverVersion());
         this.capabilities = Immutable.enumSet(config.clientCapabilities());
         this.sampling = sampling;
+        this.samplingAccess = SamplingAccessPolicy.PERMISSIVE;
         if (this.capabilities.contains(ClientCapability.SAMPLING) && this.sampling == null) {
             throw new IllegalArgumentException("sampling capability requires provider");
         }
@@ -102,7 +103,6 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         } : elicitation;
         this.listener = listener == null ? new McpClientListener() {
         } : listener;
-        this.samplingAccess = config.samplingAccessPolicy();
         this.principal = new Principal(config.principal(), Set.of());
         this.pingInterval = config.pingInterval();
         this.pingTimeout = config.pingTimeout();

--- a/src/main/java/com/amannmalik/mcp/api/config/McpClientConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/config/McpClientConfiguration.java
@@ -1,7 +1,6 @@
 package com.amannmalik.mcp.api.config;
 
 import com.amannmalik.mcp.api.ClientCapability;
-import com.amannmalik.mcp.spi.SamplingAccessPolicy;
 import com.amannmalik.mcp.util.ValidationUtil;
 
 import java.time.Duration;
@@ -34,7 +33,6 @@ public record McpClientConfiguration(
         boolean verbose,
         boolean interactiveSampling,
         List<String> rootDirectories,
-        SamplingAccessPolicy samplingAccessPolicy,
         TlsConfiguration tlsConfiguration,
         CertificateValidationMode certificateValidationMode,
         List<String> certificatePins,
@@ -69,9 +67,6 @@ public record McpClientConfiguration(
         }
         rateLimiterWindow = ValidationUtil.requirePositive(rateLimiterWindow, "Rate limiter window");
         rootDirectories = List.copyOf(rootDirectories);
-        if (samplingAccessPolicy == null) {
-            throw new IllegalArgumentException("Sampling access policy is required");
-        }
         if (tlsConfiguration == null) {
             throw new IllegalArgumentException("TLS configuration required");
         }
@@ -108,7 +103,6 @@ public record McpClientConfiguration(
                 false,
                 false,
                 List.of(),
-                SamplingAccessPolicy.PERMISSIVE,
                 new TlsConfiguration(
                         "",
                         "",

--- a/src/main/java/com/amannmalik/mcp/api/config/McpServerConfiguration.java
+++ b/src/main/java/com/amannmalik/mcp/api/config/McpServerConfiguration.java
@@ -1,8 +1,6 @@
 package com.amannmalik.mcp.api.config;
 
 import com.amannmalik.mcp.api.Protocol;
-import com.amannmalik.mcp.spi.SamplingAccessPolicy;
-import com.amannmalik.mcp.spi.ToolAccessPolicy;
 import com.amannmalik.mcp.util.ValidationUtil;
 
 import java.time.Duration;
@@ -34,8 +32,6 @@ public record McpServerConfiguration(
         String parserLoggerName,
         String cancellationLoggerName,
         LoggingLevel initialLogLevel,
-        ToolAccessPolicy toolAccessPolicy,
-        SamplingAccessPolicy samplingAccessPolicy,
         String defaultPrincipal,
         String defaultBoundary,
         String transportType,
@@ -91,7 +87,7 @@ public record McpServerConfiguration(
         if (rateLimitErrorCode >= 0) {
             throw new IllegalArgumentException("Rate limit error code must be negative");
         }
-        if (initialLogLevel == null || toolAccessPolicy == null || samplingAccessPolicy == null) {
+        if (initialLogLevel == null) {
             throw new IllegalArgumentException("Invalid policy configuration");
         }
         if (serverPort < 0 || serverPort > 65_535) {
@@ -174,8 +170,6 @@ public record McpServerConfiguration(
                 "parser",
                 "cancellation",
                 LoggingLevel.INFO,
-                ToolAccessPolicy.PERMISSIVE,
-                SamplingAccessPolicy.PERMISSIVE,
                 "default",
                 "default",
                 "stdio",
@@ -255,8 +249,6 @@ public record McpServerConfiguration(
                 parserLoggerName,
                 cancellationLoggerName,
                 initialLogLevel,
-                toolAccessPolicy,
-                samplingAccessPolicy,
                 defaultPrincipal,
                 defaultBoundary,
                 transportType,
@@ -318,8 +310,6 @@ public record McpServerConfiguration(
                 parserLoggerName,
                 cancellationLoggerName,
                 initialLogLevel,
-                toolAccessPolicy,
-                samplingAccessPolicy,
                 defaultPrincipal,
                 defaultBoundary,
                 transportType,

--- a/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/HostCommand.java
@@ -245,7 +245,6 @@ public final class HostCommand {
                     clientVerbose,
                     false,
                     List.of(System.getProperty("user.dir")),
-                    SamplingAccessPolicy.PERMISSIVE,
                     tlsConfig,
                     tls.validationMode(),
                     tls.pins(),

--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -205,6 +205,8 @@ public final class ServerCommand {
                     completions,
                     sampling,
                     privacyBoundary(config.defaultBoundary()),
+                    ToolAccessPolicy.PERMISSIVE,
+                    SamplingAccessPolicy.PERMISSIVE,
                     defaultPrincipal(),
                     instructions)) {
                 server.serve();

--- a/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ClientFeaturesSteps.java
@@ -80,7 +80,7 @@ public final class ClientFeaturesSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(),
                 tlsConfig, CertificateValidationMode.STRICT, List.of(), true
         );
         var hostConfig = new McpHostConfiguration(

--- a/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ProtocolLifecycleSteps.java
@@ -186,7 +186,7 @@ public final class ProtocolLifecycleSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(),
                 tlsConfig, CertificateValidationMode.STRICT, List.of(), true
         );
     }
@@ -202,7 +202,7 @@ public final class ProtocolLifecycleSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(),
                 tlsConfig, CertificateValidationMode.STRICT, List.of(), true
         );
     }

--- a/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/ServerFeaturesSteps.java
@@ -116,7 +116,7 @@ public final class ServerFeaturesSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), roots, base.samplingAccessPolicy(),
+                base.verbose(), base.interactiveSampling(), roots,
                 tlsConfig, CertificateValidationMode.STRICT, List.of(), true
         );
         var hostConfig = new McpHostConfiguration(

--- a/src/test/java/com/amannmalik/mcp/test/ServerHarness.java
+++ b/src/test/java/com/amannmalik/mcp/test/ServerHarness.java
@@ -51,8 +51,6 @@ public final class ServerHarness implements Closeable {
                 base.parserLoggerName(),
                 base.cancellationLoggerName(),
                 LoggingLevel.INFO,
-                ToolAccessPolicy.PERMISSIVE,
-                SamplingAccessPolicy.PERMISSIVE,
                 base.defaultPrincipal(),
                 base.defaultBoundary(),
                 "http",
@@ -241,7 +239,18 @@ public final class ServerHarness implements Closeable {
 
         var principal = new Principal(base.defaultPrincipal(), Set.of());
 
-        var server = new McpServer(config, resources, tools, prompts, completions, sampling, access, principal, null);
+        var server = new McpServer(
+                config,
+                resources,
+                tools,
+                prompts,
+                completions,
+                sampling,
+                access,
+                ToolAccessPolicy.PERMISSIVE,
+                SamplingAccessPolicy.PERMISSIVE,
+                principal,
+                null);
         Thread.ofVirtual().start(() -> {
             try {
                 server.serve();

--- a/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
+++ b/src/test/java/com/amannmalik/mcp/test/UtilitiesSteps.java
@@ -102,7 +102,7 @@ public final class UtilitiesSteps {
                 base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                 base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                 base.pingTimeout(), base.pingInterval(), base.progressPerSecond(), base.rateLimiterWindow(),
-                base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                base.verbose(), base.interactiveSampling(), base.rootDirectories(),
                 tlsConfig, CertificateValidationMode.STRICT, List.of(), true
         );
         var hostConfig = new McpHostConfiguration(
@@ -382,7 +382,7 @@ public final class UtilitiesSteps {
                     base.defaultOriginHeader(), base.httpRequestTimeout(), base.enableKeepAlive(),
                     base.sessionIdByteLength(), base.initializeRequestTimeout(), base.strictVersionValidation(),
                     base.pingTimeout(), Duration.ofMillis(interval), base.progressPerSecond(), base.rateLimiterWindow(),
-                    base.verbose(), base.interactiveSampling(), base.rootDirectories(), base.samplingAccessPolicy(),
+                    base.verbose(), base.interactiveSampling(), base.rootDirectories(),
                     tlsConfig, CertificateValidationMode.STRICT, List.of(), true
             );
             pingConfigurationFailed = false;


### PR DESCRIPTION
## Summary
- remove non-serializable access policy fields from the API configuration records
- inject tool and sampling access policies into runtime components that need them, defaulting to permissive behavior
- update CLI setup and test harnesses for the new configuration shapes

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68e43d295a848324b2c54b287e0468cf