### PR TITLE
Load policy SPI implementations via ServiceLoader

### DIFF
--- a/src/main/java/com/amannmalik/mcp/api/McpClient.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpClient.java
@@ -84,7 +84,7 @@ public final class McpClient extends JsonRpcEndpoint implements AutoCloseable {
         this.info = new ClientInfo(config.serverName(), config.serverDisplayName(), config.serverVersion());
         this.capabilities = Immutable.enumSet(config.clientCapabilities());
         this.sampling = sampling;
-        this.samplingAccess = SamplingAccessPolicy.PERMISSIVE;
+        this.samplingAccess = ServiceLoaders.loadSingleton(SamplingAccessPolicy.class);
         if (this.capabilities.contains(ClientCapability.SAMPLING) && this.sampling == null) {
             throw new IllegalArgumentException("sampling capability requires provider");
         }

--- a/src/main/java/com/amannmalik/mcp/api/McpServer.java
+++ b/src/main/java/com/amannmalik/mcp/api/McpServer.java
@@ -123,8 +123,12 @@ public final class McpServer extends JsonRpcEndpoint implements AutoCloseable {
         this.principal = principal;
         this.lifecycle = new ServerLifecycle(config.supportedVersions(), serverCapabilities, serverInfo, instructions);
         this.toolLimiter = limiter(config.toolsPerSecond(), config.rateLimiterWindowMs());
-        this.toolAccessPolicy = toolAccessPolicy == null ? ToolAccessPolicy.PERMISSIVE : toolAccessPolicy;
-        this.samplingAccess = samplingAccessPolicy == null ? SamplingAccessPolicy.PERMISSIVE : samplingAccessPolicy;
+        this.toolAccessPolicy = toolAccessPolicy == null
+                ? ServiceLoaders.loadSingleton(ToolAccessPolicy.class)
+                : toolAccessPolicy;
+        this.samplingAccess = samplingAccessPolicy == null
+                ? ServiceLoaders.loadSingleton(SamplingAccessPolicy.class)
+                : samplingAccessPolicy;
         this.logLevel.set(config.initialLogLevel());
         this.rootsManager = new RootsManager(lifecycle::clientCapabilities, this::request);
         this.resources = resources;

--- a/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
+++ b/src/main/java/com/amannmalik/mcp/cli/ServerCommand.java
@@ -199,14 +199,16 @@ public final class ServerCommand {
             var prompts = ServiceLoaders.loadSingleton(PromptProvider.class);
             var completions = ServiceLoaders.loadSingleton(CompletionProvider.class);
             var sampling = ServiceLoaders.loadSingleton(SamplingProvider.class);
+            var toolAccess = ServiceLoaders.loadSingleton(ToolAccessPolicy.class);
+            var samplingAccessPolicy = ServiceLoaders.loadSingleton(SamplingAccessPolicy.class);
             try (var server = new McpServer(config, resources,
                     tools,
                     prompts,
                     completions,
                     sampling,
                     privacyBoundary(config.defaultBoundary()),
-                    ToolAccessPolicy.PERMISSIVE,
-                    SamplingAccessPolicy.PERMISSIVE,
+                    toolAccess,
+                    samplingAccessPolicy,
                     defaultPrincipal(),
                     instructions)) {
                 server.serve();

--- a/src/main/java/com/amannmalik/mcp/spi/SamplingAccessPolicy.java
+++ b/src/main/java/com/amannmalik/mcp/spi/SamplingAccessPolicy.java
@@ -2,9 +2,6 @@ package com.amannmalik.mcp.spi;
 
 @FunctionalInterface
 public interface SamplingAccessPolicy {
-    SamplingAccessPolicy PERMISSIVE = p -> {
-    };
-
     void requireAllowed(Principal principal);
 }
 

--- a/src/main/java/com/amannmalik/mcp/spi/ToolAccessPolicy.java
+++ b/src/main/java/com/amannmalik/mcp/spi/ToolAccessPolicy.java
@@ -2,8 +2,5 @@ package com.amannmalik.mcp.spi;
 
 @FunctionalInterface
 public interface ToolAccessPolicy {
-    ToolAccessPolicy PERMISSIVE = (p, t) -> {
-    };
-
     void requireAllowed(Principal principal, Tool tool);
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -18,4 +18,7 @@ module mcp.main {
     uses com.amannmalik.mcp.spi.SamplingProvider;
     uses com.amannmalik.mcp.spi.RootsProvider;
     uses com.amannmalik.mcp.spi.ElicitationProvider;
+    uses com.amannmalik.mcp.spi.ResourceAccessPolicy;
+    uses com.amannmalik.mcp.spi.ToolAccessPolicy;
+    uses com.amannmalik.mcp.spi.SamplingAccessPolicy;
 }

--- a/src/test/java/com/amannmalik/mcp/test/impl/PermissiveResourceAccessPolicy.java
+++ b/src/test/java/com/amannmalik/mcp/test/impl/PermissiveResourceAccessPolicy.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.test.impl;
+
+import com.amannmalik.mcp.spi.*;
+
+public final class PermissiveResourceAccessPolicy implements ResourceAccessPolicy {
+    @Override
+    public void requireAllowed(Principal principal, Annotations annotations) {
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/test/impl/PermissiveSamplingAccessPolicy.java
+++ b/src/test/java/com/amannmalik/mcp/test/impl/PermissiveSamplingAccessPolicy.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.test.impl;
+
+import com.amannmalik.mcp.spi.*;
+
+public final class PermissiveSamplingAccessPolicy implements SamplingAccessPolicy {
+    @Override
+    public void requireAllowed(Principal principal) {
+    }
+}

--- a/src/test/java/com/amannmalik/mcp/test/impl/PermissiveToolAccessPolicy.java
+++ b/src/test/java/com/amannmalik/mcp/test/impl/PermissiveToolAccessPolicy.java
@@ -1,0 +1,9 @@
+package com.amannmalik.mcp.test.impl;
+
+import com.amannmalik.mcp.spi.*;
+
+public final class PermissiveToolAccessPolicy implements ToolAccessPolicy {
+    @Override
+    public void requireAllowed(Principal principal, Tool tool) {
+    }
+}

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -16,4 +16,10 @@ open module mcp.test {
     provides com.amannmalik.mcp.spi.SamplingProvider with com.amannmalik.mcp.test.impl.DefaultSamplingProvider;
     provides com.amannmalik.mcp.spi.RootsProvider with com.amannmalik.mcp.test.impl.DefaultRootsProvider;
     provides com.amannmalik.mcp.spi.ElicitationProvider with com.amannmalik.mcp.test.impl.DefaultElicitationProvider;
+    provides com.amannmalik.mcp.spi.ResourceAccessPolicy with com.amannmalik.mcp.test.impl.PermissiveResourceAccessPolicy;
+    provides com.amannmalik.mcp.spi.ToolAccessPolicy with com.amannmalik.mcp.test.impl.PermissiveToolAccessPolicy;
+    provides com.amannmalik.mcp.spi.SamplingAccessPolicy with com.amannmalik.mcp.test.impl.PermissiveSamplingAccessPolicy;
+    uses com.amannmalik.mcp.spi.ResourceAccessPolicy;
+    uses com.amannmalik.mcp.spi.ToolAccessPolicy;
+    uses com.amannmalik.mcp.spi.SamplingAccessPolicy;
 }

--- a/src/test/resources/META-INF/services/com.amannmalik.mcp.spi.ResourceAccessPolicy
+++ b/src/test/resources/META-INF/services/com.amannmalik.mcp.spi.ResourceAccessPolicy
@@ -1,0 +1,1 @@
+com.amannmalik.mcp.test.impl.PermissiveResourceAccessPolicy

--- a/src/test/resources/META-INF/services/com.amannmalik.mcp.spi.SamplingAccessPolicy
+++ b/src/test/resources/META-INF/services/com.amannmalik.mcp.spi.SamplingAccessPolicy
@@ -1,0 +1,1 @@
+com.amannmalik.mcp.test.impl.PermissiveSamplingAccessPolicy

--- a/src/test/resources/META-INF/services/com.amannmalik.mcp.spi.ToolAccessPolicy
+++ b/src/test/resources/META-INF/services/com.amannmalik.mcp.spi.ToolAccessPolicy
@@ -1,0 +1,1 @@
+com.amannmalik.mcp.test.impl.PermissiveToolAccessPolicy


### PR DESCRIPTION
## Summary
- load ToolAccessPolicy and SamplingAccessPolicy implementations through the shared ServiceLoaders utility instead of inlined PERMISSIVE constants
- register permissive policy service providers inside the test module, including JPMS `provides`/`uses` directives and META-INF service descriptors
- update the server CLI and HTTP test harness to resolve policy services via ServiceLoader so runtime and tests exercise the same SPI path

## Testing
- gradle check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e4484ff4b48324b3ba16a3ee880a22